### PR TITLE
Asynchronous testing API [AsyncXCTest 6/6]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ The rest of this document will focus on how this version of XCTest differs from 
 
 ## Working on XCTest
 
+### On Linux
+
 XCTest can be built as part of the overall Swift package. When following [the instructions for building Swift](http://www.github.com/apple/swift), pass the `--xctest` option to the build script:
 
 ```sh
 swift/utils/build-script --xctest
 ```
 
-If you want to build just XCTest, use the `build_script.py` script at the root of the project. The `master` version of XCTest must be built with the `master` version of Swift.
+If you want to build just XCTest, use the `build_script.py` script at the root of the project. The `master` version of XCTest must be built with the `master` version of Swift. XCTest has a dependency upon Foundation, so you must have built the `master` version of that as well.
 
 If your install of Swift is located at `/swift` and you wish to install XCTest into that same location, here is a sample invocation of the build script:
 
@@ -38,6 +40,7 @@ If your install of Swift is located at `/swift` and you wish to install XCTest i
 ./build_script.py \
     --swiftc="/swift/usr/bin/swiftc" \
     --build-dir="/tmp/XCTest_build" \
+    --foundation-build-dir "/swift//usr/lib/swift/linux" \
     --library-install-path="/swift/usr/lib/swift/linux" \
     --module-install-path="/swift/usr/lib/swift/linux/x86_64"
 ```
@@ -45,8 +48,26 @@ If your install of Swift is located at `/swift` and you wish to install XCTest i
 To run the tests on Linux, use the `--test` option:
 
 ```sh
-./build_script.py --swiftc="/swift/usr/bin/swiftc" --test
+./build_script.py \
+    --swiftc="/swift/usr/bin/swiftc" \
+    --foundation-build-dir "/swift/usr/lib/swift/linux" \
+    --test
 ```
+
+You may add tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`.
+
+### On OS X
+
+You may build XCTest via the "SwiftXCTest" scheme in `XCTest.xcworkspace`. The workspace assumes that Foundation and XCTest are checked out from GitHub in sibling directories. For example:
+
+```
+% cd Development
+% ls
+swift-corelibs-foundation swift-corelibs-xctest
+%
+```
+
+Unlike on Linux, you do not need to build Foundation prior to building XCTest. The "SwiftXCTest" Xcode scheme takes care of that for you.
 
 To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode workspace. You may also run them via the command line:
 
@@ -54,7 +75,7 @@ To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target 
 xcodebuild -workspace XCTest.xcworkspace -scheme SwiftXCTestFunctionalTests
 ```
 
-You may add tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`.
+When adding tests to the `Tests/Functional` directory, make sure they can be opened in the `XCTest.xcworkspace` by adding references to them, but do not add them to any of the targets.
 
 ### Additional Considerations for Swift on Linux
 

--- a/Sources/XCTest/XCTestExpectation.swift
+++ b/Sources/XCTest/XCTestExpectation.swift
@@ -1,0 +1,71 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestExpectation.swift
+//  Expectations represent specific conditions in asynchronous testing.
+//
+
+/// Expectations represent specific conditions in asynchronous testing.
+public class XCTestExpectation {
+    internal let description: String
+    internal let file: StaticString
+    internal let line: UInt
+
+    internal var fulfilled = false
+    internal weak var testCase: XCTestCase?
+
+    internal init(description: String, file: StaticString, line: UInt, testCase: XCTestCase) {
+        self.description = description
+        self.file = file
+        self.line = line
+        self.testCase = testCase
+    }
+
+    /// Marks an expectation as having been met. It's an error to call this
+    /// method on an expectation that has already been fulfilled, or when the
+    /// test case that vended the expectation has already completed.
+    ///
+    /// - Parameter file: The file name to use in the error message if
+    ///   expectations are not met before the given timeout. Default is the file
+    ///   containing the call to this method. It is rare to provide this
+    ///   parameter when calling this method.
+    /// - Parameter line: The line number to use in the error message if the
+    ///   expectations are not met before the given timeout. Default is the line
+    ///   number of the call to this method in the calling file. It is rare to
+    ///   provide this parameter when calling this method.
+    ///
+    /// - Note: Whereas Objective-C XCTest determines the file and line
+    ///   number the expectation was fulfilled using symbolication, this
+    ///   implementation opts to take `file` and `line` as parameters instead.
+    ///   As a result, the interface to these methods are not exactly identical
+    ///   between these environments. To ensure compatibility of tests between
+    ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
+    ///   explicit values for `file` and `line`.
+    public func fulfill(file: StaticString = #file, line: UInt = #line) {
+        // FIXME: Objective-C XCTest emits failures when expectations are
+        //        fulfilled after the test cases that generated those
+        //        expectations have completed. Similarly, this should cause an
+        //        error as well.
+        if fulfilled {
+            // Mirror Objective-C XCTest behavior: treat multiple calls to
+            // fulfill() as an unexpected failure.
+            let failure = XCTFailure(
+                message: "multiple calls made to XCTestExpectation.fulfill() for \(description).",
+                failureDescription: "API violation",
+                expected: false,
+                file: file,
+                line: line)
+            if let failureHandler = XCTFailureHandler {
+                failureHandler(failure)
+            }
+        } else {
+            fulfilled = true
+        }
+    }
+}

--- a/Sources/XCTest/XCWaitCompletionHandler.swift
+++ b/Sources/XCTest/XCWaitCompletionHandler.swift
@@ -1,0 +1,27 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCWaitCompletionHandler.swift
+//  A closure invoked by XCTestCase when a wait for expectations to be
+//  fulfilled times out.
+//
+
+#if os(Linux) || os(FreeBSD)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
+/// A block to be invoked when a call to wait times out or has had all
+/// associated expectations fulfilled.
+///
+/// - Parameter error: If the wait timed out or a failure was raised while
+///   waiting, the error's code will specify the type of failure. Otherwise
+///   error will be nil.
+public typealias XCWaitCompletionHandler = (NSError?) -> ()

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -1,0 +1,94 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous
+// RUN: %{built_tests_dir}/Asynchronous > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+    import Foundation
+#else
+    import SwiftXCTest
+    import SwiftFoundation
+#endif
+
+class ExpectationsTestCase: XCTestCase {
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:19: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
+    func test_waitingForAnUnfulfilledExpectation_fails() {
+        expectationWithDescription("foo")
+        waitForExpectationsWithTimeout(0.2, handler: nil)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:28: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
+    func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
+        expectationWithDescription("bar")
+        expectationWithDescription("baz")
+        waitForExpectationsWithTimeout(0.2, handler: nil)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' started.
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
+    func test_waitingForAnImmediatelyFulfilledExpectation_passes() {
+        let expectation = expectationWithDescription("flim")
+        expectation.fulfill()
+        waitForExpectationsWithTimeout(0.2, handler: nil)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' started.
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
+    func test_waitingForAnEventuallyFulfilledExpectation_passes() {
+        let expectation = expectationWithDescription("flam")
+        let timer = NSTimer.scheduledTimer(0.1, repeats: false) { _ in
+            expectation.fulfill()
+        }
+        NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
+        waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:59: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
+    func test_waitingForAnExpectationFulfilledAfterTheTimeout_fails() {
+        let expectation = expectationWithDescription("hog")
+        let timer = NSTimer.scheduledTimer(1.0, repeats: false) { _ in
+            expectation.fulfill()
+        }
+        NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' started.
+// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' passed \(\d+\.\d+ seconds\).
+    func test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes() {
+        let expectation = expectationWithDescription("smog")
+        expectation.fulfill()
+        waitForExpectationsWithTimeout(0.0, handler: nil)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:75: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
+// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
+    func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
+        expectationWithDescription("dog")
+        waitForExpectationsWithTimeout(-1.0, handler: nil)
+    }
+
+    static var allTests: [(String, ExpectationsTestCase -> () throws -> Void)] {
+        return [
+            ("test_waitingForAnUnfulfilledExpectation_fails", test_waitingForAnUnfulfilledExpectation_fails),
+            ("test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails", test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails),
+            ("test_waitingForAnImmediatelyFulfilledExpectation_passes", test_waitingForAnImmediatelyFulfilledExpectation_passes),
+            ("test_waitingForAnEventuallyFulfilledExpectation_passes", test_waitingForAnEventuallyFulfilledExpectation_passes),
+            ("test_waitingForAnExpectationFulfilledAfterTheTimeout_fails", test_waitingForAnExpectationFulfilledAfterTheTimeout_fails),
+            ("test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes", test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes),
+            ("test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails", test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails),
+        ]
+    }
+}
+
+XCTMain([testCase(ExpectationsTestCase.allTests)])
+
+// CHECK: Executed 7 tests, with 4 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 7 tests, with 4 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -1,0 +1,55 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Handler
+// RUN: %{built_tests_dir}/Handler > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+    import Foundation
+#else
+    import SwiftXCTest
+    import SwiftFoundation
+#endif
+
+class HandlerTestCase: XCTestCase {
+// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Handler/main.swift:21: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
+// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
+    func test_whenExpectationsAreNotFulfilled_handlerCalled_andFails() {
+        self.expectationWithDescription("fog")
+
+        var handlerWasCalled = false
+        self.waitForExpectationsWithTimeout(0.2) { error in
+            XCTAssertNotNil(error, "Expectation handlers for unfulfilled expectations should not be nil.")
+            XCTAssertTrue(error!.domain.hasSuffix("XCTestErrorDomain"), "The last component of the error domain should match Objective-C XCTest.")
+            XCTAssertEqual(error!.code, 0, "The error code should match Objective-C XCTest.")
+            handlerWasCalled = true
+        }
+        XCTAssertTrue(handlerWasCalled)
+    }
+
+// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' started.
+// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' passed \(\d+\.\d+ seconds\).
+    func test_whenExpectationsAreFulfilled_handlerCalled_andPasses() {
+        let expectation = self.expectationWithDescription("bog")
+        expectation.fulfill()
+
+        var handlerWasCalled = false
+        self.waitForExpectationsWithTimeout(0.2) { error in
+            XCTAssertNil(error, "Expectation handlers for fulfilled expectations should be nil.")
+            handlerWasCalled = true
+        }
+        XCTAssertTrue(handlerWasCalled)
+    }
+
+    static var allTests: [(String, HandlerTestCase -> () throws -> Void)] {
+        return [
+            ("test_whenExpectationsAreNotFulfilled_handlerCalled_andFails", test_whenExpectationsAreNotFulfilled_handlerCalled_andFails),
+            ("test_whenExpectationsAreFulfilled_handlerCalled_andPasses", test_whenExpectationsAreFulfilled_handlerCalled_andPasses),
+        ]
+    }
+}
+
+XCTMain([testCase(HandlerTestCase.allTests)])
+
+// CHECK: Executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -1,0 +1,60 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Misuse
+// RUN: %{built_tests_dir}/Misuse > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+#else
+    import SwiftXCTest
+#endif
+
+class MisuseTestCase: XCTestCase {
+// CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:17: unexpected error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails :  - Failed due to unwaited expectations.
+// CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
+    func test_whenExpectationsAreMade_butNotWaitedFor_fails() {
+        self.expectationWithDescription("the first expectation")
+        self.expectationWithDescription("the second expectation (the file and line number for this one are included in the failure message")
+    }
+
+// CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:24: unexpected error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
+// CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
+    func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
+        self.waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+
+// CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:34: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:44: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+// CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
+    func test_whenExpectationIsFulfilledMultipleTimes_fails() {
+        let expectation = self.expectationWithDescription("rob")
+        expectation.fulfill()
+        expectation.fulfill()
+        // FIXME: The behavior here is subtly different from Objective-C XCTest.
+        //        Objective-C XCTest would stop executing the test on the line
+        //        above, and so would not report a failure for this line below.
+        //        In total, it would highlight one line as a failure in this
+        //        test.
+        //
+        //        swift-corelibs-xctest continues to execute the test, and so
+        //        highlights both the lines above and below as failures.
+        //        This should be fixed such that the behavior is identical.
+        expectation.fulfill()
+        self.waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+
+    static var allTests: [(String, MisuseTestCase -> () throws -> Void)] {
+        return [
+            ("test_whenExpectationsAreMade_butNotWaitedFor_fails", test_whenExpectationsAreMade_butNotWaitedFor_fails),
+            ("test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails", test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails),
+            ("test_whenExpectationIsFulfilledMultipleTimes_fails", test_whenExpectationIsFulfilledMultipleTimes_fails),
+        ]
+    }
+}
+
+XCTMain([testCase(MisuseTestCase.allTests)])
+
+// CHECK: Executed 3 tests, with 4 failures \(4 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 3 tests, with 4 failures \(4 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -22,10 +22,8 @@ def _getenv(name):
     value = os.getenv(name, None)
     if value is None:
         lit_config.fatal(
-            'Environment variable ${} is not set.\n'
-            '$SWIFT_EXEC, $SDKROOT, $BUILT_PRODUCTS_DIR, $PLATFORM_NAME, and '
-            '$MACOSX_DEPLOYMENT_TARGET must all be set for lit tests to '
-            'run.'.format(name))
+            'Environment variable ${} is required to run tests on this '
+            'platform, but it is not set.'.format(name))
     return value
 
 built_products_dir = _getenv('BUILT_PRODUCTS_DIR')
@@ -51,6 +49,22 @@ if platform.system() == 'Darwin':
         '-sdk', sdk_root,
         '-target', target,
         '-F', built_products_dir,
+        # FIXME: We must include the C header dependencies of any module we wish
+        #        to use, due to a limitation in the Swift compiler. See SR-655
+        #        for details. Here, we include the headers from CoreFoundation.
+        '-I', os.path.join(built_products_dir, 'usr', 'local', 'include'),
+    ])
+else:
+    # On Linux, we need to jump through extra hoops to link
+    # swift-corelibs-foundation.
+    foundation_dir = _getenv('FOUNDATION_BUILT_PRODUCTS_DIR')
+    core_foundation_dir = _getenv('CORE_FOUNDATION_BUILT_PRODUCTS_DIR')
+    swift_exec.extend([
+        '-Xlinker', '-rpath',
+        '-Xlinker', foundation_dir,
+        '-L', foundation_dir,
+        '-I', foundation_dir,
+        '-I', core_foundation_dir,
     ])
 
 # Having prepared the swiftc command, we set the substitution.

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */; };
 		C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */; };
 		C265F6731C3AEB6A00520CF9 /* XCTimeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */; };
