### PR TITLE
[xcodeproj] Better lit output

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -219,7 +219,7 @@
 /* Begin PBXLegacyTarget section */
 		DAA333B51C267AD6000CC115 /* SwiftXCTestFunctionalTests */ = {
 			isa = PBXLegacyTarget;
-			buildArgumentsString = "-q Tests/Functional";
+			buildArgumentsString = "-sv --no-progress-bar Tests/Functional";
 			buildConfigurationList = DAA333B81C267AD6000CC115 /* Build configuration list for PBXLegacyTarget "SwiftXCTestFunctionalTests" */;
 			buildPhases = (
 			);

--- a/build_script.py
+++ b/build_script.py
@@ -139,9 +139,13 @@ def main():
         if args.test:
             lit_path = os.path.join(
                 os.path.dirname(SOURCE_DIR), 'llvm', 'utils', 'lit', 'lit.py')
+            lit_flags = '-sv --no-progress-bar'
             tests_path = os.path.join(SOURCE_DIR, 'Tests', 'Functional')
-            run('SWIFT_EXEC={swiftc} {lit_path} {tests_path}'.format(
-                swiftc=swiftc, lit_path=lit_path, tests_path=tests_path))
+            run('SWIFT_EXEC={swiftc} {lit_path} {lit_flags} '
+                '{tests_path}'.format(swiftc=swiftc,
+                                      lit_path=lit_path,
+                                      lit_flags=lit_flags,
+                                      tests_path=tests_path))
 
     note('Done.')
 


### PR DESCRIPTION
Because Xcode treats the default lit output as error, simply running
`lit Tests/Functional` causes build failures in Xcode. For this reason,
the script was run with the `-q` quiet parameter. However, this made it
difficult to understand why a test failed.

This commit borrows a page from LLVM (see: https://github.com/apple/swift-llvm/blob/3ebdbb2c7e5ce577363994fd0aa0f8409bc68490/CMakeLists.txt#L329-L332)
and uses `-s` (summarize results), `-v` (verbose), and
`--no-progress-bar`. This combination emits diagnostics that are not
treated as errors by Xcode, *and* they provide a great deal of detail
when tests fail--the best of both worlds!