### PR TITLE
[Tests] Add regression test suite for OS X and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 xcuserdata
+
+# Functional test suite places compiled executables in the source tree
+Tests/Fixtures/Products/*

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ If your install of swift is located at `/swift` and you wish to install XCTest i
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --build-dir="/tmp/XCTest_build" --swift-build-dir="/swift/usr" --library-install-path="/swift/usr/lib/swift/linux" --module-install-path="/swift/usr/lib/swift/linux/x86_64"
 ```
 
+To run the tests, pass the `--test` option in combination with options to install XCTest in your active version of Swift:
+
+```sh
+./build_script.py --swiftc="/swift/usr/bin/swiftc" --build-dir="/tmp/XCTest_build" --swift-build-dir="/swift/usr" --library-install-path="/swift/usr/lib/swift/linux" --module-install-path="/swift/usr/lib/swift/linux/x86_64" --test
+```
+
+To add additional tests to XCTest:
+
+1. (Linux & OS X) Add a directory with the name of your test to the `Tests/Fixtures/Sources/` directory. For example, if your test is named "TwoFailingTestCases", make a directory named `Tests/Fixtures/Sources/TwoFailingTestCases`.
+1. (Linux & OS X) Add a `main.swift` file to the directory you added above. The file should contain comments, beginning with `// `. The test runner will verify that the output of `main.swift` matches your comments exactly. This is all you need to do to run tests on Linux--you may run the `build_script.py` example above to confirm the tests pass.
+1. (OS X) If you want your tests to run on OS X, open the `XCTest.xcodeproj` Xcode project and duplicate the `SingleFailingTestCase` target. Rename the target to match the name of your test. For example, if your test is named "TwoFailingTestCases", name the target `TwoFailingTestCases` as well.
+1. (OS X) In the "Compile Sources" build phase, set your `main.swift` file in place of the one in `SingleFailingTestCase`.
+1. (OS X) Add your new target to the "Target Dependencies" section of the `SwiftXCTestTests` aggregate build target's build phases. You may build the `SwiftXCTestTests` target to confirm the tests pass.
+
 ### Additional Considerations for Swift on Linux
 
 When running on the Objective-C runtime, XCTest is able to find all of your tests by simply asking the runtime for the subclasses of `XCTestCase`. It then finds the methods that start with the string `test`. This functionality is not currently present when running on the Swift runtime. Therefore, you must currently provide an additional property called `allTests` in your `XCTestCase` subclass. This method lists all of the tests in the test class. The rest of your test case subclass still contains your test methods.

--- a/Tests/Fixtures/Sources/SingleFailingTestCase/main.swift
+++ b/Tests/Fixtures/Sources/SingleFailingTestCase/main.swift
@@ -1,0 +1,26 @@
+// Test Case 'SingleFailingTestCase.test_fails' started.
+// %file:22: error: SingleFailingTestCase.test_fails : 
+// Test Case 'SingleFailingTestCase.test_fails' failed (%ignored-time-duration seconds).
+// Executed 1 test, with 1 failure (0 unexpected) in %ignored-time-duration (%ignored-time-duration) seconds
+// Total executed 1 test, with 1 failure (0 unexpected) in %ignored-time-duration (%ignored-time-duration) seconds
+// %exit-status: 1
+
+#if os(Linux)
+    import XCTest
+#else
+    import SwiftXCTest
+#endif
+
+class SingleFailingTestCase: XCTestCase {
+    var allTests: [(String, () -> ())] {
+        return [
+            ("test_fails", test_fails),
+        ]
+    }
+
+    func test_fails() {
+        XCTAssert(false)
+    }
+}
+
+XCTMain([SingleFailingTestCase()])

--- a/Tests/test.py
+++ b/Tests/test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+
+import glob
+import os
+import re
+import subprocess
+import unittest
+
+
+# swift-corelibs-xctest/Tests/
+TESTS_DIR = os.path.dirname(__file__)
+# swift-corelibs-xctest/Tests/Fixtures/
+FIXTURES_DIR = os.path.join(TESTS_DIR, 'Fixtures')
+# swift-corelibs-xctest/Tests/Fixtures/Products/
+PRODUCTS_DIR = os.path.join(FIXTURES_DIR, 'Products')
+# swift-corelibs-xctest/Tests/Fixtures/Sources/
+SOURCES_DIR = os.path.join(FIXTURES_DIR, 'Sources')
+
+# The failure message template for fixture test exit status.
+FIXTURE_TEST_CASE_EXIT_FAILURE_MESSAGE = "Executing the test '{0}' was expected to return exit status '{1}', but actually returned '{2}'."
+
+# The failure message template for fixture test output.
+FIXTURE_TEST_CASE_OUTPUT_FAILURE_MESSAGE = """Executing the test '{0}' did not produce the expected output.
+
+EXPECTED
+--------
+{1}
+
+ACTUAL
+------
+{2}
+"""
+
+
+def replace_decimals_with_ignored(string):
+    """
+    Replaces all decimal numbers in the input string with a
+    token signifying they should be ignored.
+    """
+    return re.sub(r'\d+\.\d+', '%ignored-time-duration', string)
+
+
+def read_expected_output(source_file):
+    """
+    Opens a Swift file at the given path and concatenates all
+    source code comments. Tokens in the file, such as '%file',
+    are replaced with substitution values.
+    """
+    expected_exit_status = 0
+    expected_output_string = ""
+    with open(source_file) as f:
+        for line in f:
+            if line.startswith('// %exit-status: '):
+                expected_exit_status = int(line[17:])
+            elif line.startswith('// '):
+                line = line[3:]
+                line = line.replace('%file', os.path.abspath(source_file))
+                expected_output_string += line
+
+    return (expected_exit_status, expected_output_string)
+
+
+class FixtureTestCase(unittest.TestCase):
+    """
+    A parameterized test case for XCTest output. It takes the name of an
+    XCTest functional test fixture as its argument, and verifies the output
+    of running that fixture.
+    """
+    def __init__(self, fixture_name):
+        """
+        Initializes a parameterized test case for XCTest output, using the
+        given fixture name.
+        """
+        super(FixtureTestCase, self).__init__('compare_stdout_to_source')
+        self.fixture_name = fixture_name
+
+    def compare_stdout_to_source(self):
+        """
+        This test method compares the output of an XCTest run to the expected
+        output, which is to be encoded within the source file of the XCTest
+        fixture as a source code comment.
+        """
+        # Execute the test fixture.
+        # For example, if the fixture is named 'SingleFailingTestCase',
+        # this executes Fixtures/Products/SingleFailingTestCase.
+        executable_path = os.path.abspath(
+            os.path.join(PRODUCTS_DIR, self.fixture_name))
+        process = subprocess.Popen(
+            [executable_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        # We capture both stdout and stderr, but we're only interested
+        # in stdout.
+        out, _ = process.communicate()
+
+        # Read the expected output from the source file.
+        # For example, if the fixture is named 'SingleFailingTestCase',
+        # this reads Fixtures/Sources/SingleFailingTestCase/main.swift.
+        source_file = os.path.join(
+            SOURCES_DIR,
+            self.fixture_name,
+            'main.swift')
+        expected_exit, expected_out = read_expected_output(source_file)
+
+        # Compare the actual exit status to the expected status.
+        # If no expected exit status is specified, assert the actual
+        # status is '0'.
+        self.assertEqual(
+            process.returncode,
+            expected_exit,
+            msg=FIXTURE_TEST_CASE_EXIT_FAILURE_MESSAGE.format(
+                executable_path,
+                expected_exit,
+                process.returncode))
+        # Compare the actual execution to the expected output.
+        # Convert all decimal numbers in the XCTest output to a token.
+        sanitized_out = replace_decimals_with_ignored(out)
+        self.assertEqual(
+            sanitized_out,
+            expected_out,
+            msg=FIXTURE_TEST_CASE_OUTPUT_FAILURE_MESSAGE.format(
+                executable_path,
+                expected_out,
+                sanitized_out))
+
+
+# Conform to the load_tests protocol to customize which tests are run.
+# See: https://docs.python.org/2/library/unittest.html#load-tests-protocol
+#
+# This function executes a FixtureTestCase for each executable in
+# Tests/Fixtures/Products/. As such, those products need to be built prior
+# to running the tests.
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestSuite()
+    products_glob_path = os.path.join(PRODUCTS_DIR, '*')
+    product_path = None
+    for product_path in glob.glob(products_glob_path):
+        fixture_name = os.path.basename(product_path)
+        test_case = FixtureTestCase(fixture_name)
+        suite.addTest(test_case)
+
+    if product_path is None:
+        # If there are no files in Tests/Fixtures/Products/, something
+        # is wrong.
+        assert False, "{} does not contain any files.".format(
+            products_glob_path)
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -6,12 +6,59 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		DA075A741C14DAAF000140C8 /* SwiftXCTestTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = DA075A751C14DAAF000140C8 /* Build configuration list for PBXAggregateTarget "SwiftXCTestTests" */;
+			buildPhases = (
+				DA075A7A1C14DABA000140C8 /* ShellScript */,
+			);
+			dependencies = (
+				DA075A7C1C14DAD4000140C8 /* PBXTargetDependency */,
+				DA075A791C14DAB6000140C8 /* PBXTargetDependency */,
+			);
+			name = SwiftXCTestTests;
+			productName = SwiftXCTestTests;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
+		DAA28A081C16017300DCBAB2 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA075A6F1C14B9BD000140C8 /* main.swift */; };
+		DAA28A0B1C16017A00DCBAB2 /* SwiftXCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */; };
 		EA6E86BB1BDEA7DE007C0323 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		DA075A781C14DAB6000140C8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DAA28A001C16010900DCBAB2;