+		DA7805FA1C6704A2003C6636 /* SwiftFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA7805F91C6704A2003C6636 /* SwiftFoundation.framework */; };
+		DACC94421C8B87B900EC85F5 /* XCWaitCompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */; };
+		DADB979C1C51BDA2005E68B6 /* XCTestExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +36,9 @@
 		C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCase.swift; sourceTree = "<group>"; };
 		C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestMain.swift; sourceTree = "<group>"; };
 		C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTimeUtilities.swift; sourceTree = "<group>"; };
+		DA7805F91C6704A2003C6636 /* SwiftFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftFoundation.framework; path = "../swift-corelibs-foundation/build/Debug/SwiftFoundation.framework"; sourceTree = "<group>"; };
+		DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCWaitCompletionHandler.swift; sourceTree = "<group>"; };
+		DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestExpectation.swift; sourceTree = "<group>"; };
 		EA3E74BB1BF2B6D500635A73 /* build_script.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = build_script.py; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -41,6 +47,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA7805FA1C6704A2003C6636 /* SwiftFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,6 +60,7 @@
 				C265F6661C3AEB6A00520CF9 /* Sources */,
 				DA78F7E71C4039410082E15B /* Tests */,
 				5B5D86DC1BBC74AD00234F36 /* Products */,
