### PR TITLE
Implement throw/no throw assertions

### DIFF
--- a/XCTest/XCTest.swift
+++ b/XCTest/XCTest.swift
@@ -239,3 +239,57 @@ public func XCTAssertTrue(@autoclosure expression: () -> BooleanType, _ message:
 public func XCTFail(message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
     XCTAssert(false, message, file: file, line: line)
 }
+
+public func XCTAssertNoThrows(@autoclosure expression: () throws -> Void, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    do {
+        try expression()
+    } catch let error {
+        XCTFail("Expected no error, got \(error)", file: file, line: line)
+    }
+}
+
+public func XCTAssertNoThrowsSpecific<T: ErrorType>(@autoclosure expression: () throws -> Void, _ errorType: T.Type, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    do {
+        try expression()
+    } catch {
+        XCTAssertFalse(error is T, "Expected not \(T.self), got \(T.self)", file: file, line: line)
+    }
+}
+
+public func XCTAssertNoThrowsSpecific<T where T: ErrorType, T: Equatable>(@autoclosure expression: () throws -> Void, @autoclosure _ expectedError: () -> T, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    do {
+        try expression()
+    } catch let error as T {
+        XCTAssertNotEqual(error, expectedError())
+    } catch {
+        XCTFail("Incorrect error type thrown", file: file, line: line)
+    }
+}
+
+public func XCTAssertThrows(@autoclosure expression: () throws -> Void, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    do {
+        try expression()
+        XCTFail("Expected error, none raised", file: file, line: line)
+    } catch {
+    }
+}
+
+public func XCTAssertThrowsSpecific<T where T: ErrorType>(@autoclosure expression: () throws -> Void, _ errorType: T.Type, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    do {
+        try expression()
+        XCTFail("Expected error but none was thrown", file: file, line: line)
+    } catch let error {
+        XCTAssertTrue(error is T, "Expected \(T.self), got \(error)", file: file, line: line)
+    }
+}
+
+public func XCTAssertThrowsSpecific<T where T: ErrorType, T: Equatable>(@autoclosure expression: () throws -> Void, @autoclosure _ expectedError: () -> T, file: StaticString = __FILE__, line: UInt = __LINE__) {
+    do {
+        try expression()
+        XCTFail("Expected error but none was thrown", file: file, line: line)
+    } catch let error as T {
+        XCTAssertEqual(error, expectedError())
+    } catch {
+        XCTFail("Incorrect error type thrown", file: file, line: line)
+    }
+}


### PR DESCRIPTION
Implement throw/no throw assertions

Adds implementation of the following:

``` swift
func notThrowing() throws { }
func willThrow() throws { throw XCTestError(code: 1) }

// Fails with any error thrown
XCTAssertNoThrows(try notThrowing())

// Fails with any error of the specific Type thrown
XCTAssertNoThrowsSpecific(try notThrowing(), XCTestError.self)

// Fails with an instance of the Type that passes a check for equality
XCTAssertNoThrowsSpecific(try notThrowing(), XCTestError(code: 1))

// Fails without an error thrown
XCTAssertThrows(try willThrow())

// Fails without an error thrown, or an error of a different Type
XCTAssertThrowsSpecific(try willThrow(), XCTestError.self)

// Fails unless a specific error is raised, and passes an equality check
XCTAssertThrowsSpecific(try willThrow(), XCTestError(code: 1))

```

This differs from the existing Objective-C API as the model for error handling in Swift is different.

`XCTAssertNoThrowSpecificNamed` isn't as useful in Swift where an error could be an `enum`, `struct`, or `class`. However, by requiring `Equatable` for the more specific `ThrowsSpecific` similar (potentially more flexible) functionality is enabled.

I was able to test these changes locally (manually), however if there is further testing I could add, or other checks to pass I'm happy to update this pull request.

Thanks!