### PR TITLE
[Tests] Add functional tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ If your install of Swift is located at `/swift` and you wish to install XCTest i
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --build-dir="/tmp/XCTest_build" --swift-build-dir="/swift/usr" --library-install-path="/swift/usr/lib/swift/linux" --module-install-path="/swift/usr/lib/swift/linux/x86_64"
 ```
 
+To run the tests on Linux, pass the `--test` option in combination with options to
+install XCTest in your active version of Swift:
+
+```sh
+./build_script.py \
+    --swiftc="/swift/usr/bin/swiftc" \
+    --build-dir="/tmp/XCTest_build" \
+    --swift-build-dir="/swift/usr" \
+    --library-install-path="/swift/usr/lib/swift/linux" \
+    --module-install-path="/swift/usr/lib/swift/linux/x86_64" \
+    --test
+```
+
+To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project.
+
+You may add tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`.
+
 ### Additional Considerations for Swift on Linux
 
 When running on the Objective-C runtime, XCTest is able to find all of your tests by simply asking the runtime for the subclasses of `XCTestCase`. It then finds the methods that start with the string `test`. This functionality is not currently present when running on the Swift runtime. Therefore, you must currently provide an additional property called `allTests` in your `XCTestCase` subclass. This method lists all of the tests in the test class. The rest of your test case subclass still contains your test methods.

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -1,0 +1,28 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/SingleFailingTestCase
+// RUN: %{built_tests_dir}/SingleFailingTestCase > %{test_output} || true
+// RUN: %{xctest_checker} %{test_output} %s
+// CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
+// CHECK: .*/Tests/Functional/SingleFailingTestCase/main.swift:24: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - 
+// CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+#else
+    import SwiftXCTest
+#endif
+
+class SingleFailingTestCase: XCTestCase {
+    var allTests: [(String, () -> ())] {
+        return [
+            ("test_fails", test_fails),
+        ]
+    }
+
+    func test_fails() {
+        XCTAssert(false)
+    }
+}
+
+XCTMain([SingleFailingTestCase()])

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -1,0 +1,73 @@
+import os
+import platform
+import tempfile
+
+import lit
+
+# Set up lit config.
+config.name = 'SwiftXCTestFunctionalTests'
+config.test_format = lit.formats.ShTest(execute_external=False)
+config.suffixes = ['.swift']
+
+# Set up the substitutions used by the functional test suite.
+
+# First, our tests need a way to compile source files into
+# executables that are linked against swift-corelibs-xctest.
+# We'll provide one via the %swiftc substitution.
+#
+# Linux tests are run after swift-corelibs-xctest is installed
+# in the Swift library path, so we only need the path to `swiftc`
+# in order to compile.
+def _getenv(name):
+    value = os.getenv(name, None)
+    if value is None:
+        lit_config.fatal(
+            'Environment variable ${} is not set.\n'
+            '$SWIFT_EXEC, $SDKROOT, $BUILT_PRODUCTS_DIR, $PLATFORM_NAME, and '
+            '$MACOSX_DEPLOYMENT_TARGET must all be set for lit tests to '
+            'run.'.format(name))
+    return value
+
+swift_exec = [_getenv('SWIFT_EXEC')]
+
+if platform.system() == 'Darwin':
+    # On OS X, we need to make sure swiftc references the
+    # proper SDK, has a deployment target set, and more...
+    # Here we rely on environment variables, produced by xcodebuild.
+    sdk_root = _getenv('SDKROOT')
+    built_products_dir = _getenv('BUILT_PRODUCTS_DIR')
+    platform_name = _getenv('PLATFORM_NAME')
+    deployment_target = _getenv('MACOSX_DEPLOYMENT_TARGET')
+
+    target = '{}-apple-{}{}'.format(
+        platform.machine(), platform_name, deployment_target)
+    swift_exec.extend([
+        '-sdk', sdk_root,
+        '-target', target,
+        '-L', built_products_dir,
+        '-I', built_products_dir,
+        '-F', built_products_dir,
+        '-Xlinker', '-rpath',
+        '-Xlinker', built_products_dir])
+
+# Having prepared the swiftc command, we set the substitution.
+config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))
+
+# Add the %built_tests_dir substitution, which is a temporary
+# directory used to store built files.
+built_tests_dir = tempfile.mkdtemp()
+config.substitutions.append(('%{built_tests_dir}', built_tests_dir))
+
+# Add the %test_output substitution, which is a temporary file
+# used to store test output.
+test_output = tempfile.mkstemp()[1]
+config.substitutions.append(('%{test_output}', test_output))
+
+# Add the %xctest_checker substitution, which is a Python script
+# can be used to compare the actual XCTest output to the expected
+# output.
+xctest_checker = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'xctest_checker',
+    'xctest_checker.py')
+config.substitutions.append(('%{xctest_checker}', xctest_checker))

