### PR TITLE
[XCTestMain] Don't XCTPrint arrays of strings

### DIFF
--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -18,8 +18,8 @@ import Glibc
 import Darwin
 #endif
 
-internal func XCTPrint(items: Any..., separator: String = " ", terminator: String = "\n") {
-    print(items, separator: separator, terminator: terminator)
+internal func XCTPrint(message: String) {
+    print(message)
     fflush(stdout)
 }
 


### PR DESCRIPTION
`XCTPrint()` takes a variadic argument of items to print, mirroring the API of `print()` itself. Unfortunately, passing this variadic argument directly to `print()` causes an array object to be printed. For example:

```swift
func XCTPrint(items: Any...) {
    print(items)
}

XCTPrint("Hello!") // Prints '["Hello!"]\n'
```

As a result of this behavior, swift-corelibs-xctest currently prints out test output such as the following:

```
["Test Case \'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion\' failed (0.0 seconds)."]
["Test Case \'ErrorHandling.test_shouldThrowErrorInAssertion\' started."]
```

This is different from the expected output in `Tests/Functional`, which is causing the test suite to fail.

Instead of mirroring the `print()` API, have `XCTPrint()` simply take a string object to print. This has the added benefit of being simpler--we can add the variadic arguments and the line separator parameter back if we ever need them. The test suite passes with this change.

---

On a related note:

1. Would it be possible to have Apple CI cover this repository as well? I'd love to be able to ask @swift-ci to "please test"!
2. I'm still trying to find time to add these tests to the Swift validation-test suite. I'd love it if someone beat me to it! :wink: 