### PR TITLE
[XCTestObservation] Add XCTestSuite announcements

### DIFF
--- a/Sources/XCTest/XCAbstractTest.swift
+++ b/Sources/XCTest/XCAbstractTest.swift
@@ -1,0 +1,36 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCAbstractTest.swift
+//  An abstract base class that XCTestCase and XCTestSuite inherit from.
+//  The purpose of this class is to mirror the design of Apple XCTest.
+//
+
+/// An abstract base class for testing. `XCTestCase` and `XCTestSuite` extend
+/// `XCTest` to provide for creating, managing, and executing tests. Most
+/// developers will not need to subclass `XCTest` directly.
+public class XCTest {
+    /// Test's name. Must be overridden by subclasses.
+    public var name: String {
+        fatalError("Must be overridden by subclasses.")
+    }
+
+    /// Number of test cases. Must be overridden by subclasses.
+    public var testCaseCount: UInt {
+        fatalError("Must be overridden by subclasses.")
+    }
+
+    /// Setup method called before the invocation of each test method in the
+    /// class.
+    public func setUp() {}
+
+    /// Teardown method called after the invocation of each test method in the
+    /// class.
+    public func tearDown() {}
+}

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -24,23 +24,23 @@
 /// - seealso: `XCTMain`
 public typealias XCTestCaseEntry = (testCaseClass: XCTestCase.Type, allTests: [(String, XCTestCase throws -> Void)])
 
