### PR TITLE
Adjust duration output from the execution summary lines

### DIFF
--- a/XCTest/XCTestMain.swift
+++ b/XCTest/XCTestMain.swift
@@ -30,7 +30,7 @@ struct XCTFailure {
 }
 
 internal struct XCTRun {
-    var duration: Double
+    var duration: TimeInterval
     var method: String
     var passed: Bool
     var failures: [XCTFailure]
@@ -44,9 +44,12 @@ internal struct XCTRun {
 /// This function will not return. If the test cases pass, then it will call `exit(0)`. If there is a failure, then it will call `exit(1)`.
 /// - Parameter testCases: An array of test cases to run.
 @noreturn public func XCTMain(testCases: [XCTestCase]) {
-    for testCase in testCases {
-        testCase.invokeTest()
+    let overallDuration = measureTimeExecutingBlock {
+        for testCase in testCases {
+            testCase.invokeTest()
+        }
     }
+
     let (totalDuration, totalFailures, totalUnexpectedFailures) = XCTAllRuns.reduce((0.0, 0, 0)) { totals, run in (totals.0 + run.duration, totals.1 + run.failures.count, totals.2 + run.unexpectedFailures.count) }
     
     var testCountSuffix = "s"
@@ -57,8 +60,8 @@ internal struct XCTRun {
     if totalFailures == 1 {
         failureSuffix = ""
     }
-    let averageDuration = totalDuration / Double(XCTAllRuns.count)
-    print("Total executed \(XCTAllRuns.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(totalUnexpectedFailures) unexpected) in \(printableStringForTimeInterval(averageDuration)) (\(printableStringForTimeInterval(totalDuration))) seconds")
+
+    print("Total executed \(XCTAllRuns.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(totalUnexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
     exit(totalFailures > 0 ? 1 : 0)
 }
 

--- a/XCTest/XCTimeUtilities.swift
+++ b/XCTest/XCTimeUtilities.swift
@@ -17,18 +17,28 @@
     import Darwin
 #endif
 
+internal typealias TimeInterval = Double
+
 /// Returns the number of seconds since the reference time as a Double.
-internal func currentTimeIntervalSinceReferenceTime() -> Double {
+private func currentTimeIntervalSinceReferenceTime() -> TimeInterval {
     var tv = timeval()
-    let currentTime = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> Double in
+    let currentTime = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> TimeInterval in
         gettimeofday(t, nil)
-        return Double(t.memory.tv_sec) + Double(t.memory.tv_usec) / 1000000.0
+        return TimeInterval(t.memory.tv_sec) + TimeInterval(t.memory.tv_usec) / 1000000.0
     })
     return currentTime
 }
 
-/// Returns a string version of the given time interval rounded to no more than 3 decimal places.
-internal func printableStringForTimeInterval(timeInterval: Double) -> String {
-    return String(round(timeInterval * 1000.0) / 1000.0)
+/// Execute the given block and return the time spent during execution
+internal func measureTimeExecutingBlock(@noescape block: () -> Void) -> TimeInterval {
+    let start = currentTimeIntervalSinceReferenceTime()
+    block()
+    let end = currentTimeIntervalSinceReferenceTime()
+
+    return end - start
 }
 
+/// Returns a string version of the given time interval rounded to no more than 3 decimal places.
+internal func printableStringForTimeInterval(timeInterval: TimeInterval) -> String {
+    return String(round(timeInterval * 1000.0) / 1000.0)
+}


### PR DESCRIPTION
Instead of outputting the average and summed execution time for each test
run, output the summed execution time of each test run and the total
elapsed time between the beginning and end of the test case's execution.
The new output follows the behavior of Darwin's XCTest framework.

Old behavior example excerpt:
```
Executed 22 tests, with 22 failures (0 unexpected) in 0.091 (2.008) seconds
Total executed 22 tests, with 22 failures (0 unexpected) in 0.091 (2.008) seconds
```
New behavior example excerpt (matching Darwin XCTest):
```
Executed 22 tests, with 22 failures (0 unexpected) in 2.006 (2.015) seconds
Total executed 22 tests, with 22 failures (0 unexpected) in 2.006 (2.016) seconds
```

Other implementation changes:
* Add a typealias `TimeInterval` for `Double` to increase explicitness
* Factor out a helper for measuring the time it takes to execute a piece of code

If this PR is accepted, it makes #21 obsolete, and also resolves [SR-334](https://bugs.swift.org/browse/SR-334).