### PR TITLE
Added a line break.

### DIFF
--- a/Sources/XCTest/TestFiltering.swift
+++ b/Sources/XCTest/TestFiltering.swift
@@ -68,7 +68,8 @@ private extension SelectedTest {
         case 2:
             testCaseName = components[0]
             testName = components[1]
-        default: return nil
+        default:
+            return nil
         }
     }
 


### PR DESCRIPTION
Moved the `return nil` statement of a `default` switch-case to a new line, as this fits the pattern of the other cases.