### PR TITLE
AddsSetUp and tearDown to the XCTestCase protocol.

### DIFF
--- a/XCTest/XCTestCase.swift
+++ b/XCTest/XCTestCase.swift
@@ -12,7 +12,8 @@
 //
 
 public protocol XCTestCase : XCTestCaseProvider {
-    
+    func setUp()
+    func tearDown()
 }
 
 extension XCTestCase {


### PR DESCRIPTION
The XCTestCase invokeTest method calls setUp and tearDown before and after the test case, but these calls are statically bound to the empty versions of setUp and tearDown provided by XCTestCase. If a real test case provides its own setUp and tearDown methods, they don't get called automatically. Adding them to the protocol should change this to a dynamic invocation and call the verisons provided by the real test case, which seems to be the intention behind calling them in the first place.