### PR TITLE
[XCTestCase] Fix missing open paren for unexpected

### DIFF
--- a/XCTest/XCTestCase.swift
+++ b/XCTest/XCTestCase.swift
@@ -73,7 +73,7 @@ extension XCTestCase {
         }
         let averageDuration = totalDuration / Double(tests.count)
         
-        print("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) \(unexpectedFailures) unexpected) in \(printableStringForTimeInterval(averageDuration)) (\(printableStringForTimeInterval(totalDuration))) seconds")
+        print("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(unexpectedFailures) unexpected) in \(printableStringForTimeInterval(averageDuration)) (\(printableStringForTimeInterval(totalDuration))) seconds")
     }
     
     // This function is for the use of XCTestCase only, but we must make it public or clients will get a link failure when using XCTest (23476006)


### PR DESCRIPTION
When executing a test case with a single failure, the following output is produced:

```
Executed 1 test, with 1 failure 0 unexpected) in 0.0 (0.0) seconds
```

Add an opening parenthesis for `0 unexpected)`, to instead output `(0 unexpected)`.