### PR TITLE
Add lit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 xcuserdata
+
+# Functional test suite places compiled executables in the source tree
+Tests/Functional/Products/*

--- a/README.md
+++ b/README.md
@@ -38,6 +38,29 @@ If your install of Swift is located at `/swift` and you wish to install XCTest i
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --build-dir="/tmp/XCTest_build" --swift-build-dir="/swift/usr" --library-install-path="/swift/usr/lib/swift/linux" --module-install-path="/swift/usr/lib/swift/linux/x86_64"
 ```
 
+To run the tests, pass the `--test` option in combination with options to
+install XCTest in your active version of Swift, as well with the path to
+built LLVM binaries (which contain a program named `FileCheck`):
+
+```sh
+./build_script.py \
+    --swiftc="/swift/usr/bin/swiftc" \
+    --build-dir="/tmp/XCTest_build" \
+    --swift-build-dir="/swift/usr" \
+    --library-install-path="/swift/usr/lib/swift/linux" \
+    --module-install-path="/swift/usr/lib/swift/linux/x86_64" \
+    --test \
+    --native-llvm-tools-path="/llvm/build/Ninja-DebugAssert/llvm-macosx-x86_64/bin"
+```
+
+To add additional tests to XCTest:
+
+1. (Linux & OS X) Add a directory with the name of your test to the `Tests/Functional/Sources/` directory. For example, if your test is named "TwoFailingTestCases", make a directory named `Tests/Functional/Sources/TwoFailingTestCases`.
+1. (Linux & OS X) Add a `main.swift` file to the directory you added above. The file should contain comments, beginning with `// `. The test runner will verify that the output of `main.swift` matches your comments exactly. This is all you need to do to run tests on Linux--you may run the `build_script.py` example above to confirm the tests pass.
+1. (OS X) If you want your tests to run on OS X, open the `XCTest.xcodeproj` Xcode project and duplicate the `SingleFailingTestCase` target. Rename the target to match the name of your test. For example, if your test is named "TwoFailingTestCases", name the target `TwoFailingTestCases` as well.
+1. (OS X) In the "Compile Sources" build phase, set your `main.swift` file in place of the one in `SingleFailingTestCase`.
+1. (OS X) Add your new target to the "Target Dependencies" section of the `SwiftXCTestTests` aggregate build target's build phases. You may build the `SwiftXCTestTests` target to confirm the tests pass.
+
 ### Additional Considerations for Swift on Linux
 
 When running on the Objective-C runtime, XCTest is able to find all of your tests by simply asking the runtime for the subclasses of `XCTestCase`. It then finds the methods that start with the string `test`. This functionality is not currently present when running on the Swift runtime. Therefore, you must currently provide an additional property called `allTests` in your `XCTestCase` subclass. This method lists all of the tests in the test class. The rest of your test case subclass still contains your test methods.

--- a/Tests/Functional/Sources/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/Sources/SingleFailingTestCase/main.swift
@@ -1,0 +1,29 @@
+// RUN: %S/../../Products/SingleFailingTestCase > %t.out || true
+// RUN: FileCheck %s < %t.out
+// RUN: rm %t.out
+
+// CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
+// CHECK: {{.*}}/Tests/Functional/Sources/SingleFailingTestCase/main.swift:25: error: SingleFailingTestCase.test_fails :
+// CHECK: Test Case 'SingleFailingTestCase.test_fails' failed ({{[0-9]+\.[0-9]+}} seconds).
+// CHECK: Executed 1 test, with 1 failure (0 unexpected) in {{[0-9]+\.[0-9]+}} ({{[0-9]+\.[0-9]+}}) seconds
+// CHECK: Total executed 1 test, with 1 failure (0 unexpected) in {{[0-9]+\.[0-9]+}} ({{[0-9]+\.[0-9]+}}) seconds
+
+#if os(Linux)
+    import XCTest
+#else
+    import SwiftXCTest
+#endif
+
+class SingleFailingTestCase: XCTestCase {
+    var allTests: [(String, () -> ())] {
+        return [
+            ("test_fails", test_fails),
+        ]
+    }
+
+    func test_fails() {
+        XCTAssert(false)
+    }
+}
+
+XCTMain([SingleFailingTestCase()])

--- a/Tests/lit.cfg
+++ b/Tests/lit.cfg
@@ -1,0 +1,13 @@
+import lit.formats
+import os
+
+config.name = 'SwiftXCTestFunctionalTests'
+config.test_format = lit.formats.ShTest(execute_external=False)
+config.suffixes = ['.swift']
+
+native_llvm_tools_path = lit_config.params.get('native_llvm_tools_path')
+if native_llvm_tools_path is not None:
+    config.environment['PATH'] = os.path.pathsep.join((
+        native_llvm_tools_path, config.environment['PATH']))
+
+# vim: set syntax=python:

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -6,18 +6,64 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		DA075A741C14DAAF000140C8 /* SwiftXCTestTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = DA075A751C14DAAF000140C8 /* Build configuration list for PBXAggregateTarget "SwiftXCTestTests" */;
+			buildPhases = (
+				DA075A7A1C14DABA000140C8 /* ShellScript */,
+			);
+			dependencies = (
+				DA075A7C1C14DAD4000140C8 /* PBXTargetDependency */,
+				DA075A791C14DAB6000140C8 /* PBXTargetDependency */,
+			);
+			name = SwiftXCTestTests;
+			productName = SwiftXCTestTests;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		B11FFA2A1C1603B6004297C2 /* XCTAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11FFA291C1603B6004297C2 /* XCTAssert.swift */; };
 		B11FFA2C1C160434004297C2 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11FFA2B1C160434004297C2 /* XCTestCaseProvider.swift */; };
 		B11FFA2E1C16053C004297C2 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11FFA2D1C16053C004297C2 /* XCTestCase.swift */; };
