### PR TITLE
Add Unit Testing Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ To run the tests on Linux, use the `--test` option:
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --test
 ```
 
-To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project. You may also run them via the command line:
+To run the tests on OS X, build and run the `SwiftXCTestUnitTests` and `SwiftXCTestFunctionalTests` targets in the Xcode project. You may also run the functional tests via the command line:
 
 ```
 xcodebuild -project XCTest.xcodeproj -scheme SwiftXCTestFunctionalTests
 ```
 
-You may add tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`.
+You may add functional tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`. Unit tests should be placed in the `Tests/Unit/` directory, and then referenced in `Tests/Unit/main.swift`.
 
 ### Additional Considerations for Swift on Linux
 

--- a/Tests/Unit/Resources/Info.plist
+++ b/Tests/Unit/Resources/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2016 Apple Inc. and the Swift project authors</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Tests/Unit/TestAssertions.swift
+++ b/Tests/Unit/TestAssertions.swift
@@ -1,0 +1,52 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+class TestAssertions: XCTestCase {
+    var allTests: [(String, () throws -> Void)] {
+        return [
+            ("test_passingAssertionDoesNotCallFailureHandler", test_passingAssertionDoesNotCallFailureHandler),
+            ("test_failedAssertionCallsFailureHandlerWithCorrectFailure", test_failedAssertionCallsFailureHandlerWithCorrectFailure),
+        ]
+    }
+
+    func test_passingAssertionDoesNotCallFailureHandler() {
+        let failures = captureFailures {
+            XCTAssert(true)
+        }
+
+        XCTAssertTrue(failures.isEmpty)
+    }
+
+    func test_failedAssertionCallsFailureHandlerWithCorrectFailure() {
+        let failures = captureFailures {
+            XCTAssert(false, "This should fail")
+        }
+
+        XCTAssertEqual(failures.count, 1)
+
+        let failure = failures.first
+        XCTAssertEqual(failure?.message, "This should fail")
+        XCTAssertEqual(failure?.failureDescription, "XCTAssertTrue failed")
+        XCTAssertTrue(failure?.expected ?? false)
+
+        let baseFileName = failure?.file.stringValue.characters.split("/").map(String.init).last
+        XCTAssertEqual(baseFileName, "TestAssertions.swift")
+    }
+
+    private func captureFailures(closure: () -> Void) -> [XCTFailure] {
+        var failures = [XCTFailure]()
+
+        let oldHandler = XCTFailureHandler
+        XCTFailureHandler = { failures.append($0) }
+        closure()
+        XCTFailureHandler = oldHandler
+
+        return failures
+    }
+}

--- a/Tests/Unit/main.swift
+++ b/Tests/Unit/main.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+XCTMain([
+    TestAssertions(),
+])

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AE1569EF1C85CB8200A97839 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1569EE1C85CB8200A97839 /* main.swift */; };
+		AE1569F11C85CCF600A97839 /* TestAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1569F01C85CCF600A97839 /* TestAssertions.swift */; };
+		AE1569F21C863C9E00A97839 /* XCTAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */; };
+		AE1569F31C863C9E00A97839 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */; };
+		AE1569F41C863C9E00A97839 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66B1C3AEB6A00520CF9 /* XCTestCaseProvider.swift */; };
+		AE1569F51C863C9E00A97839 /* XCTestMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */; };
+		AE1569F61C863C9E00A97839 /* XCTimeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */; };
 		C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */; };
 		C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */; };
 		C265F6711C3AEB6A00520CF9 /* XCTestCaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66B1C3AEB6A00520CF9 /* XCTestCaseProvider.swift */; };
@@ -15,6 +22,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		AE1569EC1C85CB6500A97839 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B5D86DA1BBC74AD00234F36;
+			remoteInfo = SwiftXCTest;
+		};
 		DAA333B91C267AF3000CC115 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5B5D86D21BBC74AD00234F36 /* Project object */;
@@ -28,6 +42,10 @@
 		342A33611C470D91001AA02A /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F320B0D1C4714EC00AB3456 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		AE1569DB1C85C9E100A97839 /* SwiftXCTestUnitTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftXCTestUnitTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE1569EA1C85CB0100A97839 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AE1569EE1C85CB8200A97839 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		AE1569F01C85CCF600A97839 /* TestAssertions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAssertions.swift; sourceTree = "<group>"; };
 		B1384A411C1B3E8700EDF031 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		B1384A421C1B3E8700EDF031 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		B1384A431C1B3E8700EDF031 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -87,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */,
+				AE1569DB1C85C9E100A97839 /* SwiftXCTestUnitTests.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -97,6 +116,24 @@
 				9F320B0D1C4714EC00AB3456 /* main.swift */,
 			);
 			path = ErrorHandling;
+			sourceTree = "<group>";
+		};
+		AE1569E81C85CA3A00A97839 /* Unit */ = {
+			isa = PBXGroup;
+			children = (
+				AE1569EE1C85CB8200A97839 /* main.swift */,
+				AE1569F01C85CCF600A97839 /* TestAssertions.swift */,
+				AE1569E91C85CAE700A97839 /* Resources */,
+			);
+			path = Unit;
+			sourceTree = "<group>";
+		};
+		AE1569E91C85CAE700A97839 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				AE1569EA1C85CB0100A97839 /* Info.plist */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 		B1384A401C1B3E6A00EDF031 /* Documentation */ = {
@@ -133,6 +170,7 @@
 			isa = PBXGroup;
 			children = (
 				DA78F7E81C4039410082E15B /* Functional */,
+				AE1569E81C85CA3A00A97839 /* Unit */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -263,18 +301,37 @@
 			productReference = 5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		AE1569DA1C85C9E100A97839 /* SwiftXCTestUnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AE1569E71C85C9E100A97839 /* Build configuration list for PBXNativeTarget "SwiftXCTestUnitTests" */;
+			buildPhases = (
+				AE1569D71C85C9E100A97839 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AE1569ED1C85CB6500A97839 /* PBXTargetDependency */,
+			);
+			name = SwiftXCTestUnitTests;
+			productName = SwiftXCTestUnitTests;
+			productReference = AE1569DB1C85C9E100A97839 /* SwiftXCTestUnitTests.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		5B5D86D21BBC74AD00234F36 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0710;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = Apple;
 				TargetAttributes = {
 					5B5D86DA1BBC74AD00234F36 = {
 						CreatedOnToolsVersion = 7.1;
+					};
+					AE1569DA1C85C9E100A97839 = {
+						CreatedOnToolsVersion = 7.3;
 					};
 					DAA333B51C267AD6000CC115 = {
 						CreatedOnToolsVersion = 7.2;
@@ -296,6 +353,7 @@
 			targets = (
 				5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */,
 				DAA333B51C267AD6000CC115 /* SwiftXCTestFunctionalTests */,
+				AE1569DA1C85C9E100A97839 /* SwiftXCTestUnitTests */,
 			);
 		};
 /* End PBXProject section */
@@ -323,9 +381,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AE1569D71C85C9E100A97839 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE1569F11C85CCF600A97839 /* TestAssertions.swift in Sources */,
+				AE1569F51C863C9E00A97839 /* XCTestMain.swift in Sources */,
+				AE1569F61C863C9E00A97839 /* XCTimeUtilities.swift in Sources */,
+				AE1569F41C863C9E00A97839 /* XCTestCaseProvider.swift in Sources */,
+				AE1569F21C863C9E00A97839 /* XCTAssert.swift in Sources */,
+				AE1569F31C863C9E00A97839 /* XCTestCase.swift in Sources */,
+				AE1569EF1C85CB8200A97839 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		AE1569ED1C85CB6500A97839 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */;
+			targetProxy = AE1569EC1C85CB6500A97839 /* PBXContainerItemProxy */;
+		};
 		DAA333BA1C267AF3000CC115 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5B5D86DA1BBC74AD00234F36 /* SwiftXCTest */;
@@ -457,6 +534,33 @@
 			};
 			name = Release;
 		};
+		AE1569E51C85C9E100A97839 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/Unit/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.SwiftXCTestUnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AE1569E61C85C9E100A97839 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = Tests/Unit/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.SwiftXCTestUnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		DAA333B61C267AD6000CC115 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -499,6 +603,15 @@
 			buildConfigurations = (
 				5B5D86E41BBC74AD00234F36 /* Debug */,
 				5B5D86E51BBC74AD00234F36 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AE1569E71C85C9E100A97839 /* Build configuration list for PBXNativeTarget "SwiftXCTestUnitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AE1569E51C85C9E100A97839 /* Debug */,
+				AE1569E61C85C9E100A97839 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestUnitTests.xcscheme
+++ b/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestUnitTests.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AE1569DA1C85C9E100A97839"
+               BuildableName = "SwiftXCTestUnitTests.app"
+               BlueprintName = "SwiftXCTestUnitTests"
+               ReferencedContainer = "container:XCTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE1569DA1C85C9E100A97839"
+            BuildableName = "SwiftXCTestUnitTests.app"
+            BlueprintName = "SwiftXCTestUnitTests"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE1569DA1C85C9E100A97839"
+            BuildableName = "SwiftXCTestUnitTests.app"
+            BlueprintName = "SwiftXCTestUnitTests"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AE1569DA1C85C9E100A97839"
+            BuildableName = "SwiftXCTestUnitTests.app"
+            BlueprintName = "SwiftXCTestUnitTests"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
### Motivation

Corelibs XCTest already has an mature setup for executing end-to-end functional tests against itself which is doing an outstanding job of providing confidence that the library will work as expected when linked into clients' test suites. Sometimes, though, it feels more appropriate to write more granular unit tests against particular APIs provided by the library. This PR aims to satisfy that missing component by adding a suite of unit tests which can be run from Xcode on OS X, or from the build script on other platforms.
### Details

The unit test suite is located in the `Tests/Unit/` directory, as a sibling to the existing functional test suite. It uses Corelibs XCTest to test itself, building an app whose `main.swift` invokes `XCTMain` with the list of `XCTestCase` subclasses which contain the tests themselves. I implemented a simple pair of tests around `XCTAssert` behavior to act as a seed and example test for the suite.

Ordinarily when writing unit tests for a library, I would prefer to link the library into the test target and restrict the tests to working against the public API so as to prevent them on relying too much on implementation details. For this suite, however, I came to the conclusion that the public API (at least in its present form) lends itself rather poorly to unit testing because it generally requires calling into `XCTMain` to set up state, and that function can't be called from a unit test without exiting the process altogether! Because of this, I decided to simply build the library source files together with the unit test sources, allowing for judicious use of `internal` API in unit tests. (Note that the standard integration of the Corelibs XCTest dynamic library into client executables is thoroughly by the Functional test suite.)

For OS X, the Xcode project now has a new `SwiftXCTestUnitTests` app target which executes the test suite when run. For Linux, the build script's `test` action has been extended to also build and run the unit tests, although, notably, it does not link the unit tests against an already-built XCTest dynamic library the way that the functional tests do.
### CI

To get CI to run the new test suite, the overall Swift build script will need to be updated (around [here](https://github.com/apple/swift/blob/master/utils/build-script-impl#L2075)) to execute the unit test suite on OS X., On Linux no additional work is required because it is already taken care of by XCTest's own build script.
