### PR TITLE
[build_script.py] Add --foundation-build-dir parameter [AsyncXCTest 1/6]

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -159,6 +159,12 @@ def main(args=sys.argv[1:]):
              "temporary directory is used",
         metavar="PATH",
         default=tempfile.mkdtemp())
+    build_parser.add_argument(
+        "--foundation-build-dir",
+        help="Path to swift-corelibs-foundation build products, which "
+             "the built XCTest.so will be linked against.",
+        metavar="PATH",
+        required=False)
     build_parser.add_argument("--swift-build-dir",
                               help="deprecated, do not use")
     build_parser.add_argument("--arch", help="deprecated, do not use")
@@ -208,6 +214,12 @@ def main(args=sys.argv[1:]):
         "--swiftc",
         help="Path to the 'swiftc' compiler used to build and run the tests.",
         required=True)
+    test_parser.add_argument(
+        "--foundation-build-dir",
+        help="Path to swift-corelibs-foundation build products, which the "
+             "tests will be linked against.",
+        metavar="PATH",
+        required=False)
 
     install_parser = subparsers.add_parser(
         "install",


### PR DESCRIPTION
> This is [the first of six pull requests](https://github.com/apple/swift-corelibs-xctest/pull/43#issuecomment-192813377) necessary to introduce asynchronous testing to swift-corelibs-xctest. @modocache will merge this once the CI passes.

https://github.com/apple/swift-corelibs-xctest/pull/43 will add a dependency between swift-corelibs-xctest and swift-corelibs-foundation. This will also necessitate the build script to take a '--foundation-build-dir' parameter. However, the Swift CI does not yet supply this parameter.

To prevent CI from breaking when #43 is landed, preemptively add the '--foundation-build-dir' parameter. Before landing #43, the Swift build script will be modified to pass this parameter to the XCTest build script.