+		DAA28A0B1C16017A00DCBAB2 /* SwiftXCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */; };
+		DAD00B911C1AA434004A84A5 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD00B8C1C1AA3B3004A84A5 /* main.swift */; };
 		EA6E86BB1BDEA7DE007C0323 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DA075A781C14DAB6000140C8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DAA28A001C16010900DCBAB2;
+			remoteInfo = SingleFailingTestCase;
+		};
+		DA075A7B1C14DAD4000140C8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D86DA1BBC74AD00234F36;
+			remoteInfo = SwiftXCTest;
+		};
+		DAA28A091C16017700DCBAB2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D86DA1BBC74AD00234F36;
+			remoteInfo = SwiftXCTest;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B11FFA291C1603B6004297C2 /* XCTAssert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTAssert.swift; sourceTree = "<group>"; };
 		B11FFA2B1C160434004297C2 /* XCTestCaseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseProvider.swift; sourceTree = "<group>"; };
 		B11FFA2D1C16053C004297C2 /* XCTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCase.swift; sourceTree = "<group>"; };
+		DA075A631C14B8EA000140C8 /* SingleFailingTestCase */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SingleFailingTestCase; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAA28A011C16010900DCBAB2 /* SingleFailingTestCase */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SingleFailingTestCase; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAD00B8C1C1AA3B3004A84A5 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		DAD00B8F1C1AA3B3004A84A5 /* lit.cfg */ = {isa = PBXFileReference; lastKnownFileType = text; path = lit.cfg; sourceTree = "<group>"; };
 		EA3E74BB1BF2B6D500635A73 /* build_script.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = build_script.py; sourceTree = "<group>"; };
 		EA6E86BA1BDEA7DE007C0323 /* XCTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -30,6 +76,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAA289FE1C16010900DCBAB2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAA28A0B1C16017A00DCBAB2 /* SwiftXCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -37,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				5B5D86DD1BBC74AD00234F36 /* XCTest */,
+				DAD00B831C1AA3B3004A84A5 /* Tests */,
 				5B5D86DC1BBC74AD00234F36 /* Products */,
 				EA3E74BC1BF2B6D700635A73 /* Linux Build */,
 			);
@@ -48,6 +103,8 @@
 			isa = PBXGroup;
 			children = (
 				5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */,
+				DA075A631C14B8EA000140C8 /* SingleFailingTestCase */,
+				DAA28A011C16010900DCBAB2 /* SingleFailingTestCase */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -61,6 +118,39 @@
 				B11FFA291C1603B6004297C2 /* XCTAssert.swift */,
 			);
 			path = XCTest;
+			sourceTree = "<group>";
+		};
+		DAD00B831C1AA3B3004A84A5 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				DAD00B871C1AA3B3004A84A5 /* Functional */,
+				DAD00B8F1C1AA3B3004A84A5 /* lit.cfg */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		DAD00B871C1AA3B3004A84A5 /* Functional */ = {
+			isa = PBXGroup;
+			children = (
+				DAD00B8A1C1AA3B3004A84A5 /* Sources */,
+			);
+			path = Functional;
+			sourceTree = "<group>";
+		};
+		DAD00B8A1C1AA3B3004A84A5 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				DAD00B8B1C1AA3B3004A84A5 /* SingleFailingTestCase */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		DAD00B8B1C1AA3B3004A84A5 /* SingleFailingTestCase */ = {
+			isa = PBXGroup;
+			children = (
+				DAD00B8C1C1AA3B3004A84A5 /* main.swift */,
+			);
+			path = SingleFailingTestCase;
 			sourceTree = "<group>";
 		};
 		EA3E74BC1BF2B6D700635A73 /* Linux Build */ = {
@@ -102,6 +192,23 @@
 			productReference = 5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		DAA28A001C16010900DCBAB2 /* SingleFailingTestCase */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DAA28A071C16010900DCBAB2 /* Build configuration list for PBXNativeTarget "SingleFailingTestCase" */;
+			buildPhases = (
+				DAA289FD1C16010900DCBAB2 /* Sources */,
+				DAA289FE1C16010900DCBAB2 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DAA28A0A1C16017700DCBAB2 /* PBXTargetDependency */,
+			);
+			name = SingleFailingTestCase;
+			productName = SingleFailingTestCase;
+			productReference = DAA28A011C16010900DCBAB2 /* SingleFailingTestCase */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -131,6 +238,8 @@
 			projectRoot = "";
 			targets = (
 				5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */,
+				DAA28A001C16010900DCBAB2 /* SingleFailingTestCase */,
+				DA075A741C14DAAF000140C8 /* SwiftXCTestTests */,
 			);
 		};
 /* End PBXProject section */
