### PR TITLE
Reorganize test assertions

### DIFF
--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -1,24 +1,6 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/ErrorHandling
 // RUN: %{built_tests_dir}/ErrorHandling > %t || true
 // RUN: %{xctest_checker} %t %s
-// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started.
-// CHECK: .*/Tests/Functional/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error - 
-// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' started.
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' passed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started.
-// CHECK: .*/Tests/Functional/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) - 
-// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' started.
-// CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "AnError\("an error message"\)" - 
-// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' started.
-// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' passed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started.
-// CHECK: .*/Tests/Functional/ErrorHandling/main.swift:\d+: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" - 
-// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
-// CHECK: Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Total executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 #if os(Linux) || os(FreeBSD)
     import XCTest
@@ -53,11 +35,16 @@ class ErrorHandling: XCTestCase {
     func functionThatDoesThrowError() throws {
         throw SomeError.AnError("an error message")
     }
-    
+
+// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started.
+// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error - 
+// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
     func test_shouldButDoesNotThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesNotThrowError())
     }
     
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' started.
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' passed \(\d+\.\d+ seconds\).
     func test_shouldThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
             guard let thrownError = error as? SomeError else {
@@ -72,6 +59,9 @@ class ErrorHandling: XCTestCase {
         }
     }
     
+// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started.
+// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) - 
+// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
     func test_throwsErrorInAssertionButFailsWhenCheckingError() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
             guard let thrownError = error as? SomeError else {
@@ -86,10 +76,15 @@ class ErrorHandling: XCTestCase {
         }
     }
     
+// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' started.
+// CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "AnError\("an error message"\)" - 
+// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\).
     func test_canAndDoesThrowErrorFromTestMethod() throws {
         try functionThatDoesThrowError()
     }
     
+// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' started.
+// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' passed \(\d+\.\d+ seconds\).
     func test_canButDoesNotThrowErrorFromTestMethod() throws {
         try functionThatDoesNotThrowError()
     }
@@ -98,9 +93,15 @@ class ErrorHandling: XCTestCase {
         throw SomeError.AnError("did not actually return")
     }
     
+// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started.
+// CHECK: .*/ErrorHandling/main.swift:\d+: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" - 
+// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)
     }
 }
 
 XCTMain([testCase(ErrorHandling.allTests)])
+
+// CHECK: Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -1,19 +1,6 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/FailingTestSuite
 // RUN: %{built_tests_dir}/FailingTestSuite > %t || true
 // RUN: %{xctest_checker} %t %s
-// CHECK: Test Case 'PassingTestCase.test_passes' started.
-// CHECK: Test Case 'PassingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
-// CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Test Case 'FailingTestCase.test_passes' started.
-// CHECK: Test Case 'FailingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailingTestCase.test_fails' started.
-// CHECK: .*/Tests/Functional/FailingTestSuite/main.swift:50: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
-// CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailingTestCase.test_fails_with_message' started.
-// CHECK: .*/Tests/Functional/FailingTestSuite/main.swift:54: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
-// CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
-// CHECK: Executed 3 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 #if os(Linux) || os(FreeBSD)
     import XCTest
@@ -28,10 +15,14 @@ class PassingTestCase: XCTestCase {
         ]
     }
 
+// CHECK: Test Case 'PassingTestCase.test_passes' started.
+// CHECK: Test Case 'PassingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
     func test_passes() {
         XCTAssert(true)
     }
 }
+// CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
 
 class FailingTestCase: XCTestCase {
     static var allTests: [(String, FailingTestCase -> () throws -> Void)] {
@@ -42,20 +33,32 @@ class FailingTestCase: XCTestCase {
         ]
     }
 
+// CHECK: Test Case 'FailingTestCase.test_passes' started.
+// CHECK: Test Case 'FailingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
     func test_passes() {
         XCTAssert(true)
     }
 
+// CHECK: Test Case 'FailingTestCase.test_fails' started.
+// CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
+// CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)
     }
 
+// CHECK: Test Case 'FailingTestCase.test_fails_with_message' started.
+// CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
+// CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
     func test_fails_with_message() {
         XCTAssert(false, "Foo bar.")
     }
 }
+// CHECK: Executed 3 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
 
 XCTMain([
     testCase(PassingTestCase.allTests),
     testCase(FailingTestCase.allTests),
 ])
+
+// CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -1,74 +1,6 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/FailureMessagesTestCase
 // RUN: %{built_tests_dir}/FailureMessagesTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
