### PR TITLE
[Tests] Inline expectations and substitute [[@LINE]] numbers

### DIFF
--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -12,7 +12,7 @@
 
 class ExpectationsTestCase: XCTestCase {
     // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started.
-    // CHECK: .*/Asynchronous/Expectations/main.swift:19: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
+    // CHECK: .*/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
     // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnUnfulfilledExpectation_fails() {
         expectationWithDescription("foo")
@@ -20,7 +20,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started.
-    // CHECK: .*/Asynchronous/Expectations/main.swift:28: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
+    // CHECK: .*/Asynchronous/Expectations/main.swift:[[@LINE+5]]: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
     // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
     func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
         expectationWithDescription("bar")
@@ -48,7 +48,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started.
-    // CHECK: .*/Asynchronous/Expectations/main.swift:59: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
+    // CHECK: .*/Asynchronous/Expectations/main.swift:[[@LINE+8]]: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
     // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnExpectationFulfilledAfterTheTimeout_fails() {
         let expectation = expectationWithDescription("hog")
@@ -68,7 +68,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started.
-    // CHECK: .*/Asynchronous/Expectations/main.swift:75: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
+    // CHECK: .*/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
     // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
         expectationWithDescription("dog")

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -11,33 +11,33 @@
 #endif
 
 class ExpectationsTestCase: XCTestCase {
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:19: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started.
+    // CHECK: .*/Asynchronous/Expectations/main.swift:19: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnUnfulfilledExpectation_fails() {
         expectationWithDescription("foo")
         waitForExpectationsWithTimeout(0.2, handler: nil)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:28: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started.
+    // CHECK: .*/Asynchronous/Expectations/main.swift:28: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
     func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
         expectationWithDescription("bar")
         expectationWithDescription("baz")
         waitForExpectationsWithTimeout(0.2, handler: nil)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' started.
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' started.
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
     func test_waitingForAnImmediatelyFulfilledExpectation_passes() {
         let expectation = expectationWithDescription("flim")
         expectation.fulfill()
         waitForExpectationsWithTimeout(0.2, handler: nil)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' started.
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' started.
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
     func test_waitingForAnEventuallyFulfilledExpectation_passes() {
         let expectation = expectationWithDescription("flam")
         let timer = NSTimer.scheduledTimer(0.1, repeats: false) { _ in
@@ -47,9 +47,9 @@ class ExpectationsTestCase: XCTestCase {
         waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:59: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started.
+    // CHECK: .*/Asynchronous/Expectations/main.swift:59: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
+    // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnExpectationFulfilledAfterTheTimeout_fails() {
         let expectation = expectationWithDescription("hog")
         let timer = NSTimer.scheduledTimer(1.0, repeats: false) { _ in
@@ -59,17 +59,17 @@ class ExpectationsTestCase: XCTestCase {
         waitForExpectationsWithTimeout(0.1, handler: nil)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' started.
-// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' started.
+    // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' passed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes() {
         let expectation = expectationWithDescription("smog")
         expectation.fulfill()
         waitForExpectationsWithTimeout(0.0, handler: nil)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:75: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
-// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started.
+    // CHECK: .*/Asynchronous/Expectations/main.swift:75: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
+    // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
         expectationWithDescription("dog")
         waitForExpectationsWithTimeout(-1.0, handler: nil)
@@ -86,9 +86,7 @@ class ExpectationsTestCase: XCTestCase {
             ("test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails", test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails),
         ]
     }
-}
+} // CHECK: Executed 7 tests, with 4 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-XCTMain([testCase(ExpectationsTestCase.allTests)])
-
-// CHECK: Executed 7 tests, with 4 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Total executed 7 tests, with 4 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+XCTMain([testCase(ExpectationsTestCase.allTests)])

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -11,9 +11,9 @@
 #endif
 
 class HandlerTestCase: XCTestCase {
-// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Handler/main.swift:21: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
-// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' started.
+    // CHECK: .*/Asynchronous/Handler/main.swift:21: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
+    // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreNotFulfilled_handlerCalled_andFails() {
         self.expectationWithDescription("fog")
 
@@ -27,8 +27,8 @@ class HandlerTestCase: XCTestCase {
         XCTAssertTrue(handlerWasCalled)
     }
 
-// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' started.
-// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' started.
+    // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' passed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreFulfilled_handlerCalled_andPasses() {
         let expectation = self.expectationWithDescription("bog")
         expectation.fulfill()
@@ -47,9 +47,7 @@ class HandlerTestCase: XCTestCase {
             ("test_whenExpectationsAreFulfilled_handlerCalled_andPasses", test_whenExpectationsAreFulfilled_handlerCalled_andPasses),
         ]
     }
-}
+} // CHECK: Executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-XCTMain([testCase(HandlerTestCase.allTests)])
-
-// CHECK: Executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Total executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+XCTMain([testCase(HandlerTestCase.allTests)])

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -12,7 +12,7 @@
 
 class HandlerTestCase: XCTestCase {
     // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' started.
-    // CHECK: .*/Asynchronous/Handler/main.swift:21: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
+    // CHECK: .*/Asynchronous/Handler/main.swift:[[@LINE+6]]: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
     // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreNotFulfilled_handlerCalled_andFails() {
         self.expectationWithDescription("fog")

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -10,7 +10,7 @@
 
 class MisuseTestCase: XCTestCase {
     // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' started.
-    // CHECK: .*/Asynchronous/Misuse/main.swift:17: unexpected error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails :  - Failed due to unwaited expectations.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:[[@LINE+4]]: unexpected error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails :  - Failed due to unwaited expectations.
     // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreMade_butNotWaitedFor_fails() {
         self.expectationWithDescription("the first expectation")
@@ -18,15 +18,15 @@ class MisuseTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started.
-    // CHECK: .*/Asynchronous/Misuse/main.swift:24: unexpected error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:[[@LINE+3]]: unexpected error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
     // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
         self.waitForExpectationsWithTimeout(0.1, handler: nil)
     }
 
     // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started.
-    // CHECK: .*/Asynchronous/Misuse/main.swift:34: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
-    // CHECK: .*/Asynchronous/Misuse/main.swift:44: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:[[@LINE+6]]: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:[[@LINE+15]]: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
     // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationIsFulfilledMultipleTimes_fails() {
         let expectation = self.expectationWithDescription("rob")

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -9,25 +9,25 @@
 #endif
 
 class MisuseTestCase: XCTestCase {
-// CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:17: unexpected error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails :  - Failed due to unwaited expectations.
-// CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' started.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:17: unexpected error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails :  - Failed due to unwaited expectations.
+    // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreMade_butNotWaitedFor_fails() {
         self.expectationWithDescription("the first expectation")
         self.expectationWithDescription("the second expectation (the file and line number for this one are included in the failure message")
     }
 
-// CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:24: unexpected error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
-// CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:24: unexpected error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
+    // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
         self.waitForExpectationsWithTimeout(0.1, handler: nil)
     }
 
-// CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started.
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:34: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:44: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
-// CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:34: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+    // CHECK: .*/Asynchronous/Misuse/main.swift:44: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+    // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationIsFulfilledMultipleTimes_fails() {
         let expectation = self.expectationWithDescription("rob")
         expectation.fulfill()
@@ -52,9 +52,7 @@ class MisuseTestCase: XCTestCase {
             ("test_whenExpectationIsFulfilledMultipleTimes_fails", test_whenExpectationIsFulfilledMultipleTimes_fails),
         ]
     }
-}
+} // CHECK: Executed 3 tests, with 4 failures \(4 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-XCTMain([testCase(MisuseTestCase.allTests)])
-
-// CHECK: Executed 3 tests, with 4 failures \(4 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Total executed 3 tests, with 4 failures \(4 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+XCTMain([testCase(MisuseTestCase.allTests)])

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -9,42 +9,15 @@
 #endif
 
 class ErrorHandling: XCTestCase {
-    static var allTests: [(String, ErrorHandling -> () throws -> Void)] {
-        return [
-            // Tests for XCTAssertThrowsError
-            ("test_shouldButDoesNotThrowErrorInAssertion", test_shouldButDoesNotThrowErrorInAssertion),
-            ("test_shouldThrowErrorInAssertion", test_shouldThrowErrorInAssertion),
-            ("test_throwsErrorInAssertionButFailsWhenCheckingError", test_throwsErrorInAssertionButFailsWhenCheckingError),
-            
-            // Tests for "testFoo() throws"
-            ("test_canAndDoesThrowErrorFromTestMethod", test_canAndDoesThrowErrorFromTestMethod),
-            ("test_canButDoesNotThrowErrorFromTestMethod", test_canButDoesNotThrowErrorFromTestMethod),
-            
-            // Tests for throwing assertion expressions
-            ("test_assertionExpressionCanThrow", test_assertionExpressionCanThrow),
-        ]
-    }
-    
-    func functionThatDoesNotThrowError() throws {
-    }
-    
-    enum SomeError: ErrorProtocol {
-        case AnError(String)
-    }
-    
-    func functionThatDoesThrowError() throws {
-        throw SomeError.AnError("an error message")
-    }
-
-// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started.
-// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error - 
-// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started.
+    // CHECK: .*/ErrorHandling/main.swift:16: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error - $
+    // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
     func test_shouldButDoesNotThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesNotThrowError())
     }