+			remoteInfo = SingleFailingTestCase;
+		};
+		DA075A7B1C14DAD4000140C8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D86DA1BBC74AD00234F36;
+			remoteInfo = SwiftXCTest;
+		};
+		DAA28A091C16017700DCBAB2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D86DA1BBC74AD00234F36;
+			remoteInfo = SwiftXCTest;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA075A631C14B8EA000140C8 /* SingleFailingTestCase */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SingleFailingTestCase; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA075A6F1C14B9BD000140C8 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		DA075A721C14BB1B000140C8 /* Products */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Products; sourceTree = "<group>"; };
+		DA075A731C14C99A000140C8 /* test.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = test.py; sourceTree = "<group>"; };
+		DAA28A011C16010900DCBAB2 /* SingleFailingTestCase */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SingleFailingTestCase; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA3E74BB1BF2B6D500635A73 /* build_script.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = build_script.py; sourceTree = "<group>"; };
 		EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -24,6 +71,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAA289FE1C16010900DCBAB2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAA28A0B1C16017A00DCBAB2 /* SwiftXCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -31,6 +86,7 @@
 			isa = PBXGroup;
 			children = (
 				5B5D86DD1BBC74AD00234F36 /* XCTest */,
+				DA075A591C14B864000140C8 /* Tests */,
 				5B5D86DC1BBC74AD00234F36 /* Products */,
 				EA3E74BC1BF2B6D700635A73 /* Linux Build */,
 			);
