### PR TITLE
Don't assume python is in /usr/bin. Use 'env' instead.

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This source file is part of the Swift.org open source project
 #


### PR DESCRIPTION
This fixes build on FreeBSD (where python is installed in
/usr/local by default), and in general improves portability.