### PR TITLE
XCTestObservation and XCTestObservationCenter

### DIFF
--- a/Sources/XCTest/ObjectWrapper.swift
+++ b/Sources/XCTest/ObjectWrapper.swift
@@ -1,0 +1,25 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  ObjectWrapper.swift
+//  Utility type for adapting implementors of a `class` protocol to Hashable
+//
+
+/// A `Hashable` representation of an object and its ObjectIdentifier. This is
+/// useful because Swift classes aren't implicitly hashable based on identity.
+internal struct ObjectWrapper<T>: Hashable {
+    let object: T
+    let objectIdentifier: ObjectIdentifier
+
+    var hashValue: Int { return objectIdentifier.hashValue }
+}
+
+internal func ==<T>(lhs: ObjectWrapper<T>, rhs: ObjectWrapper<T>) -> Bool {
+    return lhs.objectIdentifier == rhs.objectIdentifier
+}

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -26,7 +26,14 @@ public typealias XCTestCaseEntry = (testCaseClass: XCTestCase.Type, allTests: [(
 
 public class XCTestCase {
 
+    /// The name of the test case, consisting of its class name and the method name it will run.
+    /// - Note: FIXME: This property should be readonly, but currently has to be publicly settable due to a
+    ///         toolchain bug on Linux. To ensure compatibility of tests between
+    ///         swift-corelibs-xctest and Apple XCTest, this property should not be modified.
+    public var name: String
+
     public required init() {
+        name = "\(self.dynamicType).<unknown>"
     }
 
     public func setUp() {
@@ -78,19 +85,19 @@ extension XCTestCase {
         let overallDuration = measureTimeExecutingBlock {
             for (name, test) in tests {
                 let testCase = self.init()
-                let fullName = "\(testCase.dynamicType).\(name)"
+                testCase.name = "\(testCase.dynamicType).\(name)"
 
                 var failures = [XCTFailure]()
                 XCTFailureHandler = { failure in
                     if !testCase.continueAfterFailure {
-                        failure.emit(fullName)
+                        failure.emit(testCase.name)
                         fatalError("Terminating execution due to test failure", file: failure.file, line: failure.line)
                     } else {
                         failures.append(failure)
                     }
                 }
 
-                XCTPrint("Test Case '\(fullName)' started.")
+                XCTPrint("Test Case '\(testCase.name)' started.")
 
                 testCase.setUp()
 
@@ -111,7 +118,7 @@ extension XCTestCase {
 
                 var result = "passed"
                 for failure in failures {
-                    failure.emit(fullName)
+                    failure.emit(testCase.name)
                     totalFailures += 1
                     if !failure.expected {
                         unexpectedFailures += 1
@@ -119,8 +126,8 @@ extension XCTestCase {
                     result = failures.count > 0 ? "failed" : "passed"
                 }
 
-                XCTPrint("Test Case '\(fullName)' \(result) (\(printableStringForTimeInterval(duration)) seconds).")
-                XCTAllRuns.append(XCTRun(duration: duration, method: fullName, passed: failures.count == 0, failures: failures))
+                XCTPrint("Test Case '\(testCase.name)' \(result) (\(printableStringForTimeInterval(duration)) seconds).")
+                XCTAllRuns.append(XCTRun(duration: duration, method: testCase.name, passed: failures.count == 0, failures: failures))
                 XCTFailureHandler = nil
             }
         }

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -31,9 +31,11 @@ struct XCTFailure {
     var expected: Bool
     var file: StaticString
     var line: UInt
-    
+
+    var failureMessage: String { return "\(failureDescription) - \(message)" }
+
     func emit(method: String) {
-        XCTPrint("\(file):\(line): \(expected ? "" : "unexpected ")error: \(method) : \(failureDescription) - \(message)")
+        XCTPrint("\(file):\(line): \(expected ? "" : "unexpected ")error: \(method) : \(failureMessage)")
     }
 }
 

--- a/Sources/XCTest/XCTestObservation.swift
+++ b/Sources/XCTest/XCTestObservation.swift
@@ -1,0 +1,44 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestObservation.swift
+//  Hooks for being notified about progress during a test run.
+//
+
+/// `XCTestObservation` provides hooks for being notified about progress during a
+/// test run.
+/// - seealso: `XCTestObservationCenter`
+public protocol XCTestObservation: class {
+    /// Called just before a test begins executing.
+    /// - Parameter testCase: The test case that is about to start. Its `name`
+    ///   property can be used to identify it.
+    func testCaseWillStart(testCase: XCTestCase)
+
+    /// Called when a test failure is reported.
+    /// - Parameter testCase: The test case that failed. Its `name` property 
+    ///   can be used to identify it.
+    /// - Parameter description: Details about the cause of the test failure.
+    /// - Parameter filePath: The path to the source file where the failure
+    ///   was reported, if available.
+    /// - Parameter lineNumber: The line number in the source file where the
+    ///   failure was reported.
+    func testCase(testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt)
+
+    /// Called just after a test finishes executing.
+    /// - Parameter testCase: The test case that finished. Its `name` property 
+    ///   can be used to identify it.
+    func testCaseDidFinish(testCase: XCTestCase)
+}
+
+// All `XCTestObservation` methods are optional, so empty default implementations are provided
+public extension XCTestObservation {
+    func testCaseWillStart(testCase: XCTestCase) {}
+    func testCase(testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {}
+    func testCaseDidFinish(testCase: XCTestCase) {}
+}

--- a/Sources/XCTest/XCTestObservationCenter.swift
+++ b/Sources/XCTest/XCTestObservationCenter.swift
@@ -1,0 +1,64 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestObservationCenter.swift
+//  Notification center for test run progress events.
+//
+
+/// Provides a registry for objects wishing to be informed about progress
+/// during the course of a test run. Observers must implement the
+/// `XCTestObservation` protocol
+/// - seealso: `XCTestObservation`
+public class XCTestObservationCenter {
+
+    private static var center = XCTestObservationCenter()
+    private var observers = Set<ObjectWrapper<XCTestObservation>>()
+
+    /// Registration should be performed on this shared instance
+    public class func sharedTestObservationCenter() -> XCTestObservationCenter {
+        return center
+    }
+
+    /// Register an observer to receive future events during a test run. The order
+    /// in which individual observers are notified about events is undefined.
+    public func addTestObserver(testObserver: XCTestObservation) {
+        observers.insert(testObserver.wrapper)
+    }
+
+    /// Remove a previously-registered observer so that it will no longer receive
+    /// event callbacks.
+    public func removeTestObserver(testObserver: XCTestObservation) {
+        observers.remove(testObserver.wrapper)
+    }
+
+
+    internal func testCaseWillStart(testCase: XCTestCase) {
+        forEachObserver { $0.testCaseWillStart(testCase) }
+    }
+
+    internal func testCase(testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {
+        forEachObserver { $0.testCase(testCase, didFailWithDescription: description, inFile: filePath, atLine: lineNumber) }
+    }
+
+    internal func testCaseDidFinish(testCase: XCTestCase) {
+        forEachObserver { $0.testCaseDidFinish(testCase) }
+    }
+
+    private func forEachObserver(@noescape body: XCTestObservation -> Void) {
+        for observer in observers {
+            body(observer.object)
+        }
+    }
+}
+
+private extension XCTestObservation {
+    var wrapper: ObjectWrapper<XCTestObservation> {
+        return ObjectWrapper(object: self, objectIdentifier: ObjectIdentifier(self))
+    }
+}

--- a/Tests/Functional/Observation/main.swift
+++ b/Tests/Functional/Observation/main.swift
@@ -1,0 +1,74 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Observation
+// RUN: %{built_tests_dir}/Observation > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+#else
+    import SwiftXCTest
+#endif
+
+class Observer: XCTestObservation {
+    var startedTestCaseNames = [String]()
+    var failureDescriptions = [String]()
+    var finishedTestCaseNames = [String]()
+
+    func testCaseWillStart(testCase: XCTestCase) {
+        startedTestCaseNames.append(testCase.name)
+    }
+
+    func testCase(testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {
+        failureDescriptions.append(description)
+    }
+
+    func testCaseDidFinish(testCase: XCTestCase) {
+        finishedTestCaseNames.append(testCase.name)
+    }
+}
+
+let observer = Observer()
+
+class Observation: XCTestCase {
+    static var allTests: [(String, Observation -> () throws -> Void)] {
+        return [
+            ("test_one", test_one),
+            ("test_two", test_two),
+            ("test_three", test_three),
+        ]
+    }
+
+// CHECK: Test Case 'Observation.test_one' started.
+// CHECK: Test Case 'Observation.test_one' passed \(\d+\.\d+ seconds\).
+    func test_one() {
+        XCTAssertEqual(observer.startedTestCaseNames, [])
+        XCTAssertEqual(observer.failureDescriptions, [])
+        XCTAssertEqual(observer.finishedTestCaseNames, [])
+
+        XCTestObservationCenter.sharedTestObservationCenter().addTestObserver(observer)
+    }
+
+// CHECK: Test Case 'Observation.test_two' started.
+// CHECK: .*/Observation/main.swift:\d+: error: Observation.test_two : failed - fail!
+// CHECK: Test Case 'Observation.test_two' failed \(\d+\.\d+ seconds\).
+    func test_two() {
+        XCTAssertEqual(observer.startedTestCaseNames, ["Observation.test_two"])
+        XCTAssertEqual(observer.finishedTestCaseNames,["Observation.test_one"])
+
+        XCTFail("fail!")
+        XCTAssertEqual(observer.failureDescriptions, ["failed - fail!"])
+
+        XCTestObservationCenter.sharedTestObservationCenter().removeTestObserver(observer)
+    }
+
+// CHECK: Test Case 'Observation.test_three' started.
+// CHECK: Test Case 'Observation.test_three' passed \(\d+\.\d+ seconds\).
+    func test_three() {
+        XCTAssertEqual(observer.startedTestCaseNames, ["Observation.test_two"])
+        XCTAssertEqual(observer.finishedTestCaseNames,["Observation.test_one"])
+    }
+}
+
+XCTMain([testCase(Observation.allTests)])
+
+// CHECK: Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		AE7DD6091C8E81A0006FC722 /* ArgumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */; };
 		AE7DD60A1C8E81A0006FC722 /* TestFiltering.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */; };
+		AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */; };
+		AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */; };
+		AE9596E11C9692B8001A9EF0 /* XCTestObservationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */; };
 		C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */; };
 		C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */; };
 		C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */; };
@@ -33,6 +36,9 @@
 		AE7DD6061C8DC6C0006FC722 /* Functional */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Functional; sourceTree = "<group>"; };
 		AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgumentParser.swift; sourceTree = "<group>"; };
 		AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFiltering.swift; sourceTree = "<group>"; };
+		AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestObservation.swift; sourceTree = "<group>"; };
+		AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectWrapper.swift; sourceTree = "<group>"; };
+		AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestObservationCenter.swift; sourceTree = "<group>"; };
 		B1384A411C1B3E8700EDF031 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		B1384A421C1B3E8700EDF031 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		B1384A431C1B3E8700EDF031 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -102,11 +108,14 @@
 			isa = PBXGroup;
 			children = (
 				AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */,
+				AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */,
 				AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */,
 				C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */,
 				C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */,
-				C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */,
 				DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */,
+				C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */,
+				AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */,
+				AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */,
 				C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */,
 				DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */,
 			);
