### PR TITLE
[Python] Add flake8 config

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[flake8]
+filename = *.py
+max-line-length = 80

--- a/build_script.py
+++ b/build_script.py
@@ -18,8 +18,10 @@ import tempfile
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 def note(msg):
     print("xctest-build: "+msg)
+
 
 def run(command):
     note(command)


### PR DESCRIPTION
In https://github.com/apple/swift/pull/1153, @practicalswift added a flake8 config to the Swift project, in order to lint the Python scripts used by that project. This does the same for XCTest.

This includes all the linting rules active on the main Swift repository. It also includes tweaks to `build_script.py`, which bring this project in full compliance with those linting rules.

To lint the Python code in the project:

    $ flake8

To install flake8:

    $ pip install flake8

See https://flake8.readthedocs.org/en/latest/ for details.