-// CHECK: Test Case 'FailureMessagesTestCase.testAssert' started.
-// CHECK: test.swift:109: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started.
-// CHECK: test.swift:113: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started.
-// CHECK: test.swift:117: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' started.
-// CHECK: test.swift:121: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' started.
-// CHECK: test.swift:125: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' started.
-// CHECK: test.swift:129: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started.
-// CHECK: test.swift:133: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started.
-// CHECK: test.swift:137: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' started.
-// CHECK: test.swift:141: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' started.
-// CHECK: test.swift:145: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' started.
-// CHECK: test.swift:149: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' started.
-// CHECK: test.swift:153: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' started.
-// CHECK: test.swift:157: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started.
-// CHECK: test.swift:161: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started.
-// CHECK: test.swift:165: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' started.
-// CHECK: test.swift:169: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' started.
-// CHECK: test.swift:173: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' started.
-// CHECK: test.swift:177: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started.
-// CHECK: test.swift:181: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started.
-// CHECK: test.swift:185: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNil failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' started.
-// CHECK: test.swift:189: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'FailureMessagesTestCase.testFail' started.
-// CHECK: test.swift:193: error: FailureMessagesTestCase.testFail : failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\).
-// CHECK: Executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Total executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 #if os(Linux) || os(FreeBSD)
     import XCTest
