### PR TITLE
Osx build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ install XCTest in your active version of Swift:
     --test
 ```
 
-To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project.
+Building and installing on OSX:
+
+```sh
+sudo ./build_script.py \
+    --swiftc="/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swiftc" \
+    --build-dir="/tmp/XCTest_build" \
+    --swift-build-dir="/Library/Developer/Toolchains/swift-latest.xctoolchain/usr" \
+    --library-install-path="/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib/swift/macosx" \
+    --module-install-path="/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib/swift/macosx/x86_64"
+```
+
+To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project, the `--test` parameter for the build script will not work.
 
 You may add tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`.
 

--- a/build_script.py
+++ b/build_script.py
@@ -112,7 +112,6 @@ def main():
     if platform.system() == "Darwin":
         sdkpath_cmd = shlex.split("xcrun --show-sdk-path --sdk macosx")
         sdk, err = subprocess.Popen(sdkpath_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-        print sdk
         run("{swiftc} -sdk {sdkpath} -c {style_options} -emit-object {obj} -module-name XCTest -parse-as-library -emit-module "
             "-emit-module-path {build_dir}/XCTest.swiftmodule -o {build_dir}/XCTest.o -force-single-frontend-invocation "
             "-module-link-name XCTest".format(


### PR DESCRIPTION
This adds OSX support to the `build_script.py` to allow using the same tests on OSX as on Linux.

Added paragraph to Readme with build instructions on OSX.

`--test` won't work on OSX currently, use the Xcode test target for testing on OSX