-    
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' started.
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' passed \(\d+\.\d+ seconds\).
+
+    // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' started.
+    // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' passed \(\d+\.\d+ seconds\).
     func test_shouldThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
             guard let thrownError = error as? SomeError else {
@@ -58,10 +31,10 @@ class ErrorHandling: XCTestCase {
             }
         }
     }
-    
-// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started.
-// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) - 
-// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
+
+    // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started.
+    // CHECK: .*/ErrorHandling/main.swift:47: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) - $
+    // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
     func test_throwsErrorInAssertionButFailsWhenCheckingError() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
             guard let thrownError = error as? SomeError else {
@@ -75,33 +48,58 @@ class ErrorHandling: XCTestCase {
             }
         }
     }
-    
-// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' started.
-// CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "AnError\("an error message"\)" - 
-// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\).
+
+    // CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' started.
+    // CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "AnError\("an error message"\)" - $
+    // CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\).
     func test_canAndDoesThrowErrorFromTestMethod() throws {
         try functionThatDoesThrowError()
     }
-    
-// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' started.
-// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' passed \(\d+\.\d+ seconds\).
+
+    // CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' started.
+    // CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' passed \(\d+\.\d+ seconds\).
     func test_canButDoesNotThrowErrorFromTestMethod() throws {
         try functionThatDoesNotThrowError()
     }
