### PR TITLE
[build_script] Use built XCTest for Linux tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,13 @@ If your install of Swift is located at `/swift` and you wish to install XCTest i
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --build-dir="/tmp/XCTest_build" --swift-build-dir="/swift/usr" --library-install-path="/swift/usr/lib/swift/linux" --module-install-path="/swift/usr/lib/swift/linux/x86_64"
 ```
 
-To run the tests on Linux, pass the `--test` option in combination with options to
-install XCTest in your active version of Swift:
+To run the tests on Linux, use the `--test` option:
 
 ```sh
 ./build_script.py \
     --swiftc="/swift/usr/bin/swiftc" \
     --build-dir="/tmp/XCTest_build" \
     --swift-build-dir="/swift/usr" \
-    --library-install-path="/swift/usr/lib/swift/linux" \
-    --module-install-path="/swift/usr/lib/swift/linux/x86_64" \
     --test
 ```
 

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -28,14 +28,18 @@ def _getenv(name):
             'run.'.format(name))
     return value
 
-swift_exec = [_getenv('SWIFT_EXEC')]
+built_products_dir = _getenv('BUILT_PRODUCTS_DIR')
+swift_exec = [
+    _getenv('SWIFT_EXEC'),
+    '-Xlinker', '-rpath',
+    '-Xlinker', built_products_dir,
+]
 
 if platform.system() == 'Darwin':
     # On OS X, we need to make sure swiftc references the
     # proper SDK, has a deployment target set, and more...
     # Here we rely on environment variables, produced by xcodebuild.
     sdk_root = _getenv('SDKROOT')
-    built_products_dir = _getenv('BUILT_PRODUCTS_DIR')
     platform_name = _getenv('PLATFORM_NAME')
     deployment_target = _getenv('MACOSX_DEPLOYMENT_TARGET')
 
@@ -47,8 +51,7 @@ if platform.system() == 'Darwin':
         '-L', built_products_dir,
         '-I', built_products_dir,
         '-F', built_products_dir,
-        '-Xlinker', '-rpath',
-        '-Xlinker', built_products_dir])
+    ])
 
 # Having prepared the swiftc command, we set the substitution.
 config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))

--- a/build_script.py
+++ b/build_script.py
@@ -136,16 +136,19 @@ def main():
         cmd = ['cp', os.path.join(build_dir, install_mod_doc), os.path.join(module_path, install_mod_doc)]
         subprocess.check_call(cmd)
 
-        if args.test:
-            lit_path = os.path.join(
-                os.path.dirname(SOURCE_DIR), 'llvm', 'utils', 'lit', 'lit.py')
-            lit_flags = '-sv --no-progress-bar'
-            tests_path = os.path.join(SOURCE_DIR, 'Tests', 'Functional')
-            run('SWIFT_EXEC={swiftc} {lit_path} {lit_flags} '
-                '{tests_path}'.format(swiftc=swiftc,
-                                      lit_path=lit_path,
-                                      lit_flags=lit_flags,
-                                      tests_path=tests_path))
+    if args.test:
+        lit_path = os.path.join(
+            os.path.dirname(SOURCE_DIR), 'llvm', 'utils', 'lit', 'lit.py')
+        lit_flags = '-sv --no-progress-bar'
+        tests_path = os.path.join(SOURCE_DIR, 'Tests', 'Functional')
+        run('SWIFT_EXEC={swiftc} '
+            'BUILT_PRODUCTS_DIR={built_products_dir} '
+            '{lit_path} {lit_flags} '
+            '{tests_path}'.format(swiftc=swiftc,
+                                  built_products_dir=build_dir,
+                                  lit_path=lit_path,
+                                  lit_flags=lit_flags,
+                                  tests_path=tests_path))
 
     note('Done.')
 


### PR DESCRIPTION
Previously, tests on Linux could only be run using the installed swift-corelibs-xctest. Modify the script to use the built XCTest instead of the installed one.

In addition, since the script no longer relies on the installed XCTest, move the `--test` logic such that it can be used even if `--module-install-path` and `--library-install-path` are not specified.

---

Now, running tests on Linux is as easy as:

```
$ ./build_script.py \
    --swiftc ~/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc \
    --build-dir ~/build/Ninja-ReleaseAssert/xctest-linux-x86_64 \
    --swift-build-dir ~/build/Ninja-ReleaseAssert/swift-linux-x86_64 \
    --test
```

Keep in mind that the tests won't pass until after #45 is merged.