-public class XCTestCase {
+public class XCTestCase: XCTest {
 
-    /// The name of the test case, consisting of its class name and the method name it will run.
-    /// - Note: FIXME: This property should be readonly, but currently has to be publicly settable due to a
-    ///         toolchain bug on Linux. To ensure compatibility of tests between
-    ///         swift-corelibs-xctest and Apple XCTest, this property should not be modified.
-    ///         See https://bugs.swift.org/browse/SR-1129 for details.
-    public var name: String
-
-    public required init() {
-        name = "\(self.dynamicType).<unknown>"
+    /// The name of the test case, consisting of its class name and the method
+    /// name it will run.
+    public override var name: String {
+        return _name
     }
+    /// A private setter for the name of this test case.
+    /// - Note: FIXME: This property should be readonly, but currently has to
+    ///   be publicly settable due to a Swift compiler bug on Linux. To ensure
+    ///   compatibility of tests between swift-corelibs-xctest and Apple XCTest,
+    ///   this property should not be modified. See
+    ///   https://bugs.swift.org/browse/SR-1129 for details.
+    public var _name: String
 
-    public func setUp() {
-    }
-
-    public func tearDown() {
+    public required override init() {
+        _name = "\(self.dynamicType).<unknown>"
     }
 }
 
@@ -91,7 +91,7 @@ extension XCTestCase {
         let overallDuration = measureTimeExecutingBlock {
             for (name, test) in tests {
                 let testCase = self.init()
-                testCase.name = "\(testCase.dynamicType).\(name)"
+                testCase._name = "\(testCase.dynamicType).\(name)"
 
                 var failures = [XCTFailure]()
                 XCTFailureHandler = { failure in

--- a/Sources/XCTest/XCTestObservation.swift
+++ b/Sources/XCTest/XCTestObservation.swift
@@ -27,6 +27,11 @@ public protocol XCTestObservation: class {
     ///   executed.
     func testBundleWillStart(testBundle: NSBundle)
 
+    /// Sent when a test suite starts executing.
+    /// - Parameter testSuite: The test suite that started. Additional
+    ///   information can be retrieved from the associated XCTestRun.
+    func testSuiteWillStart(testSuite: XCTestSuite)
+
     /// Called just before a test begins executing.
     /// - Parameter testCase: The test case that is about to start. Its `name`
     ///   property can be used to identify it.
@@ -47,6 +52,11 @@ public protocol XCTestObservation: class {
     ///   can be used to identify it.
     func testCaseDidFinish(testCase: XCTestCase)
 
+    /// Sent when a test suite finishes executing.
+    /// - Parameter testSuite: The test suite that finished. Additional
+    ///   information can be retrieved from the associated XCTestRun.
+    func testSuiteDidFinish(testSuite: XCTestSuite)
+
     /// Sent immediately after all tests have finished as a hook for any
     /// post-testing activity. The test process will generally exit after this
     /// method returns, so if there is long running and/or asynchronous work to
@@ -59,7 +69,11 @@ public protocol XCTestObservation: class {
 
 // All `XCTestObservation` methods are optional, so empty default implementations are provided
 public extension XCTestObservation {
+    func testBundleWillStart(testBundle: NSBundle) {}
+    func testSuiteWillStart(testSuite: XCTestSuite) {}
     func testCaseWillStart(testCase: XCTestCase) {}
     func testCase(testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {}
     func testCaseDidFinish(testCase: XCTestCase) {}
+    func testSuiteDidFinish(testSuite: XCTestSuite) {}
+    func testBundleDidFinish(testBundle: NSBundle) {}
 }

--- a/Sources/XCTest/XCTestObservationCenter.swift
+++ b/Sources/XCTest/XCTestObservationCenter.swift
@@ -47,6 +47,10 @@ public class XCTestObservationCenter {
         forEachObserver { $0.testBundleWillStart(testBundle) }
     }
 
+    internal func testSuiteWillStart(testSuite: XCTestSuite) {
+        forEachObserver { $0.testSuiteWillStart(testSuite) }
+    }
+
     internal func testCaseWillStart(testCase: XCTestCase) {
         forEachObserver { $0.testCaseWillStart(testCase) }
     }
@@ -57,6 +61,10 @@ public class XCTestObservationCenter {
 
     internal func testCaseDidFinish(testCase: XCTestCase) {
         forEachObserver { $0.testCaseDidFinish(testCase) }
+    }
+
+    internal func testSuiteDidFinish(testSuite: XCTestSuite) {
+        forEachObserver { $0.testSuiteDidFinish(testSuite) }
     }
 
     internal func testBundleDidFinish(testBundle: NSBundle) {

--- a/Sources/XCTest/XCTestSuite.swift
+++ b/Sources/XCTest/XCTestSuite.swift
@@ -1,0 +1,58 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestSuite.swift
+//  A collection of test cases.
+//
+
+/// A concrete subclass of XCTest, XCTestSuite is a collection of test cases.
+/// Suites are usually managed by the IDE, but XCTestSuite also provides API
+/// for dynamic test and suite management:
+///
+///     XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"My tests"];
+///     [suite addTest:[MathTest testCaseWithSelector:@selector(testAdd)]];
+///     [suite addTest:[MathTest testCaseWithSelector:@selector(testDivideByZero)]];
+///
+/// Alternatively, a test suite can extract the tests to be run automatically.
+/// To do so, pass the class of your test case class to the suite's constructor:
+///
+///     XCTestSuite *suite = [XCTestSuite testSuiteForTestCaseClass:[MathTest class]];
+///
+/// This creates a suite with all the methods starting with "test" that take no
+/// arguments. Also, a test suite of all the test cases found in the runtime
+/// can be created automatically:
+///
+///     XCTestSuite *suite = [XCTestSuite defaultTestSuite];
+///
+/// This creates a suite of suites with all the XCTestCase subclasses methods
+/// that start with "test" and take no arguments.
+public class XCTestSuite: XCTest {
+    public private(set) var tests = [XCTest]()
+
+    /// The name of this test suite.
+    override public var name: String {
+        return _name
+    }
+    private let _name: String
+
+    /// The number of test cases in this suite.
+    public override var testCaseCount: UInt {
+        return UInt(tests.count)
+    }
+
+    public init(name: String) {
+        _name = name
+    }
+
+    /// Adds a test (either an `XCTestSuite` or an `XCTestCase` to this
+    /// collection.
+    public func addTest(test: XCTest) {
+        tests.append(test)
+    }
+}

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -1,0 +1,77 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Selected
+// RUN: %{built_tests_dir}/Selected Selected.ExecutedTestCase/test_executed > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+    import Foundation
+#else
+    import SwiftXCTest
+    import SwiftFoundation
+#endif
+
+class Observer: XCTestObservation {
+    var startedTestSuites = [XCTestSuite]()
+    var finishedTestSuites = [XCTestSuite]()
+
+    func testBundleWillStart(testBundle: NSBundle) {}
+
+    func testSuiteWillStart(testSuite: XCTestSuite) {
+        startedTestSuites.append(testSuite)
+    }
+
+    func testCaseWillStart(testCase: XCTestCase) {}
+    func testCase(testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {}
+    func testCaseDidFinish(testCase: XCTestCase) {}
+
+    func testSuiteDidFinish(testSuite: XCTestSuite) {
+        print("In \(#function): \(testSuite.name)")
+    }
+
+    func testBundleDidFinish(testBundle: NSBundle) {}
+}
+
+let observer = Observer()
+XCTestObservationCenter.shared().addTestObserver(observer)
+
+class SkippedTestCase: XCTestCase {
+    static var allTests: [(String, SkippedTestCase -> () throws -> Void)] {
+        return [
+            ("test_skipped", test_skipped),
+        ]
+    }
+
+    func test_skipped() {
+        XCTFail("This test method should not be executed.")
+    }
+}
+
+class ExecutedTestCase: XCTestCase {
+    static var allTests: [(String, ExecutedTestCase -> () throws -> Void)] {
+        return [
+            ("test_executed", test_executed),
+            ("test_skipped", test_skipped),
+        ]
+    }
+
+// CHECK: Test Case 'ExecutedTestCase.test_executed' started.
+// CHECK: Test Case 'ExecutedTestCase.test_executed' passed \(\d+\.\d+ seconds\).
+    func test_executed() {
+        let suiteNames = observer.startedTestSuites.map { $0.name }
+        XCTAssertEqual(suiteNames, ["Selected tests", "ExecutedTestCase"])
+    }
+
+    func test_skipped() {
+        XCTFail("This test method should not be executed.")
+    }
+}
+
+XCTMain([
+    testCase(SkippedTestCase.allTests),
+    testCase(ExecutedTestCase.allTests),
+])
+
+// CHECK: Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: In testSuiteDidFinish: ExecutedTestCase
+// CHECK: In testSuiteDidFinish: Selected tests
+// CHECK: Total executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */; };
 		C265F6731C3AEB6A00520CF9 /* XCTimeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */; };
 		DA7805FA1C6704A2003C6636 /* SwiftFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA7805F91C6704A2003C6636 /* SwiftFoundation.framework */; };
+		DA7FB3431CA4EA4000F024F9 /* XCTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7FB3421CA4EA4000F024F9 /* XCTestSuite.swift */; };
+		DA7FB38F1CA4EE3800F024F9 /* XCAbstractTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7FB38E1CA4EE3800F024F9 /* XCAbstractTest.swift */; };
 		DACC94421C8B87B900EC85F5 /* XCWaitCompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */; };
 		DADB979C1C51BDA2005E68B6 /* XCTestExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */; };
 /* End PBXBuildFile section */
@@ -49,6 +51,8 @@
 		C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestMain.swift; sourceTree = "<group>"; };
 		C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTimeUtilities.swift; sourceTree = "<group>"; };
 		DA7805F91C6704A2003C6636 /* SwiftFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftFoundation.framework; path = "../swift-corelibs-foundation/build/Debug/SwiftFoundation.framework"; sourceTree = "<group>"; };
+		DA7FB3421CA4EA4000F024F9 /* XCTestSuite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestSuite.swift; sourceTree = "<group>"; };
+		DA7FB38E1CA4EE3800F024F9 /* XCAbstractTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCAbstractTest.swift; sourceTree = "<group>"; };
 		DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCWaitCompletionHandler.swift; sourceTree = "<group>"; };
 		DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestExpectation.swift; sourceTree = "<group>"; };
 		EA3E74BB1BF2B6D500635A73 /* build_script.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = build_script.py; sourceTree = "<group>"; };
@@ -113,6 +117,8 @@
 				AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */,
 				AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */,
 				C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */,
+				DA7FB38E1CA4EE3800F024F9 /* XCAbstractTest.swift */,
+				DA7FB3421CA4EA4000F024F9 /* XCTestSuite.swift */,
 				C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */,
 				DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */,
 				C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */,
@@ -255,12 +261,14 @@
 				510957A91CA878410091D1A1 /* XCNotificationExpectationHandler.swift in Sources */,
 				C265F6731C3AEB6A00520CF9 /* XCTimeUtilities.swift in Sources */,
 				AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */,
+				DA7FB38F1CA4EE3800F024F9 /* XCAbstractTest.swift in Sources */,
 				C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */,
 				DADB979C1C51BDA2005E68B6 /* XCTestExpectation.swift in Sources */,
 				AE7DD60A1C8E81A0006FC722 /* TestFiltering.swift in Sources */,
 				AE7DD6091C8E81A0006FC722 /* ArgumentParser.swift in Sources */,
 				AE9596E11C9692B8001A9EF0 /* XCTestObservationCenter.swift in Sources */,
 				C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */,
+				DA7FB3431CA4EA4000F024F9 /* XCTestSuite.swift in Sources */,
 				AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */,
 				C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */,
 			);


### PR DESCRIPTION
## What's in this pull request?

Apple XCTest's `XCTestObservation` protocol includes methods that announce when an `XCTestSuite` will begin executing, or has finished executing. Add these same announcements to swift-corelibs-xctest.

swift-corelibs-xctest did not already defined `XCTestSuite`, so add it.

Apple XCTest allows `XCTestObservation` listeners to determine the number of passing and failing tests by accessing an `XCTestSuite`'s `testRun` property, but this is not yet supported in swift-corelibs-xctest.

## Why merge this pull request?

- This makes the swift-corelibs-xctest and Apple XCTest versions of `XCTestObservation` identical, bringing us closer to our Swift 3 goal of API parity.

## What are the downsides of merging this pull request?

- This adds `XCTestSuite` to the codebase, but not `XCTestRun`. As a result, the most interesting aspect of test announcements (how many tests passed/failed) is still unimplemented. Still, I feel like this is a positive step forward, and one that keeps this pull request small enough to actually review.
- swift-corelibs-xctest doesn't use `XCTestSuite` to represent the collection of test cases it executes. As a result, the quality of implementation here leaves much to be desired. On the other hand, refactoring the codebase to seamless integrate `XCTestSuite` would involve more widespread changes, which would make this pull request more difficult to review. If you ask me, thanks to the functional test cases, we could merge this, then easily refactor in a subsequent pull request.