### PR TITLE
Added backticks in a comment.

### DIFF
--- a/Sources/XCTest/ObjectWrapper.swift
+++ b/Sources/XCTest/ObjectWrapper.swift
@@ -11,7 +11,7 @@
 //  Utility type for adapting implementors of a `class` protocol to Hashable
 //
 
-/// A `Hashable` representation of an object and its ObjectIdentifier. This is
+/// A `Hashable` representation of an object and its `ObjectIdentifier`. This is
 /// useful because Swift classes aren't implicitly hashable based on identity.
 internal struct ObjectWrapper<T>: Hashable {
     let object: T

--- a/Sources/XCTest/ObjectWrapper.swift
+++ b/Sources/XCTest/ObjectWrapper.swift
@@ -8,7 +8,7 @@
 //
 //
 //  ObjectWrapper.swift
-//  Utility type for adapting implementors of a `class` protocol to Hashable
+//  Utility type for adapting implementors of a `class` protocol to `Hashable`
 //
 
 /// A `Hashable` representation of an object and its `ObjectIdentifier`. This is


### PR DESCRIPTION
`ObjectIdentifier` refers to a specific Swift structure. To make this clear, I have added backticks around it's occurrence in a comment.