### PR TITLE
[XCTestObservation] Replace sharedTestObservationCenter with shared

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -82,7 +82,7 @@ extension XCTestCase {
     }
 
     internal static func invokeTests(tests: [(String, XCTestCase throws -> Void)]) {
-        let observationCenter = XCTestObservationCenter.sharedTestObservationCenter()
+        let observationCenter = XCTestObservationCenter.shared()
 
         var totalDuration = 0.0
         var totalFailures = 0

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -79,7 +79,7 @@ internal struct XCTRun {
 /// - Parameter testCases: An array of test cases run, each produced by a call to the `testCase` function
 /// - seealso: `testCase`
 @noreturn public func XCTMain(testCases: [XCTestCaseEntry]) {
-    let observationCenter = XCTestObservationCenter.sharedTestObservationCenter()
+    let observationCenter = XCTestObservationCenter.shared()
     let testBundle = NSBundle.mainBundle()
     observationCenter.testBundleWillStart(testBundle)
 

--- a/Sources/XCTest/XCTestObservationCenter.swift
+++ b/Sources/XCTest/XCTestObservationCenter.swift
@@ -27,7 +27,7 @@ public class XCTestObservationCenter {
     private var observers = Set<ObjectWrapper<XCTestObservation>>()
 
     /// Registration should be performed on this shared instance
-    public class func sharedTestObservationCenter() -> XCTestObservationCenter {
+    public class func shared() -> XCTestObservationCenter {
         return center
     }
 

--- a/Tests/Functional/Observation/main.swift
+++ b/Tests/Functional/Observation/main.swift
@@ -39,7 +39,7 @@ class Observer: XCTestObservation {
 }
 
 let observer = Observer()
-XCTestObservationCenter.sharedTestObservationCenter().addTestObserver(observer)
+XCTestObservationCenter.shared().addTestObserver(observer)
 
 class Observation: XCTestCase {
     static var allTests: [(String, Observation -> () throws -> Void)] {
@@ -72,7 +72,7 @@ class Observation: XCTestCase {
         XCTAssertEqual(observer.finishedTestCaseNames,["Observation.test_one"])
         XCTAssertEqual(observer.finishedBundlePaths.count, 0)
 
-        XCTestObservationCenter.sharedTestObservationCenter().removeTestObserver(observer)
+        XCTestObservationCenter.shared().removeTestObserver(observer)
     }
 
 // CHECK: Test Case 'Observation.test_three' started.
@@ -83,7 +83,7 @@ class Observation: XCTestCase {
         XCTAssertEqual(observer.finishedTestCaseNames,["Observation.test_one"])
         XCTAssertEqual(observer.finishedBundlePaths.count, 0)
 
-        XCTestObservationCenter.sharedTestObservationCenter().addTestObserver(observer)
+        XCTestObservationCenter.shared().addTestObserver(observer)
     }
 }
 


### PR DESCRIPTION
Replaced `sharedTestObservationCenter` with `shared` as described in https://bugs.swift.org/browse/SR-1063.