### PR TITLE
Additional Swift 3 API naming updates

### DIFF
--- a/Sources/XCTest/XCTAssert.swift
+++ b/Sources/XCTest/XCTAssert.swift
@@ -11,49 +11,49 @@
 //
 
 private enum _XCTAssertion {
-    case Equal
-    case EqualWithAccuracy
-    case GreaterThan
-    case GreaterThanOrEqual
-    case LessThan
-    case LessThanOrEqual
-    case NotEqual
-    case NotEqualWithAccuracy
-    case Nil
-    case NotNil
-    case True
-    case False
-    case Fail
-    case ThrowsError
+    case equal
+    case equalWithAccuracy
+    case greaterThan
+    case greaterThanOrEqual
+    case lessThan
+    case lessThanOrEqual
+    case notEqual
+    case notEqualWithAccuracy
+    case `nil`
+    case notNil
+    case `true`
+    case `false`
+    case fail
+    case throwsError
 
     var name: String? {
         switch(self) {
-        case .Equal: return "XCTAssertEqual"
-        case .EqualWithAccuracy: return "XCTAssertEqualWithAccuracy"
-        case .GreaterThan: return "XCTAssertGreaterThan"
-        case .GreaterThanOrEqual: return "XCTAssertGreaterThanOrEqual"
-        case .LessThan: return "XCTAssertLessThan"
-        case .LessThanOrEqual: return "XCTAssertLessThanOrEqual"
-        case .NotEqual: return "XCTAssertNotEqual"
-        case .NotEqualWithAccuracy: return "XCTAssertNotEqualWithAccuracy"
-        case .Nil: return "XCTAssertNil"
-        case .NotNil: return "XCTAssertNotNil"
-        case .True: return "XCTAssertTrue"
-        case .False: return "XCTAssertFalse"
-        case .ThrowsError: return "XCTAssertThrowsError"
-        case .Fail: return nil
+        case .equal: return "XCTAssertEqual"
+        case .equalWithAccuracy: return "XCTAssertEqualWithAccuracy"
+        case .greaterThan: return "XCTAssertGreaterThan"
+        case .greaterThanOrEqual: return "XCTAssertGreaterThanOrEqual"
+        case .lessThan: return "XCTAssertLessThan"
+        case .lessThanOrEqual: return "XCTAssertLessThanOrEqual"
+        case .notEqual: return "XCTAssertNotEqual"
+        case .notEqualWithAccuracy: return "XCTAssertNotEqualWithAccuracy"
+        case .`nil`: return "XCTAssertNil"
+        case .notNil: return "XCTAssertNotNil"
+        case .`true`: return "XCTAssertTrue"
+        case .`false`: return "XCTAssertFalse"
+        case .throwsError: return "XCTAssertThrowsError"
+        case .fail: return nil
         }
     }
 }
 
 private enum _XCTAssertionResult {
-    case Success
-    case ExpectedFailure(String?)
-    case UnexpectedFailure(ErrorProtocol)
+    case success
+    case expectedFailure(String?)
+    case unexpectedFailure(ErrorProtocol)
 
-    var expected: Bool {
+    var isExpected: Bool {
         switch self {
-        case .UnexpectedFailure(_): return false
+        case .unexpectedFailure(_): return false
         default: return true
         }
     }
@@ -61,10 +61,10 @@ private enum _XCTAssertionResult {
     func failureDescription(assertion: _XCTAssertion) -> String {
         let explanation: String
         switch self {
-        case .Success: explanation = "passed"
-        case .ExpectedFailure(let details?): explanation = "failed: \(details)"
-        case .ExpectedFailure(_): explanation = "failed"
-        case .UnexpectedFailure(let error): explanation = "threw error \"\(error)\""
+        case .success: explanation = "passed"
+        case .expectedFailure(let details?): explanation = "failed: \(details)"
+        case .expectedFailure(_): explanation = "failed"
+        case .unexpectedFailure(let error): explanation = "threw error \"\(error)\""
         }
 
         if let name = assertion.name {
@@ -80,15 +80,15 @@ private func _XCTEvaluateAssertion(assertion: _XCTAssertion, @autoclosure messag
     do {
         result = try expression()
     } catch {
-        result = .UnexpectedFailure(error)
+        result = .unexpectedFailure(error)
     }
 
     switch result {
-    case .Success:
+    case .success:
         return
     default:
         if let handler = XCTFailureHandler {
-            handler(XCTFailure(message: message(), failureDescription: result.failureDescription(assertion), expected: result.expected, file: file, line: line))
+            handler(XCTFailure(message: message(), failureDescription: result.failureDescription(assertion), expected: result.isExpected, file: file, line: line))
         }
     }
 }
@@ -153,233 +153,233 @@ public func XCTAssert(@autoclosure expression: () throws -> Boolean, @autoclosur
 }
 
 public func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () throws -> T?, @autoclosure _ expression2: () throws -> T?, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Equal, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 == value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () throws -> ArraySlice<T>, @autoclosure _ expression2: () throws -> ArraySlice<T>, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Equal, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 == value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () throws -> ContiguousArray<T>, @autoclosure _ expression2: () throws -> ContiguousArray<T>, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Equal, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 == value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertEqual<T: Equatable>(@autoclosure expression1: () throws -> [T], @autoclosure _ expression2: () throws -> [T], @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Equal, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 == value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertEqual<T, U: Equatable>(@autoclosure expression1: () throws -> [T: U], @autoclosure _ expression2: () throws -> [T: U], @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Equal, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 == value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertEqualWithAccuracy<T: FloatingPoint>(@autoclosure expression1: () throws -> T, @autoclosure _ expression2: () throws -> T, accuracy: T, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.EqualWithAccuracy, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.equalWithAccuracy, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if abs(value1.distance(to: value2)) <= abs(accuracy.distance(to: T(0))) {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\") +/- (\"\(accuracy)\")")
+            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\") +/- (\"\(accuracy)\")")
         }
     }
 }
 
 public func XCTAssertFalse(@autoclosure expression: () throws -> Boolean, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.False, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.`false`, message: message, file: file, line: line) {
         let value = try expression()
         if !value.boolValue {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure(nil)
+            return .expectedFailure(nil)
         }
     }
 }
 
 public func XCTAssertGreaterThan<T: Comparable>(@autoclosure expression1: () throws -> T, @autoclosure _ expression2: () throws -> T, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.GreaterThan, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.greaterThan, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 > value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not greater than (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is not greater than (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertGreaterThanOrEqual<T: Comparable>(@autoclosure expression1: () throws -> T, @autoclosure _ expression2: () throws -> T, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.GreaterThanOrEqual, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.greaterThanOrEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 >= value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is less than (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is less than (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertLessThan<T: Comparable>(@autoclosure expression1: () throws -> T, @autoclosure _ expression2: () throws -> T, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.LessThan, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.lessThan, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 < value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is not less than (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is not less than (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertLessThanOrEqual<T: Comparable>(@autoclosure expression1: () throws -> T, @autoclosure _ expression2: () throws -> T, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.LessThanOrEqual, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.lessThanOrEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 <= value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is greater than (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is greater than (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertNil(@autoclosure expression: () throws -> Any?, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Nil, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.`nil`, message: message, file: file, line: line) {
         let value = try expression()
         if value == nil {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("\"\(value!)\"")
+            return .expectedFailure("\"\(value!)\"")
         }
     }
 }
 
 public func XCTAssertNotEqual<T: Equatable>(@autoclosure expression1: () throws -> T?, @autoclosure _ expression2: () throws -> T?, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.NotEqual, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 != value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertNotEqual<T: Equatable>(@autoclosure expression1: () throws -> ContiguousArray<T>, @autoclosure _ expression2: () throws -> ContiguousArray<T>, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.NotEqual, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 != value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertNotEqual<T: Equatable>(@autoclosure expression1: () throws -> ArraySlice<T>, @autoclosure _ expression2: () throws -> ArraySlice<T>, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.NotEqual, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 != value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertNotEqual<T: Equatable>(@autoclosure expression1: () throws -> [T], @autoclosure _ expression2: () throws -> [T], @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.NotEqual, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 != value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertNotEqual<T, U: Equatable>(@autoclosure expression1: () throws -> [T: U], @autoclosure _ expression2: () throws -> [T: U], @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.NotEqual, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 != value2 {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
+            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
         }
     }
 }
 
 public func XCTAssertNotEqualWithAccuracy<T: FloatingPoint>(@autoclosure expression1: () throws -> T, @autoclosure _ expression2: () throws -> T, _ accuracy: T, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.NotEqualWithAccuracy, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.notEqualWithAccuracy, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if abs(value1.distance(to: value2)) > abs(accuracy.distance(to: T(0))) {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("(\"\(value1)\") is equal to (\"\(value2)\") +/- (\"\(accuracy)\")")
+            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\") +/- (\"\(accuracy)\")")
         }
     }
 }
 
 public func XCTAssertNotNil(@autoclosure expression: () throws -> Any?, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.NotNil, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.notNil, message: message, file: file, line: line) {
         let value = try expression()
         if value != nil {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure(nil)
+            return .expectedFailure(nil)
         }
     }
 }
 
 public func XCTAssertTrue(@autoclosure expression: () throws -> Boolean, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.True, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.`true`, message: message, file: file, line: line) {
         let value = try expression()
         if value.boolValue {
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure(nil)
+            return .expectedFailure(nil)
         }
     }
 }
 
 public func XCTFail(message: String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.Fail, message: message, file: file, line: line) {
-        return .ExpectedFailure(nil)
+    _XCTEvaluateAssertion(.fail, message: message, file: file, line: line) {
+        return .expectedFailure(nil)
     }
 }
 
 public func XCTAssertThrowsError<T>(@autoclosure expression: () throws -> T, _ message: String = "", file: StaticString = #file, line: UInt = #line, _ errorHandler: (error: ErrorProtocol) -> Void = { _ in }) {
-    _XCTEvaluateAssertion(.ThrowsError, message: message, file: file, line: line) {
+    _XCTEvaluateAssertion(.throwsError, message: message, file: file, line: line) {
         var caughtErrorOptional: ErrorProtocol?
         do {
             _ = try expression()
@@ -389,9 +389,9 @@ public func XCTAssertThrowsError<T>(@autoclosure expression: () throws -> T, _ m
 
         if let caughtError = caughtErrorOptional {
             errorHandler(error: caughtError)
-            return .Success
+            return .success
         } else {
-            return .ExpectedFailure("did not throw error")
+            return .expectedFailure("did not throw error")
         }
     }
 }

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -190,7 +190,7 @@ extension XCTestCase {
     ///   between these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    public func expectationWithDescription(description: String, file: StaticString = #file, line: UInt = #line) -> XCTestExpectation {
+    public func expectation(withDescription description: String, file: StaticString = #file, line: UInt = #line) -> XCTestExpectation {
         let expectation = XCTestExpectation(
             description: description,
             file: file,
@@ -225,7 +225,7 @@ extension XCTestCase {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    public func waitForExpectationsWithTimeout(timeout: NSTimeInterval, file: StaticString = #file, line: UInt = #line, handler: XCWaitCompletionHandler?) {
+    public func waitForExpectations(withTimeout timeout: NSTimeInterval, file: StaticString = #file, line: UInt = #line, handler: XCWaitCompletionHandler?) {
         // Mirror Objective-C XCTest behavior; display an unexpected test
         // failure when users wait without having first set expectations.
         // FIXME: Objective-C XCTest raises an exception for most "API
@@ -323,9 +323,9 @@ extension XCTestCase {
     ///   notification is observed. It will not be invoked on timeout. Use the
     ///   handler to further investigate if the notification fulfills the 
     ///   expectation.
-    public func expectationForNotification(notificationName: String, object objectToObserve: AnyObject?, handler: XCNotificationExpectationHandler?) -> XCTestExpectation {
+    public func expectation(forNotification notificationName: String, object objectToObserve: AnyObject?, handler: XCNotificationExpectationHandler?) -> XCTestExpectation {
         let objectDescription = objectToObserve == nil ? "any object" : "\(objectToObserve!)"
-        let expectation = self.expectationWithDescription("Expect notification '\(notificationName)' from " + objectDescription)
+        let expectation = self.expectation(withDescription: "Expect notification '\(notificationName)' from " + objectDescription)
         // Start observing the notification with specified name and object.
         var observer: NSObjectProtocol? = nil
         func removeObserver() {

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -225,7 +225,7 @@ extension XCTestCase {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    public func waitForExpectations(withTimeout timeout: NSTimeInterval, file: StaticString = #file, line: UInt = #line, handler: XCWaitCompletionHandler?) {
+    public func waitForExpectations(withTimeout timeout: NSTimeInterval, file: StaticString = #file, line: UInt = #line, handler: XCWaitCompletionHandler? = nil) {
         // Mirror Objective-C XCTest behavior; display an unexpected test
         // failure when users wait without having first set expectations.
         // FIXME: Objective-C XCTest raises an exception for most "API
@@ -323,7 +323,7 @@ extension XCTestCase {
     ///   notification is observed. It will not be invoked on timeout. Use the
     ///   handler to further investigate if the notification fulfills the 
     ///   expectation.
-    public func expectation(forNotification notificationName: String, object objectToObserve: AnyObject?, handler: XCNotificationExpectationHandler?) -> XCTestExpectation {
+    public func expectation(forNotification notificationName: String, object objectToObserve: AnyObject?, handler: XCNotificationExpectationHandler? = nil) -> XCTestExpectation {
         let objectDescription = objectToObserve == nil ? "any object" : "\(objectToObserve!)"
         let expectation = self.expectation(withDescription: "Expect notification '\(notificationName)' from " + objectDescription)
         // Start observing the notification with specified name and object.

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -263,7 +263,7 @@ extension XCTestCase {
         repeat {
             unfulfilledDescriptions = []
             for expectation in _allExpectations {
-                if !expectation.fulfilled {
+                if !expectation.isFulfilled {
                     unfulfilledDescriptions.append(expectation.description)
                 }
             }

--- a/Sources/XCTest/XCTestExpectation.swift
+++ b/Sources/XCTest/XCTestExpectation.swift
@@ -17,7 +17,7 @@ public class XCTestExpectation {
     internal let file: StaticString
     internal let line: UInt
 
-    internal var fulfilled = false
+    internal var isFulfilled = false
     internal weak var testCase: XCTestCase?
 
     internal init(description: String, file: StaticString, line: UInt, testCase: XCTestCase) {
@@ -52,7 +52,7 @@ public class XCTestExpectation {
         //        fulfilled after the test cases that generated those
         //        expectations have completed. Similarly, this should cause an
         //        error as well.
-        if fulfilled {
+        if isFulfilled {
             // Mirror Objective-C XCTest behavior: treat multiple calls to
             // fulfill() as an unexpected failure.
             let failure = XCTFailure(
@@ -65,7 +65,7 @@ public class XCTestExpectation {
                 failureHandler(failure)
             }
         } else {
-            fulfilled = true
+            isFulfilled = true
         }
     }
 }

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -15,64 +15,64 @@ class ExpectationsTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:19: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnUnfulfilledExpectation_fails() {
-        expectationWithDescription("foo")
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        expectation(withDescription: "foo")
+        waitForExpectations(withTimeout: 0.2, handler: nil)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started.
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:28: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
     func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
-        expectationWithDescription("bar")
-        expectationWithDescription("baz")
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        expectation(withDescription: "bar")
+        expectation(withDescription: "baz")
+        waitForExpectations(withTimeout: 0.2, handler: nil)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' started.
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
     func test_waitingForAnImmediatelyFulfilledExpectation_passes() {
-        let expectation = expectationWithDescription("flim")
+        let expectation = self.expectation(withDescription: "flim")
         expectation.fulfill()
-        waitForExpectationsWithTimeout(0.2, handler: nil)
+        waitForExpectations(withTimeout: 0.2, handler: nil)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' started.
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
     func test_waitingForAnEventuallyFulfilledExpectation_passes() {
-        let expectation = expectationWithDescription("flam")
+        let expectation = self.expectation(withDescription: "flam")
         let timer = NSTimer.scheduledTimer(0.1, repeats: false) { _ in
             expectation.fulfill()
         }
         NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
-        waitForExpectationsWithTimeout(1.0, handler: nil)
+        waitForExpectations(withTimeout: 1.0, handler: nil)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started.
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:59: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnExpectationFulfilledAfterTheTimeout_fails() {
-        let expectation = expectationWithDescription("hog")
+        let expectation = self.expectation(withDescription: "hog")
         let timer = NSTimer.scheduledTimer(1.0, repeats: false) { _ in
             expectation.fulfill()
         }
         NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
-        waitForExpectationsWithTimeout(0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1, handler: nil)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' started.
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' passed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes() {
-        let expectation = expectationWithDescription("smog")
+        let expectation = self.expectation(withDescription: "smog")
         expectation.fulfill()
-        waitForExpectationsWithTimeout(0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0, handler: nil)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started.
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:75: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
-        expectationWithDescription("dog")
-        waitForExpectationsWithTimeout(-1.0, handler: nil)
+        expectation(withDescription: "dog")
+        waitForExpectations(withTimeout: -1.0, handler: nil)
     }
 
     static var allTests: [(String, ExpectationsTestCase -> () throws -> Void)] {

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -16,7 +16,7 @@ class ExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnUnfulfilledExpectation_fails() {
         expectation(withDescription: "foo")
-        waitForExpectations(withTimeout: 0.2, handler: nil)
+        waitForExpectations(withTimeout: 0.2)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started.
@@ -25,7 +25,7 @@ class ExpectationsTestCase: XCTestCase {
     func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
         expectation(withDescription: "bar")
         expectation(withDescription: "baz")
-        waitForExpectations(withTimeout: 0.2, handler: nil)
+        waitForExpectations(withTimeout: 0.2)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' started.
@@ -33,7 +33,7 @@ class ExpectationsTestCase: XCTestCase {
     func test_waitingForAnImmediatelyFulfilledExpectation_passes() {
         let expectation = self.expectation(withDescription: "flim")
         expectation.fulfill()
-        waitForExpectations(withTimeout: 0.2, handler: nil)
+        waitForExpectations(withTimeout: 0.2)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' started.
@@ -44,7 +44,7 @@ class ExpectationsTestCase: XCTestCase {
             expectation.fulfill()
         }
         NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
-        waitForExpectations(withTimeout: 1.0, handler: nil)
+        waitForExpectations(withTimeout: 1.0)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started.
@@ -56,7 +56,7 @@ class ExpectationsTestCase: XCTestCase {
             expectation.fulfill()
         }
         NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' started.
@@ -64,7 +64,7 @@ class ExpectationsTestCase: XCTestCase {
     func test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes() {
         let expectation = self.expectation(withDescription: "smog")
         expectation.fulfill()
-        waitForExpectations(withTimeout: 0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started.
@@ -72,7 +72,7 @@ class ExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
         expectation(withDescription: "dog")
-        waitForExpectations(withTimeout: -1.0, handler: nil)
+        waitForExpectations(withTimeout: -1.0)
     }
 
     static var allTests: [(String, ExpectationsTestCase -> () throws -> Void)] {

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -15,10 +15,10 @@ class HandlerTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Handler/main.swift:21: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreNotFulfilled_handlerCalled_andFails() {
-        self.expectationWithDescription("fog")
+        self.expectation(withDescription: "fog")
 
         var handlerWasCalled = false
-        self.waitForExpectationsWithTimeout(0.2) { error in
+        self.waitForExpectations(withTimeout: 0.2) { error in
             XCTAssertNotNil(error, "Expectation handlers for unfulfilled expectations should not be nil.")
             XCTAssertTrue(error!.domain.hasSuffix("XCTestErrorDomain"), "The last component of the error domain should match Objective-C XCTest.")
             XCTAssertEqual(error!.code, 0, "The error code should match Objective-C XCTest.")
@@ -30,11 +30,11 @@ class HandlerTestCase: XCTestCase {
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' started.
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' passed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreFulfilled_handlerCalled_andPasses() {
-        let expectation = self.expectationWithDescription("bog")
+        let expectation = self.expectation(withDescription: "bog")
         expectation.fulfill()
 
         var handlerWasCalled = false
-        self.waitForExpectationsWithTimeout(0.2) { error in
+        self.waitForExpectations(withTimeout: 0.2) { error in
             XCTAssertNil(error, "Expectation handlers for fulfilled expectations should be nil.")
             handlerWasCalled = true
         }

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -13,15 +13,15 @@ class MisuseTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:17: unexpected error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails :  - Failed due to unwaited expectations.
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreMade_butNotWaitedFor_fails() {
-        self.expectationWithDescription("the first expectation")
-        self.expectationWithDescription("the second expectation (the file and line number for this one are included in the failure message")
+        self.expectation(withDescription: "the first expectation")
+        self.expectation(withDescription: "the second expectation (the file and line number for this one are included in the failure message")
     }
 
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started.
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:24: unexpected error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
-        self.waitForExpectationsWithTimeout(0.1, handler: nil)
+        self.waitForExpectations(withTimeout: 0.1, handler: nil)
     }
 
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started.
@@ -29,7 +29,7 @@ class MisuseTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:44: unexpected error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationIsFulfilledMultipleTimes_fails() {
-        let expectation = self.expectationWithDescription("rob")
+        let expectation = self.expectation(withDescription: "rob")
         expectation.fulfill()
         expectation.fulfill()
         // FIXME: The behavior here is subtly different from Objective-C XCTest.
@@ -42,7 +42,7 @@ class MisuseTestCase: XCTestCase {
         //        highlights both the lines above and below as failures.
         //        This should be fixed such that the behavior is identical.
         expectation.fulfill()
-        self.waitForExpectationsWithTimeout(0.1, handler: nil)
+        self.waitForExpectations(withTimeout: 0.1, handler: nil)
     }
 
     static var allTests: [(String, MisuseTestCase -> () throws -> Void)] {

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -21,7 +21,7 @@ class MisuseTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:24: unexpected error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
-        self.waitForExpectations(withTimeout: 0.1, handler: nil)
+        self.waitForExpectations(withTimeout: 0.1)
     }
 
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started.
@@ -42,7 +42,7 @@ class MisuseTestCase: XCTestCase {
         //        highlights both the lines above and below as failures.
         //        This should be fixed such that the behavior is identical.
         expectation.fulfill()
-        self.waitForExpectations(withTimeout: 0.1, handler: nil)
+        self.waitForExpectations(withTimeout: 0.1)
     }
 
     static var allTests: [(String, MisuseTestCase -> () throws -> Void)] {

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -15,9 +15,9 @@ class NotificationExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithName_passes' passed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithName_passes() {
         let notificationName = "notificationWithNameTest"
-        expectationForNotification(notificationName, object:nil, handler:nil)
+        expectation(forNotification: notificationName, object:nil, handler:nil)
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: nil)
-        waitForExpectationsWithTimeout(0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0, handler: nil)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' started.
@@ -25,28 +25,28 @@ class NotificationExpectationsTestCase: XCTestCase {
     func test_observeNotificationWithNameAndObject_passes() {
         let notificationName = "notificationWithNameAndObjectTest"
         let dummyObject = NSObject()
-        expectationForNotification(notificationName, object:dummyObject, handler:nil)
+        expectation(forNotification: notificationName, object:dummyObject, handler:nil)
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: dummyObject)
-        waitForExpectationsWithTimeout(0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0, handler: nil)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' started.
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' passed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithNameAndObject_butExpectingNoObject_passes() {
         let notificationName = "notificationWithNameAndObject_expectNoObjectTest"
-        expectationForNotification(notificationName, object:nil, handler:nil)
+        expectation(forNotification: notificationName, object:nil, handler:nil)
         let dummyObject = NSObject()
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: dummyObject)
-        waitForExpectationsWithTimeout(0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0, handler: nil)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' started.
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:49: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'expectedName' from any object
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' failed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithIncorrectName_fails() {
-        expectationForNotification("expectedName", object: nil, handler:nil)
+        expectation(forNotification: "expectedName", object: nil, handler:nil)
         NSNotificationCenter.defaultCenter().postNotificationName("actualName", object: nil)
-        waitForExpectationsWithTimeout(0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1, handler: nil)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' started.
@@ -56,9 +56,9 @@ class NotificationExpectationsTestCase: XCTestCase {
         let notificationName = "notificationWithIncorrectObjectTest"
         let dummyObject: NSString = "dummyObject"
         let anotherDummyObject = NSObject()
-        expectationForNotification(notificationName, object: dummyObject, handler: nil)
+        expectation(forNotification: notificationName, object: dummyObject, handler: nil)
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object:anotherDummyObject)
-        waitForExpectationsWithTimeout(0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1, handler: nil)
     }
     
     static var allTests: [(String, NotificationExpectationsTestCase -> () throws -> Void)] {

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -15,9 +15,9 @@ class NotificationExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithName_passes' passed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithName_passes() {
         let notificationName = "notificationWithNameTest"
-        expectation(forNotification: notificationName, object:nil, handler:nil)
+        expectation(forNotification: notificationName, object:nil)
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: nil)
-        waitForExpectations(withTimeout: 0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' started.
@@ -25,28 +25,28 @@ class NotificationExpectationsTestCase: XCTestCase {
     func test_observeNotificationWithNameAndObject_passes() {
         let notificationName = "notificationWithNameAndObjectTest"
         let dummyObject = NSObject()
-        expectation(forNotification: notificationName, object:dummyObject, handler:nil)
+        expectation(forNotification: notificationName, object:dummyObject)
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: dummyObject)
-        waitForExpectations(withTimeout: 0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' started.
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' passed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithNameAndObject_butExpectingNoObject_passes() {
         let notificationName = "notificationWithNameAndObject_expectNoObjectTest"
-        expectation(forNotification: notificationName, object:nil, handler:nil)
+        expectation(forNotification: notificationName, object:nil)
         let dummyObject = NSObject()
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object: dummyObject)
-        waitForExpectations(withTimeout: 0.0, handler: nil)
+        waitForExpectations(withTimeout: 0.0)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' started.
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:49: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'expectedName' from any object
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' failed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithIncorrectName_fails() {
-        expectation(forNotification: "expectedName", object: nil, handler:nil)
+        expectation(forNotification: "expectedName", object: nil)
         NSNotificationCenter.defaultCenter().postNotificationName("actualName", object: nil)
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' started.
@@ -56,9 +56,9 @@ class NotificationExpectationsTestCase: XCTestCase {
         let notificationName = "notificationWithIncorrectObjectTest"
         let dummyObject: NSString = "dummyObject"
         let anotherDummyObject = NSObject()
-        expectation(forNotification: notificationName, object: dummyObject, handler: nil)
+        expectation(forNotification: notificationName, object: dummyObject)
         NSNotificationCenter.defaultCenter().postNotificationName(notificationName, object:anotherDummyObject)
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1)
     }
     
     static var allTests: [(String, NotificationExpectationsTestCase -> () throws -> Void)] {

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -15,34 +15,34 @@ class NotificationHandlerTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:23: error: NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'returnFalse' from any object
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' failed \(\d+\.\d+ seconds\).
     func test_notificationNameIsObserved_handlerReturnsFalse_andFails() {
-        let _ = self.expectationForNotification("returnFalse", object: nil, handler: {
+        expectation(forNotification: "returnFalse", object: nil, handler: {
             notification in
             return false
         })
         NSNotificationCenter.defaultCenter().postNotificationName("returnFalse", object: nil)
-        waitForExpectationsWithTimeout(0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1, handler: nil)
     }
     
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' started.
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' passed \(\d+\.\d+ seconds\).
     func test_notificationNameIsObserved_handlerReturnsTrue_andPasses() {
-        let _ = self.expectationForNotification("returnTrue", object: nil, handler: {
+        expectation(forNotification: "returnTrue", object: nil, handler: {
             notification in
             return true
         })
         NSNotificationCenter.defaultCenter().postNotificationName("returnTrue", object: nil)
-        waitForExpectationsWithTimeout(0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1, handler: nil)
     }
 
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' started.
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:\d+: error: NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'note' from any object
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' failed \(\d+\.\d+ seconds\).
     func test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled() {
-        expectationForNotification("note", object: nil, handler: { _ in
+        expectation(forNotification: "note", object: nil, handler: { _ in
             XCTFail("Should not call the notification expectation handler")
             return true
         })
-        waitForExpectationsWithTimeout(0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1, handler: nil)
         NSNotificationCenter.defaultCenter().postNotificationName("note", object: nil)
     }
     

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -20,7 +20,7 @@ class NotificationHandlerTestCase: XCTestCase {
             return false
         })
         NSNotificationCenter.defaultCenter().postNotificationName("returnFalse", object: nil)
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1)
     }
     
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' started.
@@ -31,7 +31,7 @@ class NotificationHandlerTestCase: XCTestCase {
             return true
         })
         NSNotificationCenter.defaultCenter().postNotificationName("returnTrue", object: nil)
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(withTimeout: 0.1)
     }
 
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' started.

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -29,11 +29,11 @@ class ErrorHandling: XCTestCase {
     }
     
     enum SomeError: ErrorProtocol {
-        case AnError(String)
+        case anError(String)
     }
     
     func functionThatDoesThrowError() throws {
-        throw SomeError.AnError("an error message")
+        throw SomeError.anError("an error message")
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started.
@@ -53,7 +53,7 @@ class ErrorHandling: XCTestCase {
             }
             
             switch thrownError {
-            case .AnError(let message):
+            case .anError(let message):
                 XCTAssertEqual(message, "an error message")
             }
         }
@@ -70,14 +70,14 @@ class ErrorHandling: XCTestCase {
             }
             
             switch thrownError {
-            case .AnError(let message):
+            case .anError(let message):
                 XCTAssertEqual(message, "")
             }
         }
     }
     
 // CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' started.
-// CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "AnError\("an error message"\)" -
+// CHECK: \<EXPR\>:0: unexpected error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "anError\("an error message"\)" -
 // CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\).
     func test_canAndDoesThrowErrorFromTestMethod() throws {
         try functionThatDoesThrowError()
@@ -90,11 +90,11 @@ class ErrorHandling: XCTestCase {
     }
     
     func functionThatShouldReturnButThrows() throws -> Int {
-        throw SomeError.AnError("did not actually return")
+        throw SomeError.anError("did not actually return")
     }
     
 // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started.
-// CHECK: .*/ErrorHandling/main.swift:\d+: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "AnError\("did not actually return"\)" -
+// CHECK: .*/ErrorHandling/main.swift:\d+: unexpected error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "anError\("did not actually return"\)" -
 // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)


### PR DESCRIPTION
#82 got us started with updating our own APIs to match the Swift 3 guidelines, but there are a number of other changes required for us to be fully compatible. Here, I've adjusted a few public methods to match how they are imported into Swift from Apple XCTest with the Swift 3 toolchain. I have also made a handful of changes to internal APIs to bring them in line with the Swift 3 naming [guidelines](https://github.com/apple/swift-evolution/blob/master/proposals/0006-apply-api-guidelines-to-the-standard-library.md). See the commit messages for more specifics!