@@ -42,6 +98,8 @@
 			isa = PBXGroup;
 			children = (
 				5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */,
+				DA075A631C14B8EA000140C8 /* SingleFailingTestCase */,
+				DAA28A011C16010900DCBAB2 /* SingleFailingTestCase */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -52,6 +110,40 @@
 				EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */,
 			);
 			path = XCTest;
+			sourceTree = "<group>";
+		};
+		DA075A591C14B864000140C8 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				DA075A731C14C99A000140C8 /* test.py */,
+				DA075A5A1C14B864000140C8 /* Fixtures */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		DA075A5A1C14B864000140C8 /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				DA075A721C14BB1B000140C8 /* Products */,
+				DA075A5C1C14B864000140C8 /* Sources */,
+			);
+			path = Fixtures;
+			sourceTree = "<group>";
+		};
+		DA075A5C1C14B864000140C8 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				DA075A6E1C14B9BD000140C8 /* SingleFailingTestCase */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		DA075A6E1C14B9BD000140C8 /* SingleFailingTestCase */ = {
+			isa = PBXGroup;
+			children = (
+				DA075A6F1C14B9BD000140C8 /* main.swift */,
+			);
+			path = SingleFailingTestCase;
 			sourceTree = "<group>";
 		};
 		EA3E74BC1BF2B6D700635A73 /* Linux Build */ = {
@@ -93,6 +185,23 @@
 			productReference = 5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		DAA28A001C16010900DCBAB2 /* SingleFailingTestCase */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAA28A071C16010900DCBAB2 /* Build configuration list for PBXNativeTarget "SingleFailingTestCase" */;
+			buildPhases = (
+				DAA289FD1C16010900DCBAB2 /* Sources */,
+				DAA289FE1C16010900DCBAB2 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DAA28A0A1C16017700DCBAB2 /* PBXTargetDependency */,
+			);
+			name = SingleFailingTestCase;
+			productName = SingleFailingTestCase;
+			productReference = DAA28A011C16010900DCBAB2 /* SingleFailingTestCase */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -122,6 +231,8 @@
 			projectRoot = "";
 			targets = (
 				5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */,
+				DAA28A001C16010900DCBAB2 /* SingleFailingTestCase */,
+				DA075A741C14DAAF000140C8 /* SwiftXCTestTests */,
 			);
 		};
 /* End PBXProject section */
