### PR TITLE
flush stdout after any printed test result

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -46,7 +46,7 @@ extension XCTestCase {
                     }
                 }
 
-                print("Test Case '\(method)' started.")
+                XCTPrint("Test Case '\(method)' started.")
 
                 setUp()
 
@@ -73,7 +73,7 @@ extension XCTestCase {
                     result = failures.count > 0 ? "failed" : "passed"
                 }
 
-                print("Test Case '\(method)' \(result) (\(printableStringForTimeInterval(duration)) seconds).")
+                XCTPrint("Test Case '\(method)' \(result) (\(printableStringForTimeInterval(duration)) seconds).")
                 XCTAllRuns.append(XCTRun(duration: duration, method: method, passed: failures.count == 0, failures: failures))
                 XCTFailureHandler = nil
             }
@@ -88,7 +88,7 @@ extension XCTestCase {
             failureSuffix = ""
         }
 
-        print("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(unexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
+        XCTPrint("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(unexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
     }
     
     public func setUp() {

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -18,6 +18,11 @@ import Glibc
 import Darwin
 #endif
 
+internal func XCTPrint(items: Any..., separator: String = " ", terminator: String = "\n") {
+    print(items, separator: separator, terminator: terminator)
+    fflush(stdout)
+}
+
 struct XCTFailure {
     var message: String
     var failureDescription: String
@@ -26,7 +31,7 @@ struct XCTFailure {
     var line: UInt
     
     func emit(method: String) {
-        print("\(file):\(line): \(expected ? "" : "unexpected ")error: \(method) : \(failureDescription) - \(message)")
+        XCTPrint("\(file):\(line): \(expected ? "" : "unexpected ")error: \(method) : \(failureDescription) - \(message)")
     }
 }
 
@@ -62,7 +67,7 @@ internal struct XCTRun {
         failureSuffix = ""
     }
 
-    print("Total executed \(XCTAllRuns.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(totalUnexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
+    XCTPrint("Total executed \(XCTAllRuns.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(totalUnexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
     exit(totalFailures > 0 ? 1 : 0)
 }
 


### PR DESCRIPTION
When running tests from wrappers, such as continuous integration servers, the output of tests may be incorrectly buffered that will result in truncated displaying of tests when failures occur. This behavior incorrectly identifies the wrong test as the failure point in the suites, enforcing a fflush of stdout ensures the buffer is correctly flushed after each marker point for testing.