### PR TITLE
TimeInterval -> NSTimeInterval

### DIFF
--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -14,8 +14,10 @@
 
 #if os(Linux) || os(FreeBSD)
 import Glibc
+import Foundation
 #else
 import Darwin
+import SwiftFoundation
 #endif
 
 internal func XCTPrint(message: String) {
@@ -36,7 +38,7 @@ struct XCTFailure {
 }
 
 internal struct XCTRun {
-    var duration: TimeInterval
+    var duration: NSTimeInterval
     var method: String
     var passed: Bool
     var failures: [XCTFailure]

--- a/Sources/XCTest/XCTimeUtilities.swift
+++ b/Sources/XCTest/XCTimeUtilities.swift
@@ -13,24 +13,24 @@
 
 #if os(Linux) || os(FreeBSD)
     import Glibc
+    import Foundation
 #else
     import Darwin
+    import SwiftFoundation
 #endif
 
-internal typealias TimeInterval = Double
-
 /// Returns the number of seconds since the reference time as a Double.
-private func currentTimeIntervalSinceReferenceTime() -> TimeInterval {
+private func currentTimeIntervalSinceReferenceTime() -> NSTimeInterval {
     var tv = timeval()
-    let currentTime = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> TimeInterval in
+    let currentTime = withUnsafeMutablePointer(&tv, { (t: UnsafeMutablePointer<timeval>) -> NSTimeInterval in
         gettimeofday(t, nil)
-        return TimeInterval(t.pointee.tv_sec) + TimeInterval(t.pointee.tv_usec) / 1000000.0
+        return NSTimeInterval(t.pointee.tv_sec) + NSTimeInterval(t.pointee.tv_usec) / 1000000.0
     })
     return currentTime
 }
 
 /// Execute the given block and return the time spent during execution
-internal func measureTimeExecutingBlock(@noescape block: () -> Void) -> TimeInterval {
+internal func measureTimeExecutingBlock(@noescape block: () -> Void) -> NSTimeInterval {
     let start = currentTimeIntervalSinceReferenceTime()
     block()
     let end = currentTimeIntervalSinceReferenceTime()
@@ -39,6 +39,6 @@ internal func measureTimeExecutingBlock(@noescape block: () -> Void) -> TimeInte
 }
 
 /// Returns a string version of the given time interval rounded to no more than 3 decimal places.
-internal func printableStringForTimeInterval(timeInterval: TimeInterval) -> String {
+internal func printableStringForTimeInterval(timeInterval: NSTimeInterval) -> String {
     return String(round(timeInterval * 1000.0) / 1000.0)
 }


### PR DESCRIPTION
`NSTimeInterval` is already in use in some places from @modocache's async testing work. Now that we have the Foundation dependency, we should take advantage of it and use `NSTimeInterval` consistently instead of re-declaring our own.