### PR TITLE
Change ++ to += 1 based on swift proposal SE-0004

### DIFF
--- a/XCTest/XCTestCase.swift
+++ b/XCTest/XCTestCase.swift
@@ -49,9 +49,9 @@ extension XCTestCase {
             totalDuration += duration
             for failure in XCTCurrentFailures {
                 failure.emit(method)
-                totalFailures++
+                totalFailures += 1
                 if !failure.expected {
-                    unexpectedFailures++
+                    unexpectedFailures += 1
                 }
             }
             var result = "passed"


### PR DESCRIPTION
This is to prevent future warning messages based on the swift-evolution proposal for Swift 3.0 submitted by @lattner for proposal: [SE-0004](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md) 