### PR TITLE
[build_script.py] Provide default temp build dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,7 @@ If your install of Swift is located at `/swift` and you wish to install XCTest i
 To run the tests on Linux, use the `--test` option:
 
 ```sh
-./build_script.py \
-    --swiftc="/swift/usr/bin/swiftc" \
-    --build-dir="/tmp/XCTest_build" \
-    --test
+./build_script.py --swiftc="/swift/usr/bin/swiftc" --test
 ```
 
 To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project. You may also run them via the command line:

--- a/build_script.py
+++ b/build_script.py
@@ -9,7 +9,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 
-import os, subprocess, argparse
+import argparse
+import os
+import subprocess
+import tempfile
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -28,9 +31,10 @@ def main():
                         metavar="PATH",
                         required=True)
     parser.add_argument("--build-dir",
-                        help="path to the output build directory",
+                        help="path to the output build directory. If not "
+                             "specified, a temporary directory is used",
                         metavar="PATH",
-                        required=True)
+                        default=tempfile.mkdtemp())
     parser.add_argument("--swift-build-dir", help="deprecated, do not use")
     parser.add_argument("--arch", help="deprecated, do not use")
     parser.add_argument("--module-install-path",


### PR DESCRIPTION
If a user doesn't care about where the built products are located, they may omit the "--build-dir" flag, and the build script will generate a temporary directory for them.

This allows the tests to be run on Linux with a very simple command:

```
$ ./build_script.py --swiftc `which swiftc` --test
```