### PR TITLE
[XCTestObservation] Add test bundle observation

### DIFF
--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -79,6 +79,10 @@ internal struct XCTRun {
 /// - Parameter testCases: An array of test cases run, each produced by a call to the `testCase` function
 /// - seealso: `testCase`
 @noreturn public func XCTMain(testCases: [XCTestCaseEntry]) {
+    let observationCenter = XCTestObservationCenter.sharedTestObservationCenter()
+    let testBundle = NSBundle.mainBundle()
+    observationCenter.testBundleWillStart(testBundle)
+
     let filter = TestFiltering()
 
     let overallDuration = measureTimeExecutingBlock {
@@ -99,6 +103,7 @@ internal struct XCTRun {
     }
 
     XCTPrint("Total executed \(XCTAllRuns.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(totalUnexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
+    observationCenter.testBundleDidFinish(testBundle)
     exit(totalFailures > 0 ? 1 : 0)
 }
 

--- a/Sources/XCTest/XCTestObservation.swift
+++ b/Sources/XCTest/XCTestObservation.swift
@@ -11,10 +11,22 @@
 //  Hooks for being notified about progress during a test run.
 //
 
+#if os(Linux) || os(FreeBSD)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
 /// `XCTestObservation` provides hooks for being notified about progress during a
 /// test run.
 /// - seealso: `XCTestObservationCenter`
 public protocol XCTestObservation: class {
+
+    /// Sent immediately before tests begin as a hook for any pre-testing setup.
+    /// - Parameter testBundle: The bundle containing the tests that were
+    ///   executed.
+    func testBundleWillStart(testBundle: NSBundle)
+
     /// Called just before a test begins executing.
     /// - Parameter testCase: The test case that is about to start. Its `name`
     ///   property can be used to identify it.
@@ -34,6 +46,15 @@ public protocol XCTestObservation: class {
     /// - Parameter testCase: The test case that finished. Its `name` property 
     ///   can be used to identify it.
     func testCaseDidFinish(testCase: XCTestCase)
+
+    /// Sent immediately after all tests have finished as a hook for any
+    /// post-testing activity. The test process will generally exit after this
+    /// method returns, so if there is long running and/or asynchronous work to
+    /// be done after testing, be sure to implement this method in a way that
+    /// it blocks until all such activity is complete.
+    /// - Parameter testBundle: The bundle containing the tests that were
+    ///   executed.
+    func testBundleDidFinish(testBundle: NSBundle)
 }
 
 // All `XCTestObservation` methods are optional, so empty default implementations are provided

--- a/Sources/XCTest/XCTestObservationCenter.swift
+++ b/Sources/XCTest/XCTestObservationCenter.swift
@@ -11,6 +11,12 @@
 //  Notification center for test run progress events.
 //
 
+#if os(Linux) || os(FreeBSD)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
 /// Provides a registry for objects wishing to be informed about progress
 /// during the course of a test run. Observers must implement the
 /// `XCTestObservation` protocol
@@ -37,6 +43,9 @@ public class XCTestObservationCenter {
         observers.remove(testObserver.wrapper)
     }
 
+    internal func testBundleWillStart(testBundle: NSBundle) {
+        forEachObserver { $0.testBundleWillStart(testBundle) }
+    }
 
     internal func testCaseWillStart(testCase: XCTestCase) {
         forEachObserver { $0.testCaseWillStart(testCase) }
@@ -48,6 +57,10 @@ public class XCTestObservationCenter {
 
     internal func testCaseDidFinish(testCase: XCTestCase) {
         forEachObserver { $0.testCaseDidFinish(testCase) }
+    }
+
+    internal func testBundleDidFinish(testBundle: NSBundle) {
+        forEachObserver { $0.testBundleDidFinish(testBundle) }
     }
 
     private func forEachObserver(@noescape body: XCTestObservation -> Void) {


### PR DESCRIPTION
Apple XCTest defines more methods on its XCTestObservation than swift-corelibs-xctest does. Here we add two of these missing methods:

- `testBundleWillStart()`
- `testBundleDidFinish()`

The documentation for the two methods is taken from Apple XCTest's headers.