--- a/Tests/Functional/xctest_checker/.gitignore
+++ b/Tests/Functional/xctest_checker/.gitignore
@@ -1,0 +1,26 @@
+# Compile artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution/packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt

--- a/Tests/Functional/xctest_checker/setup.py
+++ b/Tests/Functional/xctest_checker/setup.py
@@ -1,0 +1,43 @@
+import os
+import setuptools
+
+import xctest_checker
+
+# setuptools expects to be invoked from within the directory of setup.py,
+# but it is nice to allow `python path/to/setup.py install` to work
+# (for scripts, etc.)
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+setuptools.setup(
+    name='xctest_checker',
+    version=xctest_checker.__version__,
+
+    author=xctest_checker.__author__,
+    author_email=xctest_checker.__email__,
+    url='http://swift.org',
+    license='Apache',
+
+    description="A tool to verify the output of XCTest runs.",
+    keywords='test xctest swift',
+
+    test_suite='tests',
+
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Software Development :: Testing',
+    ],
+
+    zip_safe=False,
+    packages=setuptools.find_packages(),
+    entry_points={
+        'console_scripts': [
+            'xctest_checker = xctest_checker:main',
+        ],
+    }
+)

--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -1,0 +1,41 @@
+import tempfile
+import unittest
+
+from xctest_checker import compare
+
+
+def _tmpfile(content):
+    """Returns the path to a temp file with the given contents."""
+    tmp = tempfile.mkstemp()[1]
+    with open(tmp, 'w') as f:
+        f.write(content)
+    return tmp
+
+
+class CompareTestCase(unittest.TestCase):
+    def test_no_match_raises(self):
+        actual = _tmpfile('foo\nbar\nbaz\n')
+        expected = _tmpfile('c: foo\nc: baz\nc: bar\n')
+        with self.assertRaises(AssertionError):
+            compare.compare(actual, expected, check_prefix='c: ')
+
+    def test_too_few_expected_raises(self):
+        actual = _tmpfile('foo\nbar\nbaz\n')
+        expected = _tmpfile('c: foo\nc: bar\n')
+        with self.assertRaises(AssertionError):
+            compare.compare(actual, expected, check_prefix='c: ')
+
+    def test_too_many_expected_raises(self):
+        actual = _tmpfile('foo\nbar\n')
+        expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
+        with self.assertRaises(AssertionError):
+            compare.compare(actual, expected, check_prefix='c: ')
+
+    def test_match_does_not_raise(self):
+        actual = _tmpfile('foo\nbar\nbaz\n')
+        expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
+        compare.compare(actual, expected, check_prefix='c: ')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/Functional/xctest_checker/xctest_checker.py
+++ b/Tests/Functional/xctest_checker/xctest_checker.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import xctest_checker
+
+if __name__ == '__main__':
+    xctest_checker.main()

