### PR TITLE
Translate Objective-C code in `XCTestSuite` doc comments into Swift

### DIFF
--- a/Sources/XCTest/XCTestSuite.swift
+++ b/Sources/XCTest/XCTestSuite.swift
@@ -15,20 +15,20 @@
 /// Suites are usually managed by the IDE, but XCTestSuite also provides API
 /// for dynamic test and suite management:
 ///
-///     XCTestSuite *suite = [XCTestSuite testSuiteWithName:@"My tests"];
-///     [suite addTest:[MathTest testCaseWithSelector:@selector(testAdd)]];
-///     [suite addTest:[MathTest testCaseWithSelector:@selector(testDivideByZero)]];
+///     let suite = XCTestSuite(name: "My tests")
+///     suite.addTest(MathTest(selector: #selector(testAdd)))
+///     suite.addTest(MathTest(selector: #selector(testDivideByZero)))
 ///
 /// Alternatively, a test suite can extract the tests to be run automatically.
 /// To do so, pass the class of your test case class to the suite's constructor:
 ///
-///     XCTestSuite *suite = [XCTestSuite testSuiteForTestCaseClass:[MathTest class]];
+///     let suite = XCTestSuite(forTestCaseClass: MathTest.self)
 ///
 /// This creates a suite with all the methods starting with "test" that take no
 /// arguments. Also, a test suite of all the test cases found in the runtime
 /// can be created automatically:
 ///
-///     XCTestSuite *suite = [XCTestSuite defaultTestSuite];
+///     let suite = XCTestSuite.defaultTestSuite()
 ///
 /// This creates a suite of suites with all the XCTestCase subclasses methods
 /// that start with "test" and take no arguments.


### PR DESCRIPTION
The doc comments on `XCTestSuite` contain some Objective-C example code. This updates the example code to be Swift instead.