### PR TITLE
Refactor to rely less on global state for failure reporting

### DIFF
--- a/Sources/XCTest/XCTAssert.swift
+++ b/Sources/XCTest/XCTAssert.swift
@@ -84,8 +84,8 @@ private enum _XCTAssertion {
 
 private func _XCTAssert(@autoclosure expression: () -> BooleanType, @autoclosure assertion: () -> _XCTAssertion, @autoclosure _ message: () -> String, file: StaticString, line: UInt) {
     if !expression().boolValue {
-        if let test = XCTCurrentTestCase {
-            test.testFailure(message(), failureDescription: assertion().failureDescription, expected: true, file: file, line: line)
+        if let handler = XCTFailureHandler {
+            handler(XCTFailure(message: message(), failureDescription: assertion().failureDescription, expected: true, file: file, line: line))
         }
     }
 }

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -66,7 +66,5 @@ internal struct XCTRun {
     exit(totalFailures > 0 ? 1 : 0)
 }
 
-internal var XCTCurrentTestCase: XCTestCase?
-internal var XCTCurrentFailures = [XCTFailure]()
+internal var XCTFailureHandler: (XCTFailure -> Void)?
 internal var XCTAllRuns = [XCTRun]()
-


### PR DESCRIPTION
* Also allows removing a weird public method from XCTestCase

This was originally a piece of #27 but it makes sense to apply standalone.