### PR TITLE
Fix the failure message emitted by XCTAssertNotNil

### DIFF
--- a/Sources/XCTest/XCTAssert.swift
+++ b/Sources/XCTest/XCTAssert.swift
@@ -358,7 +358,7 @@ public func XCTAssertNotEqualWithAccuracy<T: FloatingPoint>(@autoclosure express
 }
 
 public func XCTAssertNotNil(@autoclosure expression: () throws -> Any?, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Nil, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.NotNil, message: message, file: file, line: line) {
         let value = try expression()
         if value != nil {
             return .Success

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -171,7 +171,7 @@ class FailureMessagesTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started.
-// CHECK: test.swift:177: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNil failed - message
+// CHECK: test.swift:177: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
     func testAssertNotNil() {
         XCTAssertNotNil(nil, "message", file: "test.swift")


### PR DESCRIPTION
I noticed this was incorrect while putting together #66. Obviously there's an ordering dependency between these two PRs and one will need to be rebased, but I wanted to call out this fix in a separate PR for future reference.