### PR TITLE
Splitting implementation into several files in anticipation of growth of the code base.

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -7,11 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B11FFA2A1C1603B6004297C2 /* XCTAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11FFA291C1603B6004297C2 /* XCTAssert.swift */; };
+		B11FFA2C1C160434004297C2 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11FFA2B1C160434004297C2 /* XCTestCaseProvider.swift */; };
+		B11FFA2E1C16053C004297C2 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11FFA2D1C16053C004297C2 /* XCTestCase.swift */; };
 		EA6E86BB1BDEA7DE007C0323 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B11FFA291C1603B6004297C2 /* XCTAssert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTAssert.swift; sourceTree = "<group>"; };
+		B11FFA2B1C160434004297C2 /* XCTestCaseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseProvider.swift; sourceTree = "<group>"; };
+		B11FFA2D1C16053C004297C2 /* XCTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCase.swift; sourceTree = "<group>"; };
 		EA3E74BB1BF2B6D500635A73 /* build_script.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = build_script.py; sourceTree = "<group>"; };
 		EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -50,6 +56,9 @@
 			isa = PBXGroup;
 			children = (
 				EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */,
+				B11FFA2D1C16053C004297C2 /* XCTestCase.swift */,
+				B11FFA2B1C160434004297C2 /* XCTestCaseProvider.swift */,
+				B11FFA291C1603B6004297C2 /* XCTAssert.swift */,
 			);
 			path = XCTest;
 			sourceTree = "<group>";