--- a/Tests/Functional/xctest_checker/xctest_checker/__init__.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+from .main import main
+
+__author__ = 'Brian Gesiak'
+__email__ = 'modocache@gmail.com'
+__versioninfo__ = (0, 1, 0)
+__version__ = '.'.join(str(v) for v in __versioninfo__)
+
+__all__ = []

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -1,0 +1,46 @@
+import re
+
+
+def _actual_lines(path):
+    """
+    Returns a generator that yields each line in the file at the given path.
+    """
+    with open(path) as f:
+        for line in f:
+            yield line
+
+
+def _expected_lines(path, check_prefix):
+    """
+    Returns a generator that yields each line in the file at the given path
+    that begins with the given prefix.
+    """
+    with open(path) as f:
+        for line in f:
+            if line.startswith(check_prefix):
+                yield line[len(check_prefix):]
+
+
+def compare(actual, expected, check_prefix):
+    """
+    Compares each line in the two given files.
+    If any line in the 'actual' file doesn't match the regex in the 'expected'
+    file, raises an AssertionError. Also raises an AssertionError if the number
+    of lines in the two files differ.
+    """
+    for actual_line, expected_line in map(
+            None,
+            _actual_lines(actual),
+            _expected_lines(expected, check_prefix)):
+        if actual_line is None:
+            raise AssertionError('There were more lines expected to appear '
+                                 'than there were lines in the actual input.')
+        if expected_line is None:
+            raise AssertionError('There were more lines than expected to '
+                                 'appear.')
+        if not re.match(expected_line, actual_line):
+            raise AssertionError('Actual line did not match the expected '
+                                 'regular expression.\n'
+                                 'Actual: {}\n'
+                                 'Expected: {}\n'.format(
+                                     repr(actual_line), repr(expected_line)))

--- a/Tests/Functional/xctest_checker/xctest_checker/main.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/main.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+
+import argparse
+
+from . import compare
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('actual', help='A path to a file containing the '
+                                       'actual output of an XCTest run.')
+    parser.add_argument('expected', help='A path to a file containing the '
+                                         'expected output of an XCTest run.')
+    parser.add_argument('-p', '--check-prefix',
+                        default='// CHECK: ',
+                        help='{prog} checks actual output against expected '
+                             'output. By default, {prog} only checks lines '
+                             'that are prefixed with "// CHECK: ". This '
+                             'option can be used to change that '
+                             'prefix.'.format(prog=parser.prog))
+    args = parser.parse_args()
+    compare.compare(args.actual, args.expected, args.check_prefix)
+
+
+if __name__ == '__main__':
+    main()

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -14,6 +14,16 @@
 		C265F6731C3AEB6A00520CF9 /* XCTimeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		DAA333B91C267AF3000CC115 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D86DA1BBC74AD00234F36;
+			remoteInfo = SwiftXCTest;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1384A411C1B3E8700EDF031 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
@@ -24,6 +34,16 @@
 		C265F66B1C3AEB6A00520CF9 /* XCTestCaseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseProvider.swift; sourceTree = "<group>"; };
 		C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestMain.swift; sourceTree = "<group>"; };
 		C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTimeUtilities.swift; sourceTree = "<group>"; };
+		DA78F7E91C4039410082E15B /* lit.cfg */ = {isa = PBXFileReference; lastKnownFileType = text; path = lit.cfg; sourceTree = "<group>"; };
+		DA78F7EB1C4039410082E15B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		DA78F7EE1C4039410082E15B /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		DA78F7EF1C4039410082E15B /* setup.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = setup.py; sourceTree = "<group>"; };
+		DA78F7F11C4039410082E15B /* __init__.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		DA78F7F21C4039410082E15B /* test_compare.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = test_compare.py; sourceTree = "<group>"; };
+		DA78F7F41C4039410082E15B /* __init__.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		DA78F7F61C4039410082E15B /* compare.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = compare.py; sourceTree = "<group>"; };
+		DA78F7F81C4039410082E15B /* main.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = main.py; sourceTree = "<group>"; };
+		DA78F7FA1C4039410082E15B /* xctest_checker.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = xctest_checker.py; sourceTree = "<group>"; };
 		EA3E74BB1BF2B6D500635A73 /* build_script.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = build_script.py; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -42,6 +62,7 @@
 			isa = PBXGroup;
 			children = (
 				C265F6661C3AEB6A00520CF9 /* Sources */,
