### PR TITLE
[Tests] Properly link Linux tests

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -33,6 +33,8 @@ swift_exec = [
     _getenv('SWIFT_EXEC'),
     '-Xlinker', '-rpath',
     '-Xlinker', built_products_dir,
+    '-L', built_products_dir,
+    '-I', built_products_dir,
 ]
 
 if platform.system() == 'Darwin':
@@ -48,8 +50,6 @@ if platform.system() == 'Darwin':
     swift_exec.extend([
         '-sdk', sdk_root,
         '-target', target,
-        '-L', built_products_dir,
-        '-I', built_products_dir,
         '-F', built_products_dir,
     ])
 


### PR DESCRIPTION
https://github.com/apple/swift-corelibs-xctest/pull/46 is missing this change to the compiler invocation, which allows tests to run on Linux even when `--library-install-path` and `--module-install-path` are not specified.

---

My bad, this should have been included in #46. With this change, the following now works:

```
$ build_script.py \
    --swiftc="/swift/usr/bin/swiftc" \
    --build-dir="/tmp/XCTest_build" \
    --swift-build-dir="/swift/usr" \
    --test
```