-    
-    func functionThatShouldReturnButThrows() throws -> Int {
-        throw SomeError.AnError("did not actually return")
-    }
-    
-// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started.
-// CHECK: .*/ErrorHandling/main.swift:\d+: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" - 
-// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
+
+    // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started.
+    // CHECK: .*/ErrorHandling/main.swift:69: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" - $
+    // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)
     }
-}
 
-XCTMain([testCase(ErrorHandling.allTests)])
+    static var allTests: [(String, ErrorHandling -> () throws -> Void)] {
+        return [
+            // Tests for XCTAssertThrowsError
+            ("test_shouldButDoesNotThrowErrorInAssertion", test_shouldButDoesNotThrowErrorInAssertion),
+            ("test_shouldThrowErrorInAssertion", test_shouldThrowErrorInAssertion),
+            ("test_throwsErrorInAssertionButFailsWhenCheckingError", test_throwsErrorInAssertionButFailsWhenCheckingError),
 
-// CHECK: Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+            // Tests for "testFoo() throws"
+            ("test_canAndDoesThrowErrorFromTestMethod", test_canAndDoesThrowErrorFromTestMethod),
+            ("test_canButDoesNotThrowErrorFromTestMethod", test_canButDoesNotThrowErrorFromTestMethod),
+
+            // Tests for throwing assertion expressions
+            ("test_assertionExpressionCanThrow", test_assertionExpressionCanThrow),
+        ]
+    }
+
+    func functionThatShouldReturnButThrows() throws -> Int {
+        throw SomeError.AnError("did not actually return")
+    }
+
+    func functionThatDoesNotThrowError() throws {
+    }
+
+    enum SomeError: ErrorProtocol {
+        case AnError(String)
+    }
+
+    func functionThatDoesThrowError() throws {
+        throw SomeError.AnError("an error message")
+    }
+} // CHECK: Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
 // CHECK: Total executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+XCTMain([testCase(ErrorHandling.allTests)])

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -10,7 +10,7 @@
 
 class ErrorHandling: XCTestCase {
     // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started.
-    // CHECK: .*/ErrorHandling/main.swift:16: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error - $
+    // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error - $
     // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
     func test_shouldButDoesNotThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesNotThrowError())
@@ -33,7 +33,7 @@ class ErrorHandling: XCTestCase {
     }
 
     // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started.
-    // CHECK: .*/ErrorHandling/main.swift:47: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) - $
+    // CHECK: .*/ErrorHandling/main.swift:[[@LINE+11]]: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) - $
     // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
     func test_throwsErrorInAssertionButFailsWhenCheckingError() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
@@ -63,7 +63,7 @@ class ErrorHandling: XCTestCase {
     }
 
     // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started.
-    // CHECK: .*/ErrorHandling/main.swift:69: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" - $
+    // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" - $
     // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -9,22 +9,40 @@
 #endif
 
 class PassingTestCase: XCTestCase {
+    // CHECK: Test Case 'PassingTestCase.test_passes' started.
+    // CHECK: Test Case 'PassingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
+    func test_passes() {
+        XCTAssert(true)
+    }
+
     static var allTests: [(String, PassingTestCase -> () throws -> Void)] {
         return [
             ("test_passes", test_passes),
         ]
     }
+} // CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-// CHECK: Test Case 'PassingTestCase.test_passes' started.
-// CHECK: Test Case 'PassingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
+class FailingTestCase: XCTestCase {
+    // CHECK: Test Case 'FailingTestCase.test_passes' started.
+    // CHECK: Test Case 'FailingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
     func test_passes() {
         XCTAssert(true)
     }
-}
-// CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
+    // CHECK: Test Case 'FailingTestCase.test_fails' started.
+    // CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
+    // CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
+    func test_fails() {
+        XCTAssert(false)
+    }
 