+				DA7805FB1C6704CC003C6636 /* Linked Libraries */,
 				EA3E74BC1BF2B6D700635A73 /* Linux Build */,
 				B1384A401C1B3E6A00EDF031 /* Documentation */,
 			);
@@ -92,9 +100,19 @@
 				C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */,
 				C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */,
 				C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */,
+				DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */,
 				C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */,
+				DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */,
 			);
 			path = XCTest;
+			sourceTree = "<group>";
+		};
+		DA7805FB1C6704CC003C6636 /* Linked Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				DA7805F91C6704A2003C6636 /* SwiftFoundation.framework */,
+			);
+			name = "Linked Libraries";
 			sourceTree = "<group>";
 		};
 		DA78F7E71C4039410082E15B /* Tests */ = {
@@ -214,8 +232,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DACC94421C8B87B900EC85F5 /* XCWaitCompletionHandler.swift in Sources */,
 				C265F6731C3AEB6A00520CF9 /* XCTimeUtilities.swift in Sources */,
 				C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */,
+				DADB979C1C51BDA2005E68B6 /* XCTestExpectation.swift in Sources */,
 				C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */,
 				C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */,
 			);
@@ -331,9 +351,11 @@
 				FRAMEWORK_VERSION = A;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = SwiftXCTest;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USER_HEADER_SEARCH_PATHS = $BUILT_PRODUCTS_DIR/usr/local/include/CoreFoundation;
 			};
 			name = Debug;
 		};
