### PR TITLE
[build_script.py] Glob source files to build

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -10,6 +10,7 @@
 #
 
 import argparse
+import glob
 import os
 import subprocess
 import tempfile
@@ -73,17 +74,8 @@ def main():
     if not os.path.exists(build_dir):
         run("mkdir -p {}".format(build_dir))
 
-    sourceFiles = [
-                   "XCTAssert.swift",
-                   "XCTestCaseProvider.swift",
-                   "XCTestCase.swift",
-                   "XCTimeUtilities.swift",
-                   "XCTestMain.swift",
-                  ]
-    sourcePaths = []
-    for file in sourceFiles:
-        sourcePaths.append("{0}/Sources/XCTest/{1}".format(SOURCE_DIR, file))
-
+    sourcePaths = glob.glob(os.path.join(
+        SOURCE_DIR, 'Sources', 'XCTest', '*.swift'))
 
     if args.build_style == "debug":
         style_options = "-g"


### PR DESCRIPTION
Maintaining a list of source files to build in the build_script requires a change to that file every time a new source file is added. Instead, automatically pick up any new source files with a .swift extension.

---

One potential downside here is that we may end up including a `.swift` file in the `Sources/XCTest` which we *don't* want to compile, and in that case this would no longer work. I can't really imagine why we'd want such a thing, though.