-class FailingTestCase: XCTestCase {
+    // CHECK: Test Case 'FailingTestCase.test_fails_with_message' started.
+    // CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
+    // CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
+    func test_fails_with_message() {
+        XCTAssert(false, "Foo bar.")
+    }
+
     static var allTests: [(String, FailingTestCase -> () throws -> Void)] {
         return [
             ("test_passes", test_passes),
@@ -32,33 +50,10 @@ class FailingTestCase: XCTestCase {
             ("test_fails_with_message", test_fails_with_message),
         ]
     }
+} // CHECK: Executed 3 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-// CHECK: Test Case 'FailingTestCase.test_passes' started.
-// CHECK: Test Case 'FailingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
-    func test_passes() {
-        XCTAssert(true)
-    }
-
-// CHECK: Test Case 'FailingTestCase.test_fails' started.
-// CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
-// CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
-    func test_fails() {
-        XCTAssert(false)
-    }
-
-// CHECK: Test Case 'FailingTestCase.test_fails_with_message' started.
-// CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
-// CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
-    func test_fails_with_message() {
-        XCTAssert(false, "Foo bar.")
-    }
-}
-// CHECK: Executed 3 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-
-
+// CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 XCTMain([
     testCase(PassingTestCase.allTests),
     testCase(FailingTestCase.allTests),
 ])
-
-// CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -30,14 +30,14 @@ class FailingTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'FailingTestCase.test_fails' started.
-    // CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
+    // CHECK: .*/FailingTestSuite/main.swift:[[@LINE+3]]: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
     // CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)
     }
 
     // CHECK: Test Case 'FailingTestCase.test_fails_with_message' started.
