### PR TITLE
Print additional details when emitting assertion failure messages

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -76,11 +76,11 @@ extension XCTestCase {
     }
     
     // This function is for the use of XCTestCase only, but we must make it public or clients will get a link failure when using XCTest (23476006)
-    public func testFailure(message: String, expected: Bool, file: StaticString , line: UInt) {
+    public func testFailure(message: String, failureDescription: String, expected: Bool, file: StaticString, line: UInt) {
         if !continueAfterFailure {
             assert(false, message, file: file, line: line)
         } else {
-            XCTCurrentFailures.append(XCTFailure(message: message, expected: expected, file: file, line: line))
+            XCTCurrentFailures.append(XCTFailure(message: message, failureDescription: failureDescription, expected: expected, file: file, line: line))
         }
     }
     

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -20,12 +20,13 @@ import Darwin
 
 struct XCTFailure {
     var message: String
+    var failureDescription: String
     var expected: Bool
     var file: StaticString
     var line: UInt
     
     func emit(method: String) {
-        print("\(file):\(line): \(expected ? "" : "unexpected ")error: \(method) : \(message)")
+        print("\(file):\(line): \(expected ? "" : "unexpected ")error: \(method) : \(failureDescription) - \(message)")
     }
 }
 


### PR DESCRIPTION
This brings the output in line with what Darwin's XCTest outputs

Take a failing assertion like:
```swift
func testAssertEqual() {
    XCTAssertEqual(1, 2, "message", file: "test.swift")
}
```
The **current behavior** of `swift-corelibs-xctest` is to produce a failure message like:
```
test.swift:36: error: Test.testAssertEqual : message
```
**Darwin's XCTest** produces:
```
test.swift:36: error: -[Test.Test testAssertEqual] : XCTAssertEqual failed: ("Optional(1)") is not equal to ("Optional(2)") - message
```
**After this patch**, the output from `swift-corelibs-xctest` would be:
```
test.swift:36: error: Test.testAssertEqual : XCTAssertEqual failed: ("Optional(1)") is not equal to ("Optional(2)") - message
```

Note that this now includes the name of the failing assertion function and includes details about the asserted expressions when appropriate.

This change just screams for test coverage, but I guess that will have to wait until #20 or similar gets merged. In the meantime, though, [here](https://gist.github.com/briancroom/fd6029ad29a429596a9a) is a test fixture that I wrote while working on this, and have been using to manually verify the new behavior.