### PR TITLE
Allow Xcode to highlight failing functional test expectations

### DIFF
--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -36,6 +36,13 @@ class CompareTestCase(unittest.TestCase):
         expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
         compare.compare(actual, expected, check_prefix='c: ')
 
+    def test_includes_file_name_and_line_of_expected_in_error(self):
+        actual = _tmpfile('foo\nbar\nbaz\n')
+        expected = _tmpfile('c: foo\nc: baz\nc: bar\n')
+        with self.assertRaises(AssertionError) as cm:
+            compare.compare(actual, expected, check_prefix='c: ')
+
+        self.assertIn("{}:{}:".format(expected, 2), cm.exception.message)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -10,15 +10,15 @@ def _actual_lines(path):
             yield line
 
 
-def _expected_lines(path, check_prefix):
+def _expected_lines_and_line_numbers(path, check_prefix):
     """
     Returns a generator that yields each line in the file at the given path
     that begins with the given prefix.
     """
     with open(path) as f:
-        for line in f:
+        for line_number, line in enumerate(f):
             if line.startswith(check_prefix):
-                yield line[len(check_prefix):]
+                yield line[len(check_prefix):], line_number+1
 
 
 def compare(actual, expected, check_prefix):
@@ -28,19 +28,23 @@ def compare(actual, expected, check_prefix):
     file, raises an AssertionError. Also raises an AssertionError if the number
     of lines in the two files differ.
     """
-    for actual_line, expected_line in map(
+    for actual_line, expected_line_and_line_number in map(
             None,
             _actual_lines(actual),
-            _expected_lines(expected, check_prefix)):
+            _expected_lines_and_line_numbers(expected, check_prefix)):
+
         if actual_line is None:
             raise AssertionError('There were more lines expected to appear '
                                  'than there were lines in the actual input.')
-        if expected_line is None:
+        if expected_line_and_line_number is None:
             raise AssertionError('There were more lines than expected to '
                                  'appear.')
+
+        (expected_line, expectation_source_line_number) = expected_line_and_line_number
+
         if not re.match(expected_line, actual_line):
             raise AssertionError('Actual line did not match the expected '
                                  'regular expression.\n'
-                                 'Actual: {}\n'
+                                 '{}:{}: Actual: {}\n'
                                  'Expected: {}\n'.format(
-                                     repr(actual_line), repr(expected_line)))
+                                     expected, expectation_source_line_number, repr(actual_line), repr(expected_line)))


### PR DESCRIPTION
As a part of our continuing attempts to improve the quality of the functional test suite, I was hoping to improve the way that the test failure output integrates with Xcode.

Here, I have amended failure output to include the file name and line number where the `// CHECK:` line came from. Xcode is able to use this information to mark the line in the editor as containing an error, like so:

<img width="1123" alt="screen shot 2016-03-11 at 11 13 37 pm" src="https://cloud.githubusercontent.com/assets/1062518/13717003/efce6e7a-e7de-11e5-9ab2-85624c76857e.png">

This makes it easier to diagnose failures in the editor itself, without needing to jump over to the build log to examine the raw output from `xctest_checker`