### PR TITLE
[.xcodeproj] Share SwiftXCTest scheme

### DIFF
--- a/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTest.xcscheme
+++ b/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTest.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
+               BuildableName = "SwiftXCTest.framework"
+               BlueprintName = "SwiftXCTest"
+               ReferencedContainer = "container:XCTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
+            BuildableName = "SwiftXCTest.framework"
+            BlueprintName = "SwiftXCTest"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
+            BuildableName = "SwiftXCTest.framework"
+            BlueprintName = "SwiftXCTest"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
# What's in this pull request?

Currently, running the Swift build script `/path/to/swift/utils/build-script --xctest` on OS X fails because it attempts to use the Linux-only `build_script.py`.

We should make it possible for swift-corelibs-xctest to be built via the `--xctest` switch on OS X, which means making the project buildable via the command line.

To make the project buildable via the command line, share the "SwiftXCTest" scheme. This allows the project to be built via:

```
$ xcodebuild -project SwiftXCTest.xcodeproj -scheme SwiftXCTest
```

# Why merge this pull request?

After merging these changes and #46, I plan on allowing swift-corelibs-xctest to be built and tested via the Swift build script. This could be accomplished via the following changes to apple/swift:

```diff
diff --git a/utils/build-script-impl b/utils/build-script-impl
index eebeef7..7b176f5 100755
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1797,11 +1797,18 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 continue
                 ;;
             xctest)
-                SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
-                SWIFT_BUILD_PATH="$(build_directory ${deployment_target} swift)"
-                set -x
-                "${XCTEST_SOURCE_DIR}"/build_script.py --swiftc="${SWIFTC_BIN}" --build-dir="${build_dir}" --swift-build-dir="${SWIFT_BUILD_PATH}"
-                { set +x; } 2>/dev/null
+                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                    set -x
+                    # FIXME: When built on Darwin, the '$build_dir' is ignored.
+                    xcodebuild -project "${XCTEST_SOURCE_DIR}"/XCTest.xcodeproj -scheme SwiftXCTest
+                    { set +x; } 2>/dev/null
+                else
+                    SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
+                    SWIFT_BUILD_PATH="$(build_directory ${deployment_target} swift)"
+                    set -x
+                    "${XCTEST_SOURCE_DIR}"/build_script.py --swiftc="${SWIFTC_BIN}" --build-dir="${build_dir}" --swift-build-dir="${SWIFT_BUILD_PATH}"
+                    { set +x; } 2>/dev/null
+                fi

                 # XCTest builds itself and doesn't rely on cmake
                 continue
@@ -2021,7 +2028,21 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                 if [[ "${SKIP_TEST_XCTEST}" ]]; then
                     continue
                 fi
-                # FIXME: We don't test xctest, yet...
+                echo "--- Running tests for ${product} ---"
+                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                    set -x
+                    xcodebuild -project "${XCTEST_SOURCE_DIR}"/XCTest.xcodeproj -scheme SwiftXCTestFunctionalTests
+                    { set +x; } 2>/dev/null
+                else
+                    SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
+                    SWIFT_BUILD_PATH="$(build_directory ${deployment_target} swift)"
+                    set -x
+                    # FIXME: This re-builds swift-corelibs-xctest. Instead, 'build_script.py' should take
+                    # a top-level 'test' command that only tests an already built XCTest.
+                    "${XCTEST_SOURCE_DIR}"/build_script.py --swiftc="${SWIFTC_BIN}" --build-dir="${build_dir}" --swift-build-dir="${SWIFT_BUILD_PATH}" --test
+                    { set +x; } 2>/dev/null
+                fi
+                echo "--- Finished tests for ${product} ---"
                 continue
                 ;;
             foundation)
```

We haven't traditionally been quick to notice when swift-corelibs-xctest is broken; the failures introduced by #33 and #44 took several days to even discover. Adding swift-corelibs-xctest to the Swift test suite will allow us to discover failures quicker.

# What downsides are there to merging this pull request?

We probably want a shared scheme in any case, but one could argue that adding swift-corelibs-xctest tests to the Swift build script is premature. After all, the changes I suggest above already have two FIXMEs in them. Still, I think this is forward progress--the FIXMEs can be addressed in turn.