### PR TITLE
[Tests] Use %t for test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 xcuserdata
 .build/
+Output/

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -1,6 +1,6 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/SingleFailingTestCase
-// RUN: %{built_tests_dir}/SingleFailingTestCase > %{test_output} || true
-// RUN: %{xctest_checker} %{test_output} %s
+// RUN: %{built_tests_dir}/SingleFailingTestCase > %t || true
+// RUN: %{xctest_checker} %t %s
 // CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
 // CHECK: .*/Tests/Functional/SingleFailingTestCase/main.swift:24: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - 
 // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -58,11 +58,6 @@ config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))
 built_tests_dir = tempfile.mkdtemp()
 config.substitutions.append(('%{built_tests_dir}', built_tests_dir))
 
-# Add the %test_output substitution, which is a temporary file
-# used to store test output.
-test_output = tempfile.mkstemp()[1]
-config.substitutions.append(('%{test_output}', test_output))
-
 # Add the %xctest_checker substitution, which is a Python script
 # can be used to compare the actual XCTest output to the expected
 # output.


### PR DESCRIPTION
Addresses a suggestion by @ddunbar in #20, to use `lit`'s built-in `%t`
substitution for temporary test output. To prevent output from being
checked in to source control, add `Output` to the `.gitignore`.