### PR TITLE
[XCTestCase] Fix total number of tests output

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -63,12 +63,11 @@ extension XCTestCase {
                     if !failure.expected {
                         unexpectedFailures += 1
                     }
-
                     result = failures.count > 0 ? "failed" : "passed"
-                    XCTAllRuns.append(XCTRun(duration: duration, method: method, passed: failures.count == 0, failures: failures))
                 }
 
                 print("Test Case '\(method)' \(result) (\(printableStringForTimeInterval(duration)) seconds).")
+                XCTAllRuns.append(XCTRun(duration: duration, method: method, passed: failures.count == 0, failures: failures))
                 XCTFailureHandler = nil
             }
         }

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -13,7 +13,7 @@
 // CHECK: .*/Tests/Functional/FailingTestSuite/main.swift:54: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
 // CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
 // CHECK: Executed 3 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Total executed 2 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 #if os(Linux) || os(FreeBSD)
     import XCTest


### PR DESCRIPTION
https://github.com/apple/swift-corelibs-xctest/pull/33 introduced another regression that was not fixed in 4944003d: the total number of test runs was not being reported correctly--only the total number of failures.

Fix the misreporting, as well as the incorrect verification in the `FailingTestSuite` functional test.

---

Sorry for not catching this sooner--I only noticed the problem when rebasing #32, and realizing the output still wasn't what I expected.