@@ -145,6 +254,22 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		DA075A7A1C14DABA000140C8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "lit -v $SRCROOT/Tests --param native_llvm_tools_path=\"$SRCROOT/../build/Ninja-DebugAssert/llvm-macosx-x86_64/bin\"";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		5B5D86D61BBC74AD00234F36 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -157,7 +282,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DAA289FD1C16010900DCBAB2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DAD00B911C1AA434004A84A5 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DA075A791C14DAB6000140C8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DAA28A001C16010900DCBAB2 /* SingleFailingTestCase */;
+			targetProxy = DA075A781C14DAB6000140C8 /* PBXContainerItemProxy */;
+		};
+		DA075A7C1C14DAD4000140C8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */;
+			targetProxy = DA075A7B1C14DAD4000140C8 /* PBXContainerItemProxy */;
+		};
+		DAA28A0A1C16017700DCBAB2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */;
+			targetProxy = DAA28A091C16017700DCBAB2 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		5B5D86E11BBC74AD00234F36 /* Debug */ = {
@@ -283,6 +434,44 @@
 			};
 			name = Release;
 		};
+		DA075A761C14DAAF000140C8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		DA075A771C14DAAF000140C8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		DAA28A051C16010900DCBAB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEPLOYMENT_LOCATION = YES;
+				DSTROOT = "$(SRCROOT)/Tests/Functional/Products/";
+				INSTALL_PATH = /;
+				LD_RUNPATH_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		DAA28A061C16010900DCBAB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				DEPLOYMENT_LOCATION = YES;
+				DSTROOT = "$(SRCROOT)/Tests/Functional/Products/";
+				INSTALL_PATH = /;
+				LD_RUNPATH_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -300,6 +489,24 @@
 			buildConfigurations = (
 				5B5D86E41BBC74AD00234F36 /* Debug */,
 				5B5D86E51BBC74AD00234F36 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA075A751C14DAAF000140C8 /* Build configuration list for PBXAggregateTarget "SwiftXCTestTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA075A761C14DAAF000140C8 /* Debug */,
+				DA075A771C14DAAF000140C8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAA28A071C16010900DCBAB2 /* Build configuration list for PBXNativeTarget "SingleFailingTestCase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAA28A051C16010900DCBAB2 /* Debug */,
+				DAA28A061C16010900DCBAB2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Another attempt at #10! See the discussion on that pull request, plus the commit messages on this one, for details on the approach I'm taking. :closed_umbrella: 

As @ddunbar suggested in the comments for the last pull request, I tried using `lit` instead of a custom test runner script. Unfortunately, I think I might be doing something wrong, since I ended up adding two dependencies in the process:

1. Obviously `lit` itself, which could be installed via https://pypi.python.org/pypi/lit
2. `FileCheck`, which is included in the LLVM built products directory `bin`

It seems like nearly all of the `lit` tests in the LLVM and Swift projects use `FileCheck`. Unfortunately, it's not distributed outside of LLVM. As a result, these tests require that users have built Swift prior to running the test suite.

I also couldn't find a nice way to pass the LLVM `bin` path to the Xcode project. It now assumes that LLVM is built in a specific location relative to this project's source directory:

```sh
lit -v $SRCROOT/Tests --param native_llvm_tools_path="$SRCROOT/../build/Ninja-DebugAssert/llvm-macosx-x86_64/bin"
```

Ideally, we could just reuse the `lit.cfg` from the Swift project, which would not only get us the LLVM `bin` path, but also neat substitutions like `%target-swiftc_driver`. Those would allow us to replace the OS X-specific steps from the "adding tests" section of the README (also added in this pull request). But it turns out the Swift `lit.cfg` is very tightly coupled to the Swift build script and the environment variables it exports--it'd be a lot more work to separate those two.

I'm not really sure how to proceed, so feedback would be appreciated. I'd love to add some regression tests to this project.