### PR TITLE
[xcodeproj] Enforce indentation conventions

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -34,7 +34,9 @@
 				5B5D86DC1BBC74AD00234F36 /* Products */,
 				EA3E74BC1BF2B6D700635A73 /* Linux Build */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		5B5D86DC1BBC74AD00234F36 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
The XCTest project uses 4-space indentation as a convention. Enforce
this in the Xcode project file in order to override any developers'
local preferences.