### PR TITLE
General Code Overhaul

### DIFF
--- a/Sources/XCTest/TestFiltering.swift
+++ b/Sources/XCTest/TestFiltering.swift
@@ -40,7 +40,7 @@ internal struct TestFiltering {
             .map { testCase, tests in
                 return (testCase, tests.filter { filter(testCase, $0.0) } )
             }
-            .filter { testCase, tests in
+            .filter { _, tests in
                 return !tests.isEmpty
             }
     }

--- a/Sources/XCTest/XCTAssert.swift
+++ b/Sources/XCTest/XCTAssert.swift
@@ -27,7 +27,7 @@ private enum _XCTAssertion {
     case ThrowsError
 
     var name: String? {
-        switch(self) {
+        switch self {
         case .Equal: return "XCTAssertEqual"
         case .EqualWithAccuracy: return "XCTAssertEqualWithAccuracy"
         case .GreaterThan: return "XCTAssertGreaterThan"
@@ -353,22 +353,14 @@ public func XCTAssertNotEqualWithAccuracy<T: FloatingPoint>(@autoclosure express
 public func XCTAssertNotNil(@autoclosure expression: () throws -> Any?, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.NotNil, message: message, file: file, line: line) {
         let value = try expression()
-        if value != nil {
-            return .Success
-        } else {
-            return .ExpectedFailure(nil)
-        }
+        return value != nil ? .Success : ExpectedFailure(nil)
     }
 }
 
 public func XCTAssertTrue(@autoclosure expression: () throws -> Boolean, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.True, message: message, file: file, line: line) {
         let value = try expression()
-        if value.boolValue {
-            return .Success
-        } else {
-            return .ExpectedFailure(nil)
-        }
+        return value.boolValue ? .Success : .ExpectedFailure(nil)
     }
 }
 

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -92,7 +92,7 @@ extension XCTestCase {
                 let testCase = self.init()
                 testCase.name = "\(testCase.dynamicType).\(name)"
 
-                var failures = [XCTFailure]()
+                var failures: [XCTFailure] = []
                 XCTFailureHandler = { failure in
                     observationCenter.testCase(testCase,
                                                didFailWithDescription: failure.failureMessage,
@@ -146,8 +146,8 @@ extension XCTestCase {
             }
         }
 
-        let testCountSuffix = (tests.count == 1) ? "" : "s"
-        let failureSuffix = (totalFailures == 1) ? "" : "s"
+        let testCountSuffix = tests.count == 1 ? "" : "s"
+        let failureSuffix = totalFailures == 1 ? "" : "s"
 
         XCTPrint("Executed \(tests.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(unexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
     }
@@ -155,16 +155,16 @@ extension XCTestCase {
     /// It is an API violation to create expectations but not wait for them to
     /// be completed. Notify the user of a mistake via a test failure.
     private func failIfExpectationsNotWaitedFor(expectations: [XCTestExpectation]) {
-        if expectations.count > 0 {
-            let failure = XCTFailure(
-                message: "Failed due to unwaited expectations.",
-                failureDescription: "",
-                expected: false,
-                file: expectations.last!.file,
-                line: expectations.last!.line)
-            if let failureHandler = XCTFailureHandler {
-                failureHandler(failure)
-            }
+        guard expectations.count > 0 else { return }
+        
+        let failure = XCTFailure(
+            message: "Failed due to unwaited expectations.",
+            failureDescription: "",
+            expected: false,
+            file: expectations.last!.file,
+            line: expectations.last!.line)
+        if let failureHandler = XCTFailureHandler {
+            failureHandler(failure)
         }
     }
 
@@ -248,7 +248,7 @@ extension XCTestCase {
         // expectation. We gather them into this array, which is also used
         // to determine failure--a non-empty array meets expectations weren't
         // met.
-        var unfulfilledDescriptions = [String]()
+        var unfulfilledDescriptions: [String] = []
 
         // We continue checking whether expectations have been fulfilled until
         // the specified timeout has been reached.

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -45,7 +45,7 @@ internal struct XCTRun {
     var passed: Bool
     var failures: [XCTFailure]
     var unexpectedFailures: [XCTFailure] {
-        get { return failures.filter({ failure -> Bool in failure.expected == false }) }
+        return failures.filter { failure -> Bool in failure.expected == false }
     }
 }
 
@@ -93,14 +93,8 @@ internal struct XCTRun {
 
     let (totalDuration, totalFailures, totalUnexpectedFailures) = XCTAllRuns.reduce((0.0, 0, 0)) { totals, run in (totals.0 + run.duration, totals.1 + run.failures.count, totals.2 + run.unexpectedFailures.count) }
     
-    var testCountSuffix = "s"
-    if XCTAllRuns.count == 1 {
-        testCountSuffix = ""
-    }
-    var failureSuffix = "s"
-    if totalFailures == 1 {
-        failureSuffix = ""
-    }
+    let testCountSuffix = XCTAllRuns.count == 1 ? "" : "s"
+    let failureSuffix = totalFailures == 1 ? "" : "s"
 
     XCTPrint("Total executed \(XCTAllRuns.count) test\(testCountSuffix), with \(totalFailures) failure\(failureSuffix) (\(totalUnexpectedFailures) unexpected) in \(printableStringForTimeInterval(totalDuration)) (\(printableStringForTimeInterval(overallDuration))) seconds")
     observationCenter.testBundleDidFinish(testBundle)
@@ -108,4 +102,4 @@ internal struct XCTRun {
 }
 
 internal var XCTFailureHandler: (XCTFailure -> Void)?
-internal var XCTAllRuns = [XCTRun]()
+internal var XCTAllRuns: [XCTRun] = []

--- a/Sources/XCTest/XCTestObservationCenter.swift
+++ b/Sources/XCTest/XCTestObservationCenter.swift
@@ -24,7 +24,7 @@
 public class XCTestObservationCenter {
 
     private static var center = XCTestObservationCenter()
-    private var observers = Set<ObjectWrapper<XCTestObservation>>()
+    private var observers: Set<ObjectWrapper<XCTestObservation>> = []
 
     /// Registration should be performed on this shared instance
     public class func sharedTestObservationCenter() -> XCTestObservationCenter {

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -10,9 +10,7 @@
 
 class PassingTestCase: XCTestCase {
     static var allTests: [(String, PassingTestCase -> () throws -> Void)] {
-        return [
-            ("test_passes", test_passes),
-        ]
+        return [("test_passes", test_passes)]
     }
 
 // CHECK: Test Case 'PassingTestCase.test_passes' started.
@@ -29,7 +27,7 @@ class FailingTestCase: XCTestCase {
         return [
             ("test_passes", test_passes),
             ("test_fails", test_fails),
-            ("test_fails_with_message", test_fails_with_message),
+            ("test_fails_with_message", test_fails_with_message)
         ]
     }
 
@@ -58,7 +56,7 @@ class FailingTestCase: XCTestCase {
 
 XCTMain([
     testCase(PassingTestCase.allTests),
-    testCase(FailingTestCase.allTests),
+    testCase(FailingTestCase.allTests)
 ])
 
 // CHECK: Total executed 4 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -33,7 +33,7 @@ class FailureMessagesTestCase: XCTestCase {
             ("testAssertNotEqualWithAccuracy", testAssertNotEqualWithAccuracy),
             ("testAssertNotNil", testAssertNotNil),
             ("testAssertTrue", testAssertTrue),
-            ("testFail", testFail),
+            ("testFail", testFail)
         ]
     }
 
@@ -76,7 +76,7 @@ class FailureMessagesTestCase: XCTestCase {
 // CHECK: test.swift:79: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertEqualDictionaries() {
-        XCTAssertEqual([1:2], [3:4], "message", file: "test.swift")
+        XCTAssertEqual([1: 2], [3: 4], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started.
@@ -160,7 +160,7 @@ class FailureMessagesTestCase: XCTestCase {
 // CHECK: test.swift:163: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualDictionaries() {
-        XCTAssertNotEqual([1:1], [1:1], "message", file: "test.swift")
+        XCTAssertNotEqual([1: 1], [1: 1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started.

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -15,7 +15,7 @@ class NegativeAccuracyTestCase: XCTestCase {
             ("test_equalWithAccuracy_passes", test_equalWithAccuracy_passes),
             ("test_equalWithAccuracy_fails", test_equalWithAccuracy_fails),
             ("test_notEqualWithAccuracy_passes", test_notEqualWithAccuracy_passes),
-            ("test_notEqualWithAccuracy_fails", test_notEqualWithAccuracy_fails),
+            ("test_notEqualWithAccuracy_fails", test_notEqualWithAccuracy_fails)
         ]
     }
 

--- a/Tests/Functional/Observation/main.swift
+++ b/Tests/Functional/Observation/main.swift
@@ -11,11 +11,11 @@
 #endif
 
 class Observer: XCTestObservation {
-    var startedBundlePaths = [String]()
-    var startedTestCaseNames = [String]()
-    var failureDescriptions = [String]()
-    var finishedTestCaseNames = [String]()
-    var finishedBundlePaths = [String]()
+    var startedBundlePaths: [String] = []
+    var startedTestCaseNames: [String] = []
+    var failureDescriptions: [String] = []
+    var finishedTestCaseNames: [String] = []
+    var finishedBundlePaths: [String] = []
 
     func testBundleWillStart(testBundle: NSBundle) {
         startedBundlePaths.append(testBundle.bundlePath)
@@ -46,7 +46,7 @@ class Observation: XCTestCase {
         return [
             ("test_one", test_one),
             ("test_two", test_two),
-            ("test_three", test_three),
+            ("test_three", test_three)
         ]
     }
 

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -16,7 +16,7 @@ class ExecutedTestCase: XCTestCase {
     static var allTests: [(String, ExecutedTestCase -> () throws -> Void)] {
         return [
             ("test_bar", test_bar),
-            ("test_foo", test_foo),
+            ("test_foo", test_foo)
         ]
     }
 
@@ -26,18 +26,19 @@ class ExecutedTestCase: XCTestCase {
 // CHECK-TESTCASE: Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\).
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' started.
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\).
-    func test_bar() {}
+    func test_bar() {
+    }
 
 // CHECK-TESTCASE: Test Case 'ExecutedTestCase.test_foo' started.
 // CHECK-TESTCASE: Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' started.
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
-    func test_foo() {}
+    func test_foo() {
+    }
 }
 // CHECK-METHOD:   Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-TESTCASE: Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-ALL:      Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-
 
 class SkippedTestCase: XCTestCase {
     static var allTests: [(String, SkippedTestCase -> () throws -> Void)] {
@@ -46,13 +47,14 @@ class SkippedTestCase: XCTestCase {
 
 // CHECK-ALL: Test Case 'SkippedTestCase.test_baz' started.
 // CHECK-ALL: Test Case 'SkippedTestCase.test_baz' passed \(\d+\.\d+ seconds\).
-    func test_baz() {}
+    func test_baz() {
+    }
 }
 // CHECK-ALL: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([
     testCase(ExecutedTestCase.allTests),
-    testCase(SkippedTestCase.allTests),
+    testCase(SkippedTestCase.allTests)
 ])
 
 // CHECK-METHOD:   Total executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -10,9 +10,7 @@
 
 class SingleFailingTestCase: XCTestCase {
     static var allTests: [(String, SingleFailingTestCase -> () throws -> Void)] {
-        return [
-            ("test_fails", test_fails)
-        ]
+        return [("test_fails", test_fails)]
     }
 
 // CHECK: Test Case 'SingleFailingTestCase.test_fails' started.

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -10,9 +10,7 @@
 
 class SetUpTearDownTestCase: XCTestCase {
     static var allTests: [(String, SetUpTearDownTestCase -> () throws -> Void)] {
-        return [
-            ("test_hasValueFromSetUp", test_hasValueFromSetUp),
-        ]
+        return [("test_hasValueFromSetUp", test_hasValueFromSetUp)]
     }
 
     var value = 0
@@ -45,7 +43,7 @@ class NewInstanceForEachTestTestCase: XCTestCase {
     static var allTests: [(String, NewInstanceForEachTestTestCase -> () throws -> Void)] {
         return [
             ("test_hasInitializedValue", test_hasInitializedValue),
-            ("test_hasInitializedValueInAnotherTest", test_hasInitializedValueInAnotherTest),
+            ("test_hasInitializedValueInAnotherTest", test_hasInitializedValueInAnotherTest)
         ]
     }
 


### PR DESCRIPTION
In this pull request I went through every .swift file in XCTest, and updated the code if appropriate.
This includes reformatting, switching from `if` to `guard`, utilizing the ternary operator, switching from `var` to `let`, and fixing problems with array literals, which should have caused compilation errors.

For the details on each file, check the commit's description.