### PR TITLE
Prevent div-by-0 when producing test execution summary

### DIFF
--- a/XCTest/XCTestCase.swift
+++ b/XCTest/XCTestCase.swift
@@ -71,7 +71,7 @@ extension XCTestCase {
         if totalFailures == 1 {
             failureSuffix = ""
         }
-        let averageDuration = totalDuration / Double(tests.count)
+        let averageDuration = totalDuration / Double(max(tests.count, 1))
         
         print("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(unexpectedFailures) unexpected) in \(printableStringForTimeInterval(averageDuration)) (\(printableStringForTimeInterval(totalDuration))) seconds")
     }

--- a/XCTest/XCTestMain.swift
+++ b/XCTest/XCTestMain.swift
@@ -57,7 +57,7 @@ internal struct XCTRun {
     if totalFailures == 1 {
         failureSuffix = ""
     }
-    let averageDuration = totalDuration / Double(XCTAllRuns.count)
+    let averageDuration = totalDuration / Double(max(XCTAllRuns.count, 1))
     print("Total executed \(XCTAllRuns.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(totalUnexpectedFailures) unexpected) in \(printableStringForTimeInterval(averageDuration)) (\(printableStringForTimeInterval(totalDuration))) seconds")
     exit(totalFailures > 0 ? 1 : 0)
 }


### PR DESCRIPTION
This is a fix for [SR-334](https://bugs.swift.org/browse/SR-334), in which a `NaN` value would appear in the final summary line at the end of test execution:

```
Total executed 0 tests, with 0 failures (0 unexpected) in -nan (0.0) seconds
```
This is a simple fix for the issue, but I have greater doubts about the calculation of the time values that are being printed. The current code prints `... in {average test duration} ({total test duration}) seconds`, however the two figures printed by the original XCTest seem to be something closer to `... in {total time spent executing tests} ({total elapsed time since XCTest began running}) seconds`, or similar. Does anyone have more insight into what XCTest provides here?

@modocache 