### PR TITLE
Preemptively add XCTest.xcworkspace [AsyncXCTest 2/6]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 xcuserdata
+*.xcscmblueprint
 .build/
 Output/

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ To run the tests on Linux, use the `--test` option:
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --test
 ```
 
-To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode project. You may also run them via the command line:
+To run the tests on OS X, build and run the `SwiftXCTestFunctionalTests` target in the Xcode workspace. You may also run them via the command line:
 
 ```
-xcodebuild -project XCTest.xcodeproj -scheme SwiftXCTestFunctionalTests
+xcodebuild -workspace XCTest.xcworkspace -scheme SwiftXCTestFunctionalTests
 ```
 
 You may add tests for XCTest by including them in the `Tests/Functional/` directory. For an example, see `Tests/Functional/SingleFailingTestCase`.

--- a/XCTest.xcworkspace/contents.xcworkspacedata
+++ b/XCTest.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:XCTest.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
> This is [the second of six pull requests](https://github.com/apple/swift-corelibs-xctest/pull/43#issuecomment-192813377) necessary to introduce asynchronous testing to swift-corelibs-xctest. @modocache will merge this once the CI passes.

https://github.com/apple/swift-corelibs-xctest/pull/43 will add a dependency between swift-corelibs-xctest and swift-corelibs-foundation. On OS X, this will also necessitate an Xcode workspace that references both XCTest and Foundation .xcodeproj's.

To prevent CI from breaking when #43 is landed, preemptively add an Xcode workspace. Before landing #43, the Swift build script will be modified to build XCTest.xcworkspace, not XCTest.xcodeproj.