### PR TITLE
Fix coding style of return type from () -> () to () -> Void

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When running on the Objective-C runtime, XCTest is able to find all of your test
 
 ```swift
 class TestNSURL : XCTestCase {
-    var allTests : [(String, () -> ())] {
+    var allTests : [(String, () -> Void)] {
         return [
             ("test_URLStrings", test_URLStrings),
             ("test_fileURLWithPath_relativeToURL", test_fileURLWithPath_relativeToURL ),

--- a/XCTest/XCTestCaseProvider.swift
+++ b/XCTest/XCTestCaseProvider.swift
@@ -13,6 +13,6 @@
 
 public protocol XCTestCaseProvider {
     // In the Objective-C version of XCTest, it is possible to discover all tests when the test is executed by asking the runtime for all methods and looking for the string "test". In Swift, we ask test providers to tell us the list of tests by implementing this property.
-    var allTests : [(String, () -> ())] { get }
+    var allTests : [(String, () -> Void)] { get }
 }
 


### PR DESCRIPTION
As stated in https://devforums.apple.com/message/1133616#1133616, `() -> Void` is now standard.
Related: https://github.com/apple/swift/commit/6536edd68c3cf44f0c61eb69c117a69f8b4185c2