-    // CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
+    // CHECK: .*/FailingTestSuite/main.swift:[[@LINE+3]]: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
     // CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
     func test_fails_with_message() {
         XCTAssert(false, "Foo bar.")

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -11,154 +11,154 @@
 // Regression test for https://github.com/apple/swift-corelibs-xctest/pull/22
 class FailureMessagesTestCase: XCTestCase {
     // CHECK: Test Case 'FailureMessagesTestCase.testAssert' started.
-    // CHECK: test.swift:17: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
     func testAssert() {
         XCTAssert(false, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started.
-    // CHECK: test.swift:24: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertEqualOptionals() {
         XCTAssertEqual(1, 2, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started.
-    // CHECK: test.swift:31: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
     func testAssertEqualArraySlices() {
         XCTAssertEqual([1][0..<1], [2][0..<1], "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' started.
-    // CHECK: test.swift:38: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
     func testAssertEqualContiguousArrays() {
         XCTAssertEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 2), "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' started.
-    // CHECK: test.swift:45: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\).
     func testAssertEqualArrays() {
         XCTAssertEqual([1], [2], "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' started.
-    // CHECK: test.swift:52: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertEqualDictionaries() {
         XCTAssertEqual([1:2], [3:4], "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started.
-    // CHECK: test.swift:59: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
     func testAssertEqualWithAccuracy() {
         XCTAssertEqualWithAccuracy(1, 2, accuracy: 0.1, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started.
-    // CHECK: test.swift:66: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\).
     func testAssertFalse() {
         XCTAssertFalse(true, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' started.
-    // CHECK: test.swift:73: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\).
     func testAssertGreaterThan() {
         XCTAssertGreaterThan(0, 0, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' started.
-    // CHECK: test.swift:80: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\).
     func testAssertGreaterThanOrEqual() {
         XCTAssertGreaterThanOrEqual(-1, 0, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' started.
-    // CHECK: test.swift:87: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\).
     func testAssertLessThan() {
         XCTAssertLessThan(0, 0, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' started.
-    // CHECK: test.swift:94: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\).
     func testAssertLessThanOrEqual() {
         XCTAssertLessThanOrEqual(1, 0, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' started.
-    // CHECK: test.swift:101: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\).
     func testAssertNil() {
         XCTAssertNil("helloworld", "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started.
-    // CHECK: test.swift:108: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualOptionals() {
         XCTAssertNotEqual(1, 1, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started.
-    // CHECK: test.swift:115: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualArraySlices() {
         XCTAssertNotEqual([1][0..<1], [1][0..<1], "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' started.
-    // CHECK: test.swift:122: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualContiguousArrays() {
         XCTAssertNotEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 1), "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' started.
-    // CHECK: test.swift:129: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualArrays() {
         XCTAssertNotEqual([1], [1], "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' started.
-    // CHECK: test.swift:136: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualDictionaries() {
         XCTAssertNotEqual([1:1], [1:1], "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started.
-    // CHECK: test.swift:143: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualWithAccuracy() {
         XCTAssertNotEqualWithAccuracy(1, 1, 0.1, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started.
-    // CHECK: test.swift:150: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
     func testAssertNotNil() {
         XCTAssertNotNil(nil, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' started.
-    // CHECK: test.swift:157: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
     // CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\).
     func testAssertTrue() {
         XCTAssertTrue(false, "message", file: "test.swift")
     }
 
     // CHECK: Test Case 'FailureMessagesTestCase.testFail' started.
-    // CHECK: test.swift:164: error: FailureMessagesTestCase.testFail : failed - message
+    // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testFail : failed - message
     // CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\).
     func testFail() {
         XCTFail("message", file: "test.swift")

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -10,6 +10,160 @@
 
 // Regression test for https://github.com/apple/swift-corelibs-xctest/pull/22
 class FailureMessagesTestCase: XCTestCase {
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssert' started.
+    // CHECK: test.swift:17: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
+    func testAssert() {
+        XCTAssert(false, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started.
+    // CHECK: test.swift:24: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
+    func testAssertEqualOptionals() {
+        XCTAssertEqual(1, 2, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started.
+    // CHECK: test.swift:31: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
+    func testAssertEqualArraySlices() {
+        XCTAssertEqual([1][0..<1], [2][0..<1], "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' started.
+    // CHECK: test.swift:38: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
+    func testAssertEqualContiguousArrays() {
+        XCTAssertEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 2), "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' started.
+    // CHECK: test.swift:45: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\).
+    func testAssertEqualArrays() {
+        XCTAssertEqual([1], [2], "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' started.
+    // CHECK: test.swift:52: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
+    func testAssertEqualDictionaries() {
+        XCTAssertEqual([1:2], [3:4], "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started.
+    // CHECK: test.swift:59: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
+    func testAssertEqualWithAccuracy() {
+        XCTAssertEqualWithAccuracy(1, 2, accuracy: 0.1, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started.
+    // CHECK: test.swift:66: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\).
+    func testAssertFalse() {
+        XCTAssertFalse(true, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' started.
+    // CHECK: test.swift:73: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\).
+    func testAssertGreaterThan() {
+        XCTAssertGreaterThan(0, 0, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' started.
+    // CHECK: test.swift:80: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\).
+    func testAssertGreaterThanOrEqual() {
+        XCTAssertGreaterThanOrEqual(-1, 0, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' started.
+    // CHECK: test.swift:87: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\).
+    func testAssertLessThan() {
+        XCTAssertLessThan(0, 0, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' started.
+    // CHECK: test.swift:94: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\).
+    func testAssertLessThanOrEqual() {
+        XCTAssertLessThanOrEqual(1, 0, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' started.
+    // CHECK: test.swift:101: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\).
+    func testAssertNil() {
+        XCTAssertNil("helloworld", "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started.
+    // CHECK: test.swift:108: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
+    func testAssertNotEqualOptionals() {
+        XCTAssertNotEqual(1, 1, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started.
+    // CHECK: test.swift:115: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
+    func testAssertNotEqualArraySlices() {
+        XCTAssertNotEqual([1][0..<1], [1][0..<1], "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' started.
+    // CHECK: test.swift:122: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
+    func testAssertNotEqualContiguousArrays() {
+        XCTAssertNotEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 1), "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' started.
+    // CHECK: test.swift:129: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\).
+    func testAssertNotEqualArrays() {
+        XCTAssertNotEqual([1], [1], "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' started.
+    // CHECK: test.swift:136: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
+    func testAssertNotEqualDictionaries() {
+        XCTAssertNotEqual([1:1], [1:1], "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started.
+    // CHECK: test.swift:143: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
+    func testAssertNotEqualWithAccuracy() {
+        XCTAssertNotEqualWithAccuracy(1, 1, 0.1, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started.
+    // CHECK: test.swift:150: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
+    func testAssertNotNil() {
+        XCTAssertNotNil(nil, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' started.
+    // CHECK: test.swift:157: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\).
+    func testAssertTrue() {
+        XCTAssertTrue(false, "message", file: "test.swift")
+    }
+
+    // CHECK: Test Case 'FailureMessagesTestCase.testFail' started.
+    // CHECK: test.swift:164: error: FailureMessagesTestCase.testFail : failed - message
+    // CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\).
+    func testFail() {
+        XCTFail("message", file: "test.swift")
+    }
+
     static var allTests: [(String, FailureMessagesTestCase -> () throws -> Void)] {
         return [
             ("testAssert", testAssert),
@@ -36,163 +190,7 @@ class FailureMessagesTestCase: XCTestCase {
             ("testFail", testFail),
         ]
     }
+} // CHECK: Executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-// CHECK: Test Case 'FailureMessagesTestCase.testAssert' started.
-// CHECK: test.swift:44: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
-    func testAssert() {
-        XCTAssert(false, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started.
-// CHECK: test.swift:51: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
-    func testAssertEqualOptionals() {
-        XCTAssertEqual(1, 2, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started.
-// CHECK: test.swift:58: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
-    func testAssertEqualArraySlices() {
-        XCTAssertEqual([1][0..<1], [2][0..<1], "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' started.
-// CHECK: test.swift:65: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
-    func testAssertEqualContiguousArrays() {
-        XCTAssertEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 2), "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' started.
-// CHECK: test.swift:72: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\).
-    func testAssertEqualArrays() {
-        XCTAssertEqual([1], [2], "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' started.
-// CHECK: test.swift:79: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
-    func testAssertEqualDictionaries() {
-        XCTAssertEqual([1:2], [3:4], "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started.
-// CHECK: test.swift:86: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
-    func testAssertEqualWithAccuracy() {
-        XCTAssertEqualWithAccuracy(1, 2, accuracy: 0.1, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started.
-// CHECK: test.swift:93: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\).
-    func testAssertFalse() {
-        XCTAssertFalse(true, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' started.
-// CHECK: test.swift:100: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\).
-    func testAssertGreaterThan() {
-        XCTAssertGreaterThan(0, 0, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' started.
-// CHECK: test.swift:107: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\).
-    func testAssertGreaterThanOrEqual() {
-        XCTAssertGreaterThanOrEqual(-1, 0, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' started.
-// CHECK: test.swift:114: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\).
-    func testAssertLessThan() {
-        XCTAssertLessThan(0, 0, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' started.
-// CHECK: test.swift:121: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\).
-    func testAssertLessThanOrEqual() {
-        XCTAssertLessThanOrEqual(1, 0, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' started.
-// CHECK: test.swift:128: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\).
-    func testAssertNil() {
-        XCTAssertNil("helloworld", "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started.
-// CHECK: test.swift:135: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
-    func testAssertNotEqualOptionals() {
-        XCTAssertNotEqual(1, 1, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started.
-// CHECK: test.swift:142: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
-    func testAssertNotEqualArraySlices() {
-        XCTAssertNotEqual([1][0..<1], [1][0..<1], "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' started.
-// CHECK: test.swift:149: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
-    func testAssertNotEqualContiguousArrays() {
-        XCTAssertNotEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 1), "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' started.
-// CHECK: test.swift:156: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\).
-    func testAssertNotEqualArrays() {
-        XCTAssertNotEqual([1], [1], "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' started.
-// CHECK: test.swift:163: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
-    func testAssertNotEqualDictionaries() {
-        XCTAssertNotEqual([1:1], [1:1], "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started.
-// CHECK: test.swift:170: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
-    func testAssertNotEqualWithAccuracy() {
-        XCTAssertNotEqualWithAccuracy(1, 1, 0.1, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started.
-// CHECK: test.swift:177: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
-    func testAssertNotNil() {
-        XCTAssertNotNil(nil, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' started.
-// CHECK: test.swift:184: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\).
-    func testAssertTrue() {
-        XCTAssertTrue(false, "message", file: "test.swift")
-    }
-
-// CHECK: Test Case 'FailureMessagesTestCase.testFail' started.
-// CHECK: test.swift:191: error: FailureMessagesTestCase.testFail : failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\).
-    func testFail() {
-        XCTFail("message", file: "test.swift")
-    }
-}
-
-XCTMain([testCase(FailureMessagesTestCase.allTests)])
-
-// CHECK: Executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Total executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+XCTMain([testCase(FailureMessagesTestCase.allTests)])

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -17,7 +17,7 @@ class NegativeAccuracyTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started.
-    // CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
+    // CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
     // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
     func test_equalWithAccuracy_fails() {
         XCTAssertEqualWithAccuracy(0, 0.2, accuracy: -0.1)
@@ -30,7 +30,7 @@ class NegativeAccuracyTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started.
-    // CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
+    // CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
     // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
     func test_notEqualWithAccuracy_fails() {
         XCTAssertNotEqualWithAccuracy(1, 2, -1)

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -10,6 +10,32 @@
 
 // Regression test for https://github.com/apple/swift-corelibs-xctest/pull/7
 class NegativeAccuracyTestCase: XCTestCase {
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' started.
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
+    func test_equalWithAccuracy_passes() {
+        XCTAssertEqualWithAccuracy(0, 0.1, accuracy: -0.1)
+    }
+
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started.
+    // CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
+    func test_equalWithAccuracy_fails() {
+        XCTAssertEqualWithAccuracy(0, 0.2, accuracy: -0.1)
+    }
+
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' started.
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
+    func test_notEqualWithAccuracy_passes() {
+        XCTAssertNotEqualWithAccuracy(1, 2, -0.5)
+    }
+
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started.
+    // CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
+    // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
+    func test_notEqualWithAccuracy_fails() {
+        XCTAssertNotEqualWithAccuracy(1, 2, -1)
+    }
+
     static var allTests: [(String, NegativeAccuracyTestCase -> () throws -> Void)] {
         return [
             ("test_equalWithAccuracy_passes", test_equalWithAccuracy_passes),
@@ -18,35 +44,7 @@ class NegativeAccuracyTestCase: XCTestCase {
             ("test_notEqualWithAccuracy_fails", test_notEqualWithAccuracy_fails),
         ]
     }
+} // CHECK: Executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' started.
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
-    func test_equalWithAccuracy_passes() {
-        XCTAssertEqualWithAccuracy(0, 0.1, accuracy: -0.1)
-    }
-
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started.
-// CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
-    func test_equalWithAccuracy_fails() {
-        XCTAssertEqualWithAccuracy(0, 0.2, accuracy: -0.1)
-    }
-
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' started.
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
-    func test_notEqualWithAccuracy_passes() {
-        XCTAssertNotEqualWithAccuracy(1, 2, -0.5)
-    }
-
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started.
-// CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
-    func test_notEqualWithAccuracy_fails() {
-        XCTAssertNotEqualWithAccuracy(1, 2, -1)
-    }
-}
-
-XCTMain([testCase(NegativeAccuracyTestCase.allTests)])
-
-// CHECK: Executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+XCTMain([testCase(NegativeAccuracyTestCase.allTests)])

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -9,21 +9,19 @@
 #endif
 
 class SingleFailingTestCase: XCTestCase {
+    // CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
+    // CHECK: .*/SingleFailingTestCase/main.swift:16: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - $
+    // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
+    func test_fails() {
+        XCTAssert(false)
+    }
+
     static var allTests: [(String, SingleFailingTestCase -> () throws -> Void)] {
         return [
             ("test_fails", test_fails)
         ]
     }
+} // CHECK: Executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-// CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
-// CHECK: .*/SingleFailingTestCase/main.swift:22: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - 
-// CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
-    func test_fails() {
-        XCTAssert(false)
-    }
-}
-
-XCTMain([testCase(SingleFailingTestCase.allTests)])
-
-// CHECK: Executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Total executed 1 test, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+XCTMain([testCase(SingleFailingTestCase.allTests)])

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -10,7 +10,7 @@
 
 class SingleFailingTestCase: XCTestCase {
     // CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
-    // CHECK: .*/SingleFailingTestCase/main.swift:16: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - $
+    // CHECK: .*/SingleFailingTestCase/main.swift:[[@LINE+3]]: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - $
     // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -9,12 +9,6 @@
 #endif
 
 class SetUpTearDownTestCase: XCTestCase {
-    static var allTests: [(String, SetUpTearDownTestCase -> () throws -> Void)] {
-        return [
-            ("test_hasValueFromSetUp", test_hasValueFromSetUp),
-        ]
-    }
-
     var value = 0
 
     override func setUp() {
@@ -28,48 +22,49 @@ class SetUpTearDownTestCase: XCTestCase {
         print("In \(#function)")
     }
 
-// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' started.
-// CHECK: In setUp\(\)
-// CHECK: In test_hasValueFromSetUp\(\)
-// CHECK: In tearDown\(\)
-// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' started.
+    // CHECK: In setUp\(\)
+    // CHECK: In test_hasValueFromSetUp\(\)
+    // CHECK: In tearDown\(\)
+    // CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' passed \(\d+\.\d+ seconds\).
     func test_hasValueFromSetUp() {
         print("In \(#function)")
         XCTAssertEqual(value, 42)
     }
-}
-// CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
+    static var allTests: [(String, SetUpTearDownTestCase -> () throws -> Void)] {
+        return [
+            ("test_hasValueFromSetUp", test_hasValueFromSetUp),
+        ]
+    }
+} // CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 class NewInstanceForEachTestTestCase: XCTestCase {
+    var value = 1
+
+    // CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' started.
+    // CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' passed \(\d+\.\d+ seconds\).
+    func test_hasInitializedValue() {
+        XCTAssertEqual(value, 1)
+        value += 1
+    }
+
+    // CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' started.
+    // CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' passed \(\d+\.\d+ seconds\).
+    func test_hasInitializedValueInAnotherTest() {
+        XCTAssertEqual(value, 1)
+    }
+
     static var allTests: [(String, NewInstanceForEachTestTestCase -> () throws -> Void)] {
         return [
             ("test_hasInitializedValue", test_hasInitializedValue),
             ("test_hasInitializedValueInAnotherTest", test_hasInitializedValueInAnotherTest),
         ]
     }
+} // CHECK: Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
-    var value = 1
-
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' started.
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' passed \(\d+\.\d+ seconds\).
-    func test_hasInitializedValue() {
-        XCTAssertEqual(value, 1)
-        value += 1
-    }
-
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' started.
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' passed \(\d+\.\d+ seconds\).
-    func test_hasInitializedValueInAnotherTest() {
-        XCTAssertEqual(value, 1)
-    }
-}
-// CHECK: Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-
-
+// CHECK: Total executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 XCTMain([
     testCase(SetUpTearDownTestCase.allTests),
     testCase(NewInstanceForEachTestTestCase.allTests)
 ])
-
-// CHECK: Total executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -57,6 +57,11 @@ class CompareTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             compare.compare(actual, expected, check_prefix='c: ')
 
+    def test_line_number_substitution(self):
+        actual = _tmpfile('beep 1\nboop 5\n')
+        expected = _tmpfile('c: beep [[@LINE]]\nc: boop [[@LINE+3]]')
+        compare.compare(actual, expected, check_prefix='c: ')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -46,6 +46,17 @@ class CompareTestCase(unittest.TestCase):
         expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
         compare.compare(actual, expected, check_prefix='c: ')
 
+    def test_match_with_inline_check_does_not_raise(self):
+        actual = _tmpfile('bling\nblong\n')
+        expected = _tmpfile('meep meep // c: bling\nmeep\n// c: blong\n')
+        compare.compare(actual, expected, check_prefix='// c: ')
+
+    def test_check_prefix_twice_in_the_same_line_raises(self):
+        actual = _tmpfile('blorp\n')
+        expected = _tmpfile('c: blorp c: blammo\n')
+        with self.assertRaises(ValueError):
+            compare.compare(actual, expected, check_prefix='c: ')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -10,6 +10,8 @@
 
 import re
 
+from xctest_checker.line import replace_offsets
+
 
 def _actual_lines(path):
     """
@@ -26,10 +28,12 @@ def _expected_lines(path, check_prefix):
     that begins with the given prefix.
     """
     with open(path) as f:
-        for line in f:
+        for line_number, line in enumerate(f):
             components = line.split(check_prefix)
             if len(components) == 2:
-                yield components[1]
+                # Replace line keywords with line number. Note that line
+                # numbers are not zero-indexed, so we add one.
+                yield replace_offsets(components[1], line_number + 1)
             elif len(components) > 2:
                 raise ValueError(
                     'Usage violation: prefix "{}" appears twice in the same '

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -27,8 +27,13 @@ def _expected_lines(path, check_prefix):
     """
     with open(path) as f:
         for line in f:
-            if line.startswith(check_prefix):
-                yield line[len(check_prefix):]
+            components = line.split(check_prefix)
+            if len(components) == 2:
+                yield components[1]
+            elif len(components) > 2:
+                raise ValueError(
+                    'Usage violation: prefix "{}" appears twice in the same '
+                    'line.'.format(check_prefix))
 
 
 def compare(actual, expected, check_prefix):

--- a/Tests/Functional/xctest_checker/xctest_checker/line.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/line.py
@@ -1,0 +1,40 @@
+# xctest_checker/line.py - Replaces [[@LINE]] with line numbers -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import re
+
+
+def replace_offsets(line, line_number):
+    """
+    Replace all line directives in the given line with the given line number.
+
+    Line directives come in two forms:
+    1. "[[@LINE]]", with no offset.
+    2. "[[@LINE+10]]" or "[[@LINE-3]]", with a positive or negative offset.
+    """
+    pattern = re.compile(r'\[\[@LINE(?P<offset>[+-]\d+)?\]\]')
+
+    result = line
+    for match in pattern.finditer(line):
+        offset_string = match.groupdict()['offset']
+        if offset_string is None:
+            offset_string = '0'
+        try:
+            offset = int(offset_string)
+        except ValueError:
+            # Re-raise the error, but with a friendlier explanation of what
+            # went wrong.
+            raise ValueError(
+                'Invalid line offset: "{}". Line offsets must be numerical, '
+                'such as "[[@LINE+10]]" or "[[@LINE-2]]"'.format(
+                    match.group()))
+        result = result.replace(match.group(), str(line_number + offset))
+
+    return result

--- a/Tests/Functional/xctest_checker/xctest_checker/main.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/main.py
@@ -25,10 +25,9 @@ def main():
     parser.add_argument('-p', '--check-prefix',
                         default='// CHECK: ',
                         help='%(prog)s checks actual output against expected '
-                             'output. By default, %(prog)s only checks lines '
-                             'that are prefixed with "%(default)s". This '
-                             'option can be used to change that '
-                             'prefix.')
+                             'output. By default, %(prog)s only checks the '
+                             'the text that follows the prefix "%(default)s". '
+                             'This option can be used to change that prefix.')
     args = parser.parse_args()
     compare.compare(args.actual, args.expected, args.check_prefix)
 

--- a/Tests/Functional/xctest_checker/xctest_checker/main.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/main.py
@@ -24,11 +24,11 @@ def main():
                                          'expected output of an XCTest run.')
     parser.add_argument('-p', '--check-prefix',
                         default='// CHECK: ',
-                        help='{prog} checks actual output against expected '
-                             'output. By default, {prog} only checks lines '
-                             'that are prefixed with "// CHECK: ". This '
+                        help='%(prog)s checks actual output against expected '
+                             'output. By default, %(prog)s only checks lines '
+                             'that are prefixed with "%(default)s". This '
                              'option can be used to change that '
-                             'prefix.'.format(prog=parser.prog))
+                             'prefix.')
     args = parser.parse_args()
     compare.compare(args.actual, args.expected, args.check_prefix)
 


### PR DESCRIPTION
1. Enhance xctest_checker such that it can parse "CHECK" prefixes that are in the middle of a line (instead of just at the very beginning). This allows us to inline the test expectations.
2. Enhance xctest_checker such that it substitutes the string "[[@LINE]]" with the current line number of the source file when performing checks. This mirrors the behavior of FileCheck (although that program also handles "[[@LINE+\<offset\>]]").
3. Inline all checks in the suite, and replace all hardcoded and regex line numbers in the functional test suite with the new substitution.

This allows us to add and remove arbitary lines in the functional test suite without manually updating line numbers! :100: 

For example, the old tests looked like this:

```swift
// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started.
// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:19: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
func test_waitingForAnUnfulfilledExpectation_fails() {
    waitForExpectationsWithTimeout(0.2, handler: nil)
}
```

The new tests look like this (notice we don't hardcode the line number "19"):

```swift
func test_waitingForAnUnfulfilledExpectation_fails() { // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started.
    expectationWithDescription("foo")
    waitForExpectationsWithTimeout(0.2, handler: nil) // CHECK: .*/Asynchronous/Expectations/main.swift:[[@LINE]]: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
} // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
```