### PR TITLE
[XCTestExpectation] Adding expectationForNotification

### DIFF
--- a/Sources/XCTest/XCNotificationExpectationHandler.swift
+++ b/Sources/XCTest/XCNotificationExpectationHandler.swift
@@ -1,0 +1,26 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCNotificationExpectationHandler.swift
+//  A closure invoked by XCTestCase when a notification for the expectation is
+//  observed.
+//
+
+#if os(Linux) || os(FreeBSD)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
+/// A block to be invoked when a notification specified by the expectation is
+/// observed.
+///
+/// - Parameter notification: The notification that the expectation was 
+///   observing. 
+public typealias XCNotificationExpectationHandler = (NSNotification) -> (Bool)

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -1,0 +1,78 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous-Notifications
+// RUN: %{built_tests_dir}/Asynchronous-Notifications > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+    import Foundation
+#else
+    import SwiftXCTest
+    import SwiftFoundation
+#endif
+
+class NotificationExpectationsTestCase: XCTestCase {
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithName_passes' started.
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithName_passes' passed \(\d+\.\d+ seconds\).
+    func test_observeNotificationWithName_passes() {
+        let notificationName = "notificationWithNameTest"
+        expectationForNotification(notificationName, object:nil, handler:nil)
+        NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: nil)
+        waitForExpectationsWithTimeout(0.0, handler: nil)
+    }
+    
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' started.
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' passed \(\d+\.\d+ seconds\).
+    func test_observeNotificationWithNameAndObject_passes() {
+        let notificationName = "notificationWithNameAndObjectTest"
+        let dummyObject = NSObject()
+        expectationForNotification(notificationName, object:dummyObject, handler:nil)
+        NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: dummyObject)
+        waitForExpectationsWithTimeout(0.0, handler: nil)
+    }
+    
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' started.
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' passed \(\d+\.\d+ seconds\).
+    func test_observeNotificationWithNameAndObject_butExpectingNoObject_passes() {
+        let notificationName = "notificationWithNameAndObject_expectNoObjectTest"
+        expectationForNotification(notificationName, object:nil, handler:nil)
+        let dummyObject = NSObject()
+        NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: dummyObject)
+        waitForExpectationsWithTimeout(0.0, handler: nil)
+    }
+    
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:49: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'expectedName' from any object
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' failed \(\d+\.\d+ seconds\).
+    func test_observeNotificationWithIncorrectName_fails() {
+        expectationForNotification("expectedName", object: nil, handler:nil)
+        NSNotificationCenter.defaultCenter().postNotificationName("actualName", object: nil)
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:61: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'notificationWithIncorrectObjectTest' from dummyObject
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' failed \(\d+\.\d+ seconds\).
+    func test_observeNotificationWithIncorrectObject_fails() {
+        let notificationName = "notificationWithIncorrectObjectTest"
+        let dummyObject: NSString = "dummyObject"
+        let anotherDummyObject = NSObject()
+        expectationForNotification(notificationName, object: dummyObject, handler: nil)
+        NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object:anotherDummyObject)
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    static var allTests: [(String, NotificationExpectationsTestCase -> () throws -> Void)] {
+        return [
+                   ("test_observeNotificationWithName_passes", test_observeNotificationWithName_passes),
+                   ("test_observeNotificationWithNameAndObject_passes", test_observeNotificationWithNameAndObject_passes),
+                   ("test_observeNotificationWithNameAndObject_butExpectingNoObject_passes", test_observeNotificationWithNameAndObject_butExpectingNoObject_passes),
+                   ("test_observeNotificationWithIncorrectName_fails", test_observeNotificationWithIncorrectName_fails),
+                   ("test_observeNotificationWithIncorrectObject_fails", test_observeNotificationWithIncorrectObject_fails),
+        ]
+    }
+}
+
+XCTMain([testCase(NotificationExpectationsTestCase.allTests)])
+
+// CHECK: Executed 5 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 5 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -1,0 +1,48 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous-Notifications-Handler
+// RUN: %{built_tests_dir}/Asynchronous-Notifications-Handler > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+    import Foundation
+#else
+    import SwiftXCTest
+    import SwiftFoundation
+#endif
+
+class NotificationHandlerTestCase: XCTestCase {
+// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' started.
+// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:23: error: NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'returnFalse' from any object
+// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' failed \(\d+\.\d+ seconds\).
+    func test_notificationNameIsObserved_handlerReturnsFalse_andFails() {
+        let _ = self.expectationForNotification("returnFalse", object: nil, handler: {
+            notification in
+            return false
+        })
+        NSNotificationCenter.defaultCenter().postNotificationName("returnFalse", object: nil)
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' started.
+// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' passed \(\d+\.\d+ seconds\).
+    func test_notificationNameIsObserved_handlerReturnsTrue_andPasses() {
+        let _ = self.expectationForNotification("returnTrue", object: nil, handler: {
+            notification in
+            return true
+        })
+        NSNotificationCenter.defaultCenter().postNotificationName("returnTrue", object: nil)
+        waitForExpectationsWithTimeout(0.1, handler: nil)
+    }
+    
+    static var allTests: [(String, NotificationHandlerTestCase -> () throws -> Void)] {
+        return [
+                   ("test_notificationNameIsObserved_handlerReturnsFalse_andFails", test_notificationNameIsObserved_handlerReturnsFalse_andFails),
+                   ("test_notificationNameIsObserved_handlerReturnsTrue_andPasses", test_notificationNameIsObserved_handlerReturnsTrue_andPasses),
+        ]
+    }
+}
+
+XCTMain([testCase(NotificationHandlerTestCase.allTests)])
+
+// CHECK: Executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Total executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		510957A91CA878410091D1A1 /* XCNotificationExpectationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510957A81CA878410091D1A1 /* XCNotificationExpectationHandler.swift */; };
 		AE7DD6091C8E81A0006FC722 /* ArgumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */; };
 		AE7DD60A1C8E81A0006FC722 /* TestFiltering.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */; };
 		AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */; };
@@ -32,6 +33,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		510957A81CA878410091D1A1 /* XCNotificationExpectationHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCNotificationExpectationHandler.swift; sourceTree = "<group>"; };
 		5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE7DD6061C8DC6C0006FC722 /* Functional */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Functional; sourceTree = "<group>"; };
 		AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgumentParser.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */,
 				C265F66D1C3AEB6A00520CF9 /* XCTimeUtilities.swift */,
 				DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */,
+				510957A81CA878410091D1A1 /* XCNotificationExpectationHandler.swift */,
 			);
 			path = XCTest;
 			sourceTree = "<group>";
@@ -249,6 +252,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DACC94421C8B87B900EC85F5 /* XCWaitCompletionHandler.swift in Sources */,
+				510957A91CA878410091D1A1 /* XCNotificationExpectationHandler.swift in Sources */,
 				C265F6731C3AEB6A00520CF9 /* XCTimeUtilities.swift in Sources */,
 				AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */,
 				C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */,


### PR DESCRIPTION
## What's in this pull request?

This pull request adds the XCTestCase convenience constructor for XCTestExpectation `expectationForNotification:object:handler:`.

It also includes the `XCNotificationExpectationHandler` `typealias` file as well as tests to check `expectationForNotification:object:handler:` behavior.

https://bugs.swift.org/browse/SR-907
However, this pull request does not include the convenience constructor `expectationForPredicate:evaluatedWithObject:handler:` described in the ticket, as `NSPredicate` initializers have yet to be implemented.

## Why merge this pull request?

This will provide a full Swift implementation of `expectationForNotification:object:handler:` that allows asynchronous testing for `NSNotification`. 