@@ -350,8 +372,10 @@
 				FRAMEWORK_VERSION = A;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = SwiftXCTest;
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = $BUILT_PRODUCTS_DIR/usr/local/include/CoreFoundation;
 			};
 			name = Release;
 		};
@@ -362,6 +386,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -373,6 +398,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/XCTest.xcworkspace/contents.xcworkspacedata
+++ b/XCTest.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "container:XCTest.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:../swift-corelibs-foundation/Foundation.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
# What's in this pull request?

An attempt to add asynchronous testing support, mirroring the Objective-C XCTest API. This is done primarily via two methods:

- `XCTestCase.expectationWithDescription()`
- `XCTestCase.waitForExpectationsWithTimeout()`

The tests in the pull request pass on Darwin, but not on Linux. Still, I've encountered a few issues that I'd like to get feedback on.

# What's worth discussing about this pull request?

The methods added are identical to their Objective-C SDK overlay counterparts, with the following exceptions:

1. If expectations are created but not waited for, Objective-C XCTest generates a test failure. In order to display a failure on the exact line of the last expectation that was created, Objective-C XCTest symbolicates the call stack. It does so using a private framework called `CoreSymbolication.framework`. We don't have this at our disposal for swift-corelibs-xctest, so instead this pull request has the method take `file` and `line` as parameters, defaulting to `__FILE__` and `__LINE__`. By doing so, we provide the same failure highlighting functionality while also maintaining a (nearly) identical API.
2. If `waitForExpectationsWithTimeout()` fails, Objective-C XCTest generates a test failure on the exact line that method was called, using the same technique from (1). For the same reason, this method also takes `file` and `line` parameters in this pull request.
3. `waitForExpectationsWithTimeout()` takes a handler callback, which in Objective-C XCTest is passed an instance of `NSError`. swift-corelibs-xctest doesn't depend upon swift-corelibs-foundation, and so does not have access to `NSError`. Instead, it defines a shim, `XCTError`.

