### PR TITLE
[XCTestCase] Don't check equality with boolean

### DIFF
--- a/XCTest/XCTestCase.swift
+++ b/XCTest/XCTestCase.swift
@@ -58,7 +58,7 @@ extension XCTestCase {
             for failure in XCTCurrentFailures {
                 failure.emit(method)
                 totalFailures++
-                if failure.expected == false {
+                if !failure.expected {
                     unexpectedFailures++
                 }
             }


### PR DESCRIPTION
Rather than checking equality with false, this condition could be expressed more succinctly with if `!failure.expected`.