### PR TITLE
[xcodeproj] Share test scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ install XCTest in your active version of Swift:
     --test
 ```
 
-To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project.
+To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project. You may also run them via the command line:
+
+```
+xcodebuild -project XCTest.xcodeproj -scheme SwiftXCTestFunctionalTests
+```
 
 You may add tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`.
 

--- a/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestFunctionalTests.xcscheme
+++ b/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestFunctionalTests.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAA333B51C267AD6000CC115"
+               BuildableName = "SwiftXCTestFunctionalTests"
+               BlueprintName = "SwiftXCTestFunctionalTests"
+               ReferencedContainer = "container:XCTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAA333B51C267AD6000CC115"
+            BuildableName = "SwiftXCTestFunctionalTests"
+            BlueprintName = "SwiftXCTestFunctionalTests"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAA333B51C267AD6000CC115"
+            BuildableName = "SwiftXCTestFunctionalTests"
+            BlueprintName = "SwiftXCTestFunctionalTests"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
- Allow the `SwiftXCTestFunctionalTests` scheme to be run from the
  command-line, by marking it as a "shared" scheme in Xcode.
- Add instructions on how to run the tests via the command line to the
  README.

Allowing the tests to be run via the command-line on all platforms is
necessary for integrating swift-corelibs-xctest tests into the greater
Swift test suite.
(See: https://github.com/apple/swift/blob/162becc91e1eab9118a17c34f994e79d5983819f/utils/build-script-impl#L1968-L1974)