I'd like to discuss the following:

**(A)** Without using something like `CoreSymbolication.framework`, we cannot emit failures for the correct file or line while maintaining an identical API. This pull request is a sort of middle ground; the *use* of the API looks identical:

```swift
// Objective-C XCTest
let expectation = self.expectationWithDescription("foo")
expectation.fulfill()
self.waitForExpectationsWithTimeout(10, handler: nil)
self.waitForExpectationsWithTimeout(10) { error in
    // ...
}
```

```swift
// swift-corelibs-xctest
let expectation = self.expectationWithDescription("bar")
expectation.fulfill()
self.waitForExpectationsWithTimeout(10, handler: nil)
self.waitForExpectationsWithTimeout(10) { error in
    // ...
}
```

However, they're not totally identical. The following is only possible in swift-corelibs-xctest:

```swift
// swift-corelibs-xctest
let expectation = self.expectationWithDescription("baz", file: "/path/to/file", line: 10)
expectation.fulfill()
self.waitForExpectationsWithTimeout(10, file: "/path/to/file", line: 20, handler: nil)
```

Is this an acceptable solution?

**(B)** The code in this pull request has a dummy implementation to wait for expectations to be fulfilled. For a real implementation, I think we'll need to add a dependency to swift-corelibs-xctest, and I think that should either be [swift-corelibs-libdispatch](https://github.com/apple/swift-corelibs-libdispatch) or [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation).

I think [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation) would be ideal: it includes both:

- `NSRunLoop`, which we can use to implement the waiting logic, and...
- ...`NSError`, which is used by the callback to `waitForExpectationsWithTimeout()`.

However, [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation) uses swift-corelibs-xctest for its own unit test suite. So while the dependency isn't exactly cyclical (Foundation's *tests* depend on XCTest, which depends on Foundation--no cycle), it's still a little murky as to whether it's a good idea.

Should swift-corelibs-xctest depend on [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation)? Should it depend on [swift-corelibs-libdispatch](https://github.com/apple/swift-corelibs-libdispatch)? Or should it depend on neither--and if so, how can we implement asynchronous testing?

/cc @briancroom @jeffh