@@ -142,6 +151,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA6E86BB1BDEA7DE007C0323 /* XCTest.swift in Sources */,
+				B11FFA2C1C160434004297C2 /* XCTestCaseProvider.swift in Sources */,
+				B11FFA2E1C16053C004297C2 /* XCTestCase.swift in Sources */,
+				B11FFA2A1C1603B6004297C2 /* XCTAssert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XCTest/XCTAssert.swift
+++ b/XCTest/XCTAssert.swift
@@ -1,0 +1,104 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTAssert.swift
+//  Test assertion functions
+//
+
+public func XCTAssert(@autoclosure expression: () -> BooleanType, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    if !expression().boolValue {
+        if let test = XCTCurrentTestCase {
+            test.testFailure(message, file: file, line: line)
+        }
+    }
+}
+
+public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> T?, @autoclosure _ expression2: () -> T?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() == expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> ArraySlice<T>, @autoclosure _ expression2: () -> ArraySlice<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() == expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> ContiguousArray<T>, @autoclosure _ expression2: () -> ContiguousArray<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() == expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> [T], @autoclosure _ expression2: () -> [T], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() == expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertEqual<T, U : Equatable>(@autoclosure expression1: () -> [T : U], @autoclosure _ expression2: () -> [T : U], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() == expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertEqualWithAccuracy<T : FloatingPointType>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, accuracy: T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(abs(expression1().distanceTo(expression2())) <= abs(accuracy.distanceTo(T(0))), message, file: file, line: line)
+}
+
+public func XCTAssertFalse(@autoclosure expression: () -> BooleanType, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(!expression().boolValue, message, file: file, line: line)
+}
+
+public func XCTAssertGreaterThan<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() > expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertGreaterThanOrEqual<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() >= expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertLessThan<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() < expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertLessThanOrEqual<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() <= expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertNil(@autoclosure expression: () -> Any?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression() == nil, message, file: file, line: line)
+}
+
+public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> T?, @autoclosure _ expression2: () -> T?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() != expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> ContiguousArray<T>, @autoclosure _ expression2: () -> ContiguousArray<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() != expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> ArraySlice<T>, @autoclosure _ expression2: () -> ArraySlice<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() != expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> [T], @autoclosure _ expression2: () -> [T], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() != expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertNotEqual<T, U : Equatable>(@autoclosure expression1: () -> [T : U], @autoclosure _ expression2: () -> [T : U], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression1() != expression2(), message, file: file, line: line)
+}
+
+public func XCTAssertNotEqualWithAccuracy<T : FloatingPointType>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ accuracy: T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(abs(expression1().distanceTo(expression2())) > abs(accuracy.distanceTo(T(0))), message, file: file, line: line)
+}
+
+public func XCTAssertNotNil(@autoclosure expression: () -> Any?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression() != nil, message, file: file, line: line)
+}
+
+public func XCTAssertTrue(@autoclosure expression: () -> BooleanType, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(expression().boolValue, message, file: file, line: line)
+}
+
+public func XCTFail(message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+    XCTAssert(false, message, file: file, line: line)
+}

--- a/XCTest/XCTest.swift
+++ b/XCTest/XCTest.swift
@@ -8,7 +8,8 @@
 //
 //
 //  XCTest.swift
-//  a mini version XCTest
+//  This is the main file for the framework. It provides the entry point function
+//  for running tests and some infrastructure for running them.
 //
 
 #if os(Linux)
@@ -17,90 +18,13 @@ import Glibc
 import Darwin
 #endif
 
-public protocol XCTestCaseProvider {
-    // In the Objective-C version of XCTest, it is possible to discover all tests when the test is executed by asking the runtime for all methods and looking for the string "test". In Swift, we ask test providers to tell us the list of tests by implementing this property.
-    var allTests : [(String, () -> ())] { get }
-}
-
-public protocol XCTestCase : XCTestCaseProvider {
-
-}
-
-extension XCTestCase {
+struct XCTFailure {
+    var message: String
+    var file: StaticString
+    var line: UInt
     
-    public var continueAfterFailure: Bool {
-        get {
-            return true
-        }
-        set {
-            // TODO: When using the Objective-C runtime, XCTest is able to throw an exception from an assert and then catch it at the frame above the test method. This enables the framework to effectively stop all execution in the current test. There is no such facility in Swift. Until we figure out how to get a compatible behavior, we have decided to hard-code the value of 'true' for continue after failure.
-        }
-    }
-    
-    public func invokeTest() {
-        let tests = self.allTests
-        var totalDuration = 0.0
-        var totalFailures = 0
-        for (name, test) in tests {
-            XCTCurrentTestCase = self
-            let method = "\(self.dynamicType).\(name)"
-            var duration: Double = 0.0
-            print("Test Case '\(method)' started.")
-            var tv = timeval()
-            let start = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> Double in
-                gettimeofday(t, nil)
-                return Double(t.memory.tv_sec) + Double(t.memory.tv_usec) / 1000000.0
-            })
-            
-            test()
-            let end = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> Double in
-                gettimeofday(t, nil)
-                return Double(t.memory.tv_sec) + Double(t.memory.tv_usec) / 1000000.0
-            })
-            duration = end - start
-            totalDuration += duration
-            for failure in XCTCurrentFailures {
-                failure.emit(method)
-                totalFailures++
-            }
-            var result = "passed"
-            if XCTCurrentFailures.count > 0 {
-                result = "failed"
-            }
-            print("Test Case '\(method)' \(result) (\(round(duration * 1000.0) / 1000.0) seconds).")
-            XCTAllRuns.append(XCTRun(duration: duration, method: method, passed: XCTCurrentFailures.count == 0, failures: XCTCurrentFailures))
-            XCTCurrentFailures.removeAll()
-            XCTCurrentTestCase = nil
-        }
-        var testCountSuffix = "s"
-        if tests.count == 1 {
-            testCountSuffix = ""
-        }
-        var failureSuffix = "s"
-        if totalFailures == 1 {
-            failureSuffix = ""
-        }
-        let averageDuration = totalDuration / Double(tests.count)
-
-        
-        print("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (0 unexpected) in \(round(averageDuration * 1000.0) / 1000.0) (\(round(totalDuration * 1000.0) / 1000.0)) seconds")
-    }
-    
-    // This function is for the use of XCTestCase only, but we must make it public or clients will get a link failure when using XCTest (23476006)
-    public func testFailure(message: String, file: StaticString , line: UInt) {
-        if !continueAfterFailure {
-            assert(false, message, file: file, line: line)
-        } else {
-            XCTCurrentFailures.append(XCTFailure(message: message, file: file, line: line))
-        }
-    }
-    
-    public func setUp() {
-        
-    }
-    
-    public func tearDown() {
-        
+    func emit(method: String) {
+        print("\(file):\(line): error: \(method) : \(message)")
     }
 }
 
@@ -134,108 +58,7 @@ internal struct XCTRun {
     exit(totalFailures > 0 ? 1 : 0)
 }
 
-struct XCTFailure {
-    var message: String
-    var file: StaticString
-    var line: UInt
-    
-    func emit(method: String) {
-        print("\(file):\(line): error: \(method) : \(message)")
-    }
-}
-
 internal var XCTCurrentTestCase: XCTestCase?
 internal var XCTCurrentFailures = [XCTFailure]()
 internal var XCTAllRuns = [XCTRun]()
 
-public func XCTAssert(@autoclosure expression: () -> BooleanType, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    if !expression().boolValue {
-        if let test = XCTCurrentTestCase {
-            test.testFailure(message, file: file, line: line)
-        }
-    }
-}
-
-public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> T?, @autoclosure _ expression2: () -> T?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() == expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> ArraySlice<T>, @autoclosure _ expression2: () -> ArraySlice<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() == expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> ContiguousArray<T>, @autoclosure _ expression2: () -> ContiguousArray<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() == expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertEqual<T : Equatable>(@autoclosure expression1: () -> [T], @autoclosure _ expression2: () -> [T], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() == expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertEqual<T, U : Equatable>(@autoclosure expression1: () -> [T : U], @autoclosure _ expression2: () -> [T : U], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() == expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertEqualWithAccuracy<T : FloatingPointType>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, accuracy: T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(abs(expression1().distanceTo(expression2())) <= abs(accuracy.distanceTo(T(0))), message, file: file, line: line)
-}
-
-public func XCTAssertFalse(@autoclosure expression: () -> BooleanType, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(!expression().boolValue, message, file: file, line: line)
-}
-
-public func XCTAssertGreaterThan<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() > expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertGreaterThanOrEqual<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() >= expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertLessThan<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() < expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertLessThanOrEqual<T : Comparable>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() <= expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertNil(@autoclosure expression: () -> Any?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression() == nil, message, file: file, line: line)
-}
-
-public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> T?, @autoclosure _ expression2: () -> T?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() != expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> ContiguousArray<T>, @autoclosure _ expression2: () -> ContiguousArray<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() != expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> ArraySlice<T>, @autoclosure _ expression2: () -> ArraySlice<T>, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() != expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertNotEqual<T : Equatable>(@autoclosure expression1: () -> [T], @autoclosure _ expression2: () -> [T], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() != expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertNotEqual<T, U : Equatable>(@autoclosure expression1: () -> [T : U], @autoclosure _ expression2: () -> [T : U], _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression1() != expression2(), message, file: file, line: line)
-}
-
-public func XCTAssertNotEqualWithAccuracy<T : FloatingPointType>(@autoclosure expression1: () -> T, @autoclosure _ expression2: () -> T, _ accuracy: T, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(abs(expression1().distanceTo(expression2())) > abs(accuracy.distanceTo(T(0))), message, file: file, line: line)
-}
-
-public func XCTAssertNotNil(@autoclosure expression: () -> Any?, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression() != nil, message, file: file, line: line)
-}
-
-public func XCTAssertTrue(@autoclosure expression: () -> BooleanType, _ message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(expression().boolValue, message, file: file, line: line)
-}
-
-public func XCTFail(message: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
-    XCTAssert(false, message, file: file, line: line)
-}

--- a/XCTest/XCTestCase.swift
+++ b/XCTest/XCTestCase.swift
@@ -1,0 +1,100 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestCase.swift
+//  Base protocol (and extension with default methods) for test cases
+//
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin
+#endif
+
+public protocol XCTestCase : XCTestCaseProvider {
+    
+}
+
+extension XCTestCase {
+    
+    public var continueAfterFailure: Bool {
+        get {
+            return true
+        }
+        set {
+            // TODO: When using the Objective-C runtime, XCTest is able to throw an exception from an assert and then catch it at the frame above the test method. This enables the framework to effectively stop all execution in the current test. There is no such facility in Swift. Until we figure out how to get a compatible behavior, we have decided to hard-code the value of 'true' for continue after failure.
+        }
+    }
+    
+    public func invokeTest() {
+        let tests = self.allTests
+        var totalDuration = 0.0
+        var totalFailures = 0
+        for (name, test) in tests {
+            XCTCurrentTestCase = self
+            let method = "\(self.dynamicType).\(name)"
+            var duration: Double = 0.0
+            print("Test Case '\(method)' started.")
+            var tv = timeval()
+            let start = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> Double in
+                gettimeofday(t, nil)
+                return Double(t.memory.tv_sec) + Double(t.memory.tv_usec) / 1000000.0
+            })
+            
+            test()
+            let end = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> Double in
+                gettimeofday(t, nil)
+                return Double(t.memory.tv_sec) + Double(t.memory.tv_usec) / 1000000.0
+            })
+            duration = end - start
+            totalDuration += duration
+            for failure in XCTCurrentFailures {
+                failure.emit(method)
+                totalFailures++
+            }
+            var result = "passed"
+            if XCTCurrentFailures.count > 0 {
+                result = "failed"
+            }
+            print("Test Case '\(method)' \(result) (\(round(duration * 1000.0) / 1000.0) seconds).")
+            XCTAllRuns.append(XCTRun(duration: duration, method: method, passed: XCTCurrentFailures.count == 0, failures: XCTCurrentFailures))
+            XCTCurrentFailures.removeAll()
+            XCTCurrentTestCase = nil
+        }
+        var testCountSuffix = "s"
+        if tests.count == 1 {
+            testCountSuffix = ""
+        }
+        var failureSuffix = "s"
+        if totalFailures == 1 {
+            failureSuffix = ""
+        }
+        let averageDuration = totalDuration / Double(tests.count)
+        
+        
+        print("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (0 unexpected) in \(round(averageDuration * 1000.0) / 1000.0) (\(round(totalDuration * 1000.0) / 1000.0)) seconds")
+    }
+    
+    // This function is for the use of XCTestCase only, but we must make it public or clients will get a link failure when using XCTest (23476006)
+    public func testFailure(message: String, file: StaticString , line: UInt) {
+        if !continueAfterFailure {
+            assert(false, message, file: file, line: line)
+        } else {
+            XCTCurrentFailures.append(XCTFailure(message: message, file: file, line: line))
+        }
+    }
+    
+    public func setUp() {
+        
+    }
+    
+    public func tearDown() {
+        
+    }
+}

--- a/XCTest/XCTestCaseProvider.swift
+++ b/XCTest/XCTestCaseProvider.swift
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestCaseProvider.swift
+//  Protocol for classes that can provide test cases
+//
+
+public protocol XCTestCaseProvider {
+    // In the Objective-C version of XCTest, it is possible to discover all tests when the test is executed by asking the runtime for all methods and looking for the string "test". In Swift, we ask test providers to tell us the list of tests by implementing this property.
+    var allTests : [(String, () -> ())] { get }
+}
+

--- a/build_script.py
+++ b/build_script.py
@@ -66,10 +66,15 @@ def main():
     if not os.path.exists(build_dir):
         run("mkdir -p {}".format(build_dir))
 
+    sourceFiles = ["XCTest.swift", "XCTestCaseProvider.swift", "XCTestCase.swift", "XCTAssert.swift"]
+    sourcePaths = []
+    for file in sourceFiles:
+        sourcePaths.append("{0}/XCTest/{1}".format(os.path.dirname(os.path.abspath(__file__)), file))
+
     # Not incremental..
-    run("{0} -c -O -emit-object {1}/XCTest/XCTest.swift -module-name XCTest -parse-as-library -emit-module "
+    run("{0} -c -O -emit-object {1} -module-name XCTest -parse-as-library -emit-module "
         "-emit-module-path {2}/XCTest.swiftmodule -o {2}/XCTest.o -force-single-frontend-invocation "
-        "-module-link-name XCTest".format(swiftc, os.path.dirname(os.path.abspath(__file__)), build_dir))
+        "-module-link-name XCTest".format(swiftc, " ".join(sourcePaths), build_dir))
 
     run("clang {0}/XCTest.o -shared -o {0}/libXCTest.so -Wl,--no-undefined -Wl,-soname,libXCTest.so -L{1}/lib/swift/linux/ -lswiftGlibc -lswiftCore -lm".format(build_dir, swift_build_dir))
 


### PR DESCRIPTION
My general goal here is to go by the general pattern of defining things in their own files. I have split the assertion functions into XCTAssert.swift, I have also created separate a file for XCTestCaseProvider and another for the XCTestCase protocol and its extension. Finally XCTest.swift remains with the XCTMain function and some attendant global state and the structs used to track it.