### PR TITLE
Allow differing leading/trailing whitespace when checking test output

### DIFF
--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -37,7 +37,7 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started.
-// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error - 
+// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error -
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
     func test_shouldButDoesNotThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesNotThrowError())
@@ -60,7 +60,7 @@ class ErrorHandling: XCTestCase {
     }
     
 // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started.
-// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) - 
+// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) -
 // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
     func test_throwsErrorInAssertionButFailsWhenCheckingError() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
@@ -77,7 +77,7 @@ class ErrorHandling: XCTestCase {
     }
     
 // CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' started.
-// CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "AnError\("an error message"\)" - 
+// CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "AnError\("an error message"\)" -
 // CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\).
     func test_canAndDoesThrowErrorFromTestMethod() throws {
         try functionThatDoesThrowError()
@@ -94,7 +94,7 @@ class ErrorHandling: XCTestCase {
     }
     
 // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started.
-// CHECK: .*/ErrorHandling/main.swift:\d+: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" - 
+// CHECK: .*/ErrorHandling/main.swift:\d+: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" -
 // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -2,9 +2,9 @@
 // RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_method || true
 // RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case || true
 // RUN: %{built_tests_dir}/SelectedTest > %T/all || true
-// RUN: %{xctest_checker} -p "// CHECK-METHOD:   " %T/one_test_method %s
-// RUN: %{xctest_checker} -p "// CHECK-TESTCASE: " %T/one_test_case %s
-// RUN: %{xctest_checker} -p "// CHECK-ALL:      " %T/all %s
+// RUN: %{xctest_checker} -p "// CHECK-METHOD:" %T/one_test_method %s
+// RUN: %{xctest_checker} -p "// CHECK-TESTCASE:" %T/one_test_case %s
+// RUN: %{xctest_checker} -p "// CHECK-ALL:" %T/all %s
 
 #if os(Linux) || os(FreeBSD)
     import XCTest
@@ -44,11 +44,11 @@ class SkippedTestCase: XCTestCase {
         return [("test_baz", test_baz)]
     }
 
-// CHECK-ALL:      Test Case 'SkippedTestCase.test_baz' started.
-// CHECK-ALL:      Test Case 'SkippedTestCase.test_baz' passed \(\d+\.\d+ seconds\).
+// CHECK-ALL: Test Case 'SkippedTestCase.test_baz' started.
+// CHECK-ALL: Test Case 'SkippedTestCase.test_baz' passed \(\d+\.\d+ seconds\).
     func test_baz() {}
 }
-// CHECK-ALL:      Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK-ALL: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([
     testCase(ExecutedTestCase.allTests),

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -16,7 +16,7 @@ class SingleFailingTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'SingleFailingTestCase.test_fails' started.
-// CHECK: .*/SingleFailingTestCase/main.swift:22: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed - 
+// CHECK: .*/SingleFailingTestCase/main.swift:22: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
 // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)

--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -54,5 +54,15 @@ class CompareTestCase(unittest.TestCase):
 
         self.assertIn("{}:{}:".format(expected, 2), cm.exception.message)
 
+    def test_matching_ignores_leading_and_trailing_whitespace(self):
+        actual = _tmpfile('foo\nbar\nbaz\n')
+        expected = _tmpfile('c:  foo\nc: bar \nc: baz\n')
+        compare.compare(actual, expected, check_prefix='c:')
+
+    def test_can_explicitly_match_leading_and_trailing_whitespace(self):
+        actual = _tmpfile('foo\n bar\nbaz \n')
+        expected = _tmpfile('c: foo\nc: ^ bar \nc: baz $\n')
+        compare.compare(actual, expected, check_prefix='c:')
+
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -28,8 +28,10 @@ def _expected_lines_and_line_numbers(path, check_prefix):
     with open(path) as f:
         for line_number, line in enumerate(f):
             if line.startswith(check_prefix):
-                yield line[len(check_prefix):], line_number+1
+                yield line[len(check_prefix):].strip(), line_number+1
 
+def _add_whitespace_leniency(original_regex):
+    return "^ *" + original_regex + " *$"
 
 def compare(actual, expected, check_prefix):
     """
@@ -52,7 +54,7 @@ def compare(actual, expected, check_prefix):
 
         (expected_line, expectation_source_line_number) = expected_line_and_line_number
 
-        if not re.match(expected_line, actual_line):
+        if not re.match(_add_whitespace_leniency(expected_line), actual_line):
             raise AssertionError('Actual line did not match the expected '
                                  'regular expression.\n'
                                  '{}:{}: Actual: {}\n'

--- a/Tests/Functional/xctest_checker/xctest_checker/main.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/main.py
@@ -23,12 +23,14 @@ def main():
     parser.add_argument('expected', help='A path to a file containing the '
                                          'expected output of an XCTest run.')
     parser.add_argument('-p', '--check-prefix',
-                        default='// CHECK: ',
+                        default='// CHECK:',
                         help='{prog} checks actual output against expected '
                              'output. By default, {prog} only checks lines '
-                             'that are prefixed with "// CHECK: ". This '
+                             'that are prefixed with "// CHECK:". This '
                              'option can be used to change that '
-                             'prefix.'.format(prog=parser.prog))
+                             'prefix. Leading and trailing whitespace is '
+                             'ignored unless the check line contains explicit '
+                             '^ or $ characters'.format(prog=parser.prog))
     args = parser.parse_args()
     compare.compare(args.actual, args.expected, args.check_prefix)
 


### PR DESCRIPTION
There are two situations lately where I've been finding myself fighting the testing framework's current strictness with respect to whitespace at the beginning and end of lines:

1. [Here](https://github.com/apple/swift-corelibs-xctest/pull/64/files#diff-ed8e21c5d2f214bfdc63dde56bcf7930R47), I had to include some awkward whitespace after the `// CHECK-ALL:` prefix, in order to also be able to keep things nicely lined up on lines like [this](https://github.com/briancroom/swift-corelibs-xctest/blob/select-test/Tests/Functional/SelectedTest/main.swift#L27).
2. Whenever dealing with lines like [this one](https://github.com/apple/swift-corelibs-xctest/blob/master/Tests/Functional/SingleFailingTestCase/main.swift#L19), Xcode likes to trim the trailing space, which results in a test failure that is very difficult to understand because the difference between the lines is effectively invisible.

As I see it, we don't have any tests right now for which precise matching of leading/trailing whitespace is important, and I don't foresee any such tests coming up either, so it seems that this change will make the test checker a little easier to work with. On the other hand if there are concerns about this, we could also add a flag for turning this behavior off and on.