### PR TITLE
[README] Use correct build script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ XCTest can be built as part of the overall Swift package. When following [the in
 swift/utils/build-script --xctest
 ```
 
-If you want to build just XCTest, use the `build_xctest.py` script at the root of the project. The `master` version of XCTest must be built with the `master` version of Swift.
+If you want to build just XCTest, use the `build_script.py` script at the root of the project. The `master` version of XCTest must be built with the `master` version of Swift.
 
 If your install of swift is located at `/swift` and you wish to install XCTest into that same location, here is a sample invocation of the build script:
 


### PR DESCRIPTION
The script used to build just XCTest is named "build_script.py", not "build_xctest.py".