@@ -241,11 +250,14 @@
 			files = (
 				DACC94421C8B87B900EC85F5 /* XCWaitCompletionHandler.swift in Sources */,
 				C265F6731C3AEB6A00520CF9 /* XCTimeUtilities.swift in Sources */,
+				AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */,
 				C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */,
 				DADB979C1C51BDA2005E68B6 /* XCTestExpectation.swift in Sources */,
 				AE7DD60A1C8E81A0006FC722 /* TestFiltering.swift in Sources */,
 				AE7DD6091C8E81A0006FC722 /* ArgumentParser.swift in Sources */,
+				AE9596E11C9692B8001A9EF0 /* XCTestObservationCenter.swift in Sources */,
 				C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */,
+				AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */,
 				C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
As requested by @modocache, here is the start of some work on this missing feature for early review. I'm waiting for the next snapshot to rebase on top of the latest master because I don't have an environment with the new Swift 3 stdlib and corelibs-foundation stuff at this point.

For the `XCTestObservation` protocol, I've only included the methods related to `XCTestCase` at this point, not the bundle or test suite ones. If and when we decide to introduce `XCTestSuite` we can introduce the relevant events at that point.

Note that I haven't touched `XCTestRun` yet which could be added to provide a useful summary (failure count, test case success) in `testCaseDidFinish()`. I do remember that @mike-ferris-apple had [mentioned](https://github.com/apple/swift-corelibs-xctest/pull/40#issuecomment-171766079) avoiding it for some reason, and I was hoping to get an understanding of why that was before starting down that path. I did add `XCTestCase`'s `name` property though, which allows differentiating between instances in the observation callbacks.

Method documentation will also still be needed before this is mergeable! Looking for feedback first though :grinning: 