+				DA78F7E71C4039410082E15B /* Tests */,
 				5B5D86DC1BBC74AD00234F36 /* Products */,
 				EA3E74BC1BF2B6D700635A73 /* Linux Build */,
 				B1384A401C1B3E6A00EDF031 /* Documentation */,
@@ -88,6 +109,63 @@
 			path = XCTest;
 			sourceTree = "<group>";
 		};
+		DA78F7E71C4039410082E15B /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				DA78F7E81C4039410082E15B /* Functional */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		DA78F7E81C4039410082E15B /* Functional */ = {
+			isa = PBXGroup;
+			children = (
+				DA78F7E91C4039410082E15B /* lit.cfg */,
+				DA78F7EA1C4039410082E15B /* SingleFailingTestCase */,
+				DA78F7ED1C4039410082E15B /* xctest_checker */,
+			);
+			path = Functional;
+			sourceTree = "<group>";
+		};
+		DA78F7EA1C4039410082E15B /* SingleFailingTestCase */ = {
+			isa = PBXGroup;
+			children = (
+				DA78F7EB1C4039410082E15B /* main.swift */,
+			);
+			path = SingleFailingTestCase;
+			sourceTree = "<group>";
+		};
+		DA78F7ED1C4039410082E15B /* xctest_checker */ = {
+			isa = PBXGroup;
+			children = (
+				DA78F7EE1C4039410082E15B /* .gitignore */,
+				DA78F7EF1C4039410082E15B /* setup.py */,
+				DA78F7F01C4039410082E15B /* tests */,
+				DA78F7F31C4039410082E15B /* xctest_checker */,
+				DA78F7FA1C4039410082E15B /* xctest_checker.py */,
+			);
+			path = xctest_checker;
+			sourceTree = "<group>";
+		};
+		DA78F7F01C4039410082E15B /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				DA78F7F11C4039410082E15B /* __init__.py */,
+				DA78F7F21C4039410082E15B /* test_compare.py */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		DA78F7F31C4039410082E15B /* xctest_checker */ = {
+			isa = PBXGroup;
+			children = (
+				DA78F7F41C4039410082E15B /* __init__.py */,
+				DA78F7F61C4039410082E15B /* compare.py */,
+				DA78F7F81C4039410082E15B /* main.py */,
+			);
+			path = xctest_checker;
+			sourceTree = "<group>";
+		};
 		EA3E74BC1BF2B6D700635A73 /* Linux Build */ = {
 			isa = PBXGroup;
 			children = (
@@ -107,6 +185,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
+
+/* Begin PBXLegacyTarget section */
+		DAA333B51C267AD6000CC115 /* SwiftXCTestFunctionalTests */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-q Tests/Functional";
+			buildConfigurationList = DAA333B81C267AD6000CC115 /* Build configuration list for PBXLegacyTarget "SwiftXCTestFunctionalTests" */;
+			buildPhases = (
+			);
+			buildToolPath = "$(SRCROOT)/../llvm/utils/lit/lit.py";
+			buildWorkingDirectory = "";
+			dependencies = (
+				DAA333BA1C267AF3000CC115 /* PBXTargetDependency */,
+			);
+			name = SwiftXCTestFunctionalTests;
+			passBuildSettingsInEnvironment = 1;
+			productName = SwiftXCTestFunctionalTests;
+		};
+/* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
 		5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */ = {
@@ -140,6 +236,9 @@
 					5B5D86DA1BBC74AD00234F36 = {
 						CreatedOnToolsVersion = 7.1;
 					};
+					DAA333B51C267AD6000CC115 = {
+						CreatedOnToolsVersion = 7.2;
+					};
 				};
 			};
 			buildConfigurationList = 5B5D86D51BBC74AD00234F36 /* Build configuration list for PBXProject "XCTest" */;