@@ -105,93 +37,162 @@ class FailureMessagesTestCase: XCTestCase {
         ]
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssert' started.
+// CHECK: test.swift:44: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
     func testAssert() {
         XCTAssert(false, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started.
+// CHECK: test.swift:51: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertEqualOptionals() {
         XCTAssertEqual(1, 2, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started.
+// CHECK: test.swift:58: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
     func testAssertEqualArraySlices() {
         XCTAssertEqual([1][0..<1], [2][0..<1], "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' started.
+// CHECK: test.swift:65: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
     func testAssertEqualContiguousArrays() {
         XCTAssertEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 2), "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' started.
+// CHECK: test.swift:72: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\).
     func testAssertEqualArrays() {
         XCTAssertEqual([1], [2], "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' started.
+// CHECK: test.swift:79: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertEqualDictionaries() {
         XCTAssertEqual([1:2], [3:4], "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started.
+// CHECK: test.swift:86: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
     func testAssertEqualWithAccuracy() {
         XCTAssertEqualWithAccuracy(1, 2, accuracy: 0.1, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started.
+// CHECK: test.swift:93: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\).
     func testAssertFalse() {
         XCTAssertFalse(true, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' started.
+// CHECK: test.swift:100: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\).
     func testAssertGreaterThan() {
         XCTAssertGreaterThan(0, 0, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' started.
+// CHECK: test.swift:107: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\).
     func testAssertGreaterThanOrEqual() {
         XCTAssertGreaterThanOrEqual(-1, 0, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' started.
+// CHECK: test.swift:114: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\).
     func testAssertLessThan() {
         XCTAssertLessThan(0, 0, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' started.
+// CHECK: test.swift:121: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\).
     func testAssertLessThanOrEqual() {
         XCTAssertLessThanOrEqual(1, 0, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' started.
+// CHECK: test.swift:128: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\).
     func testAssertNil() {
         XCTAssertNil("helloworld", "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started.
+// CHECK: test.swift:135: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualOptionals() {
         XCTAssertNotEqual(1, 1, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started.
+// CHECK: test.swift:142: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualArraySlices() {
         XCTAssertNotEqual([1][0..<1], [1][0..<1], "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' started.
+// CHECK: test.swift:149: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualContiguousArrays() {
         XCTAssertNotEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 1), "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' started.
+// CHECK: test.swift:156: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualArrays() {
         XCTAssertNotEqual([1], [1], "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' started.
+// CHECK: test.swift:163: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualDictionaries() {
         XCTAssertNotEqual([1:1], [1:1], "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started.
+// CHECK: test.swift:170: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualWithAccuracy() {
         XCTAssertNotEqualWithAccuracy(1, 1, 0.1, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started.
+// CHECK: test.swift:177: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNil failed - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
     func testAssertNotNil() {
         XCTAssertNotNil(nil, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' started.
+// CHECK: test.swift:184: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\).
     func testAssertTrue() {
         XCTAssertTrue(false, "message", file: "test.swift")
     }
-    
+
+// CHECK: Test Case 'FailureMessagesTestCase.testFail' started.
+// CHECK: test.swift:191: error: FailureMessagesTestCase.testFail : failed - message
+// CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\).
     func testFail() {
         XCTFail("message", file: "test.swift")
     }
 }
 
 XCTMain([testCase(FailureMessagesTestCase.allTests)])
+
+// CHECK: Executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -1,18 +1,6 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/NegativeAccuracyTestCase
 // RUN: %{built_tests_dir}/NegativeAccuracyTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' started.
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started.
-// CHECK: .*/Tests/Functional/NegativeAccuracyTestCase/main.swift:39: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' started.
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started.
-// CHECK: .*/Tests/Functional/NegativeAccuracyTestCase/main.swift:47: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
-// CHECK: Executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 #if os(Linux) || os(FreeBSD)
     import XCTest
@@ -31,21 +19,34 @@ class NegativeAccuracyTestCase: XCTestCase {
         ]
     }
 
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' started.
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
     func test_equalWithAccuracy_passes() {
         XCTAssertEqualWithAccuracy(0, 0.1, accuracy: -0.1)
     }
 
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started.
+// CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
     func test_equalWithAccuracy_fails() {
         XCTAssertEqualWithAccuracy(0, 0.2, accuracy: -0.1)
     }
 
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' started.
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
     func test_notEqualWithAccuracy_passes() {
         XCTAssertNotEqualWithAccuracy(1, 2, -0.5)
     }
 
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started.
+// CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
     func test_notEqualWithAccuracy_fails() {
         XCTAssertNotEqualWithAccuracy(1, 2, -1)
     }
 }
 
 XCTMain([testCase(NegativeAccuracyTestCase.allTests)])
+
+// CHECK: Executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -1,11 +1,6 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/SingleFailingTestCase
 // RUN: %{built_tests_dir}/SingleFailingTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
-// CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
-// CHECK: .*/Tests/Functional/SingleFailingTestCase/main.swift:24: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - 
-// CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
-// CHECK: Executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Total executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 #if os(Linux) || os(FreeBSD)
     import XCTest
@@ -20,9 +15,15 @@ class SingleFailingTestCase: XCTestCase {
         ]
     }
 
+// CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
+// CHECK: .*/SingleFailingTestCase/main.swift:22: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - 
+// CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)
     }
 }
 
 XCTMain([testCase(SingleFailingTestCase.allTests)])
+
+// CHECK: Executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -1,18 +1,6 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/TestCaseLifecycle
 // RUN: %{built_tests_dir}/TestCaseLifecycle > %t || true
 // RUN: %{xctest_checker} %t %s
-// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' started.
-// CHECK: In setUp\(\)
-// CHECK: In test_hasValueFromSetUp\(\)
-// CHECK: In tearDown\(\)
-// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' passed \(\d+\.\d+ seconds\).
-// CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' started.
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' passed \(\d+\.\d+ seconds\).
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' started.
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' passed \(\d+\.\d+ seconds\).
-// CHECK: Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK: Total executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 #if os(Linux) || os(FreeBSD)
     import XCTest
@@ -40,11 +28,18 @@ class SetUpTearDownTestCase: XCTestCase {
         print("In \(__FUNCTION__)")
     }
 
+// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' started.
+// CHECK: In setUp\(\)
+// CHECK: In test_hasValueFromSetUp\(\)
+// CHECK: In tearDown\(\)
+// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' passed \(\d+\.\d+ seconds\).
     func test_hasValueFromSetUp() {
         print("In \(__FUNCTION__)")
         XCTAssertEqual(value, 42)
     }
 }
+// CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
 
 class NewInstanceForEachTestTestCase: XCTestCase {
     static var allTests: [(String, NewInstanceForEachTestTestCase -> () throws -> Void)] {
@@ -56,17 +51,25 @@ class NewInstanceForEachTestTestCase: XCTestCase {
 
     var value = 1
 
+// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' started.
+// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' passed \(\d+\.\d+ seconds\).
     func test_hasInitializedValue() {
         XCTAssertEqual(value, 1)
         value += 1
     }
 
+// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' started.
+// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' passed \(\d+\.\d+ seconds\).
     func test_hasInitializedValueInAnotherTest() {
         XCTAssertEqual(value, 1)
     }
 }
+// CHECK: Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
 
 XCTMain([
     testCase(SetUpTearDownTestCase.allTests),
     testCase(NewInstanceForEachTestTestCase.allTests)
 ])
+
+// CHECK: Total executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -19,13 +19,13 @@ class SetUpTearDownTestCase: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        print("In \(__FUNCTION__)")
+        print("In \(#function)")
         value = 42
     }
 
     override func tearDown() {
         super.tearDown()
-        print("In \(__FUNCTION__)")
+        print("In \(#function)")
     }
 
 // CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' started.
@@ -34,7 +34,7 @@ class SetUpTearDownTestCase: XCTestCase {
 // CHECK: In tearDown\(\)
 // CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' passed \(\d+\.\d+ seconds\).
     func test_hasValueFromSetUp() {
-        print("In \(__FUNCTION__)")
+        print("In \(#function)")
         XCTAssertEqual(value, 42)
     }
 }


### PR DESCRIPTION
I've gone ahead and taken a first pass at rearranging the assertions in our existing functional tests, as discussed.

@modocache already has [more ideas](https://github.com/apple/swift-corelibs-xctest/pull/43#discussion_r55156054) of ways that this could potentially be made even better, but this seemed like nice low-hanging fruit until such time as new functionality is added to the `xctest_checker`.

I made a couple of other minor changes to the assertions here as well. In particular, I reduced the number of tests that explicitly check for correct line numbers in assertion failure, because the specific line numbers are prone to change as the project evolves, and it's wasteful to test the same behavior repeatedly. I also made a slight simplification to the file path in lines checking assertion failures. What previous was:

```
// CHECK: .*/Tests/Functional/SingleFailingTestCase/main.swift:22: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
```

is now

```
// CHECK: .*/SingleFailingTestCase/main.swift:22: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
```

I don't think that including the extra path components improved the quality of the assertion in any way, while it *does* increase the amount of noise, making it harder to determine what parts of the line are most relevant.