@@ -136,6 +247,22 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		DA075A7A1C14DABA000140C8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = $SRCROOT/Tests/test.py;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		5B5D86D61BBC74AD00234F36 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -145,7 +272,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAA289FD1C16010900DCBAB2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAA28A081C16017300DCBAB2 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DA075A791C14DAB6000140C8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DAA28A001C16010900DCBAB2 /* SingleFailingTestCase */;
+			targetProxy = DA075A781C14DAB6000140C8 /* PBXContainerItemProxy */;
+		};
+		DA075A7C1C14DAD4000140C8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */;
+			targetProxy = DA075A7B1C14DAD4000140C8 /* PBXContainerItemProxy */;
+		};
+		DAA28A0A1C16017700DCBAB2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */;
+			targetProxy = DAA28A091C16017700DCBAB2 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		5B5D86E11BBC74AD00234F36 /* Debug */ = {
@@ -271,6 +424,44 @@
 			};
 			name = Release;
 		};
+		DA075A761C14DAAF000140C8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		DA075A771C14DAAF000140C8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		DAA28A051C16010900DCBAB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEPLOYMENT_LOCATION = YES;
+				DSTROOT = "$(SRCROOT)/Tests/Fixtures/Products/";
+				INSTALL_PATH = /;
+				LD_RUNPATH_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		DAA28A061C16010900DCBAB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEPLOYMENT_LOCATION = YES;
+				DSTROOT = "$(SRCROOT)/Tests/Fixtures/Products/";
+				INSTALL_PATH = /;
+				LD_RUNPATH_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -291,6 +482,23 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		DA075A751C14DAAF000140C8 /* Build configuration list for PBXAggregateTarget "SwiftXCTestTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA075A761C14DAAF000140C8 /* Debug */,
+				DA075A771C14DAAF000140C8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAA28A071C16010900DCBAB2 /* Build configuration list for PBXNativeTarget "SingleFailingTestCase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAA28A051C16010900DCBAB2 /* Debug */,
+				DAA28A061C16010900DCBAB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
See the individual commit messages for details, and the instructions added to the README for an idea of how the test suite works.

This approach differs from the one suggested on the mailing list by @ddunbar, in which XCTest itself is used to test XCTest. I believe this approach is simpler to implement and maintain.

In addition, using XCTest to test itself is a dangerous proposition: one or more bugs in XCTest may cause regressions, which may then not be caught because of those same bugs.