@@ -156,6 +255,7 @@
 			projectRoot = "";
 			targets = (
 				5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */,
+				DAA333B51C267AD6000CC115 /* SwiftXCTestFunctionalTests */,
 			);
 		};
 /* End PBXProject section */
@@ -184,6 +284,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DAA333BA1C267AF3000CC115 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */;
+			targetProxy = DAA333B91C267AF3000CC115 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		5B5D86E11BBC74AD00234F36 /* Debug */ = {
@@ -309,6 +417,31 @@
 			};
 			name = Release;
 		};
+		DAA333B61C267AD6000CC115 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUGGING_SYMBOLS = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EXEC = "$(TOOLCHAIN_DIR)/usr/bin/swiftc";
+			};
+			name = Debug;
+		};
+		DAA333B71C267AD6000CC115 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EXEC = "$(TOOLCHAIN_DIR)/usr/bin/swiftc";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -326,6 +459,15 @@
 			buildConfigurations = (
 				5B5D86E41BBC74AD00234F36 /* Debug */,
 				5B5D86E51BBC74AD00234F36 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DAA333B81C267AD6000CC115 /* Build configuration list for PBXLegacyTarget "SwiftXCTestFunctionalTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DAA333B61C267AD6000CC115 /* Debug */,
+				DAA333B71C267AD6000CC115 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
## What's in this pull request?

Yet another attempt at #10, this pull request adds functional tests that verify the output of programs that use XCTest. This pull request is based off of the discussion on #14, and uses `lit` as a test runner.

A developer can kick off the tests by either running `build_script.py --test` or by building and running the `SwiftXCTestFunctionalTests` Xcode target.

Here's a breakdown of what happens when a user kicks off the tests:

1. `../llvm/utils/lit/lit.py Tests/Functional` is run, which kicks off the configuration in `Tests/Functional/lit.cfg`.
2. `lit.cfg` uses environment variables to provide substitutions, such as `%swiftc`, to the tests. On Linux, these environment variables are set as part of `build_script.py`. On OS X, these environment variables are provided by `xcodebuild`.
3. `lit` finds every Swift source file that contains a `RUN:` command and executes those commands.
4. The `RUN:` commands in `SingleFailingTestCase/main.swift` compiles the source into an executable in a temporary directory, runs that executable, and checks the output. Output verification is done via `xctest_checker`, a Python script.
5. The checker raises an exception and produces a failing exit code for the test runner if any tests fail.

## Why merge this pull request?

- It adds a functional test suite to this project. These tests will allow us to prevent regressions and verify the behavior of XCTest. For example, I noticed the typo in #18 as a result of functional testing.
- Adding tests is as easy as adding a single file: `Tests/Functional/MyNewTest/main.swift`. Unlike #10 and #14, new tests don't need to be configured in the Xcode project to work.

## What downsides are there to merging this pull request?

- The test runner, because it uses `lit`, is dependent upon the `llvm` codebase being installed in `../llvm`. Alternatively, it could check for `pip` or `easy_install` being installed on the host system, and if available use them to install https://pypi.python.org/pypi/lit. Either way, the test suite is not completely independent: it relies on either `llvm` being cloned ahead of time, or on an Internet connection to install `lit` from the Python Package Index.
- The test runner in #10 could verify the exit code of the program. `lit` is unable to do so. The tests verify the output, but not whether the exit code emitted by XCTest indicated a failure. @ddunbar, is it possible to test this using `lit`?
- Functional tests only test the system as a whole. Ideally, these would be complemented with a unit test suite that could verify the behavior of smaller components in XCTest. I'd certainly like to pursue this idea in the future, but I think these tests are beneficial in their own way. They're not meant to be the only tests for this project.