### PR TITLE
Add constants for XCTest error domain and codes

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -296,8 +296,8 @@ extension XCTestCase {
             if unfulfilledDescriptions.count > 0 {
                 // If the test failed, send an error object.
                 error = NSError(
-                    domain: "org.swift.XCTestErrorDomain",
-                    code: 0,
+                    domain: XCTestErrorDomain,
+                    code: XCTestErrorCode.timeoutWhileWaiting.rawValue,
                     userInfo: [:])
             }
             completionHandler(error)

--- a/Sources/XCTest/XCTestErrors.swift
+++ b/Sources/XCTest/XCTestErrors.swift
@@ -1,0 +1,27 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestErrors.swift
+//  Constants used in errors produced by the XCTest library.
+//
+
+/// The domain used by errors produced by the XCTest library.
+public let XCTestErrorDomain = "org.swift.XCTestErrorDomain"
+
+/// Error codes for errors in the XCTestErrorDomain.
+public enum XCTestErrorCode : Int {
+    /// Indicates that one or more expectations failed to be fulfilled in time
+    /// during a call to `waitForExpectations(withTimeout:handler:)`
+    case timeoutWhileWaiting
+
+    /// Indicates that a test assertion failed while waiting for expectations
+    /// during a call to `waitForExpectations(withTimeout:handler:)`
+    /// FIXME: swift-corelibs-xctest does not currently produce this error code.
+    case failureWhileWaiting
+}

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -24,8 +24,8 @@ class HandlerTestCase: XCTestCase {
         var handlerWasCalled = false
         self.waitForExpectations(withTimeout: 0.2) { error in
             XCTAssertNotNil(error, "Expectation handlers for unfulfilled expectations should not be nil.")
-            XCTAssertTrue(error!.domain.hasSuffix("XCTestErrorDomain"), "The last component of the error domain should match Objective-C XCTest.")
-            XCTAssertEqual(error!.code, 0, "The error code should match Objective-C XCTest.")
+            XCTAssertEqual(error?.domain, XCTestErrorDomain, "The error domain should be XCTest's own error domain")
+            XCTAssertEqual(error?.code, XCTestErrorCode.timeoutWhileWaiting.rawValue, "The error code should indicate that a timeout occurred")
             handlerWasCalled = true
         }
         XCTAssertTrue(handlerWasCalled)

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */; };
 		AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */; };
 		AE9596E11C9692B8001A9EF0 /* XCTestObservationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */; };
+		AED59FF61CB5394800F49260 /* XCTestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED59FF51CB5394800F49260 /* XCTestErrors.swift */; };
 		C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */; };
 		C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */; };
 		C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */; };
@@ -46,6 +47,7 @@
 		AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestObservation.swift; sourceTree = "<group>"; };
 		AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectWrapper.swift; sourceTree = "<group>"; };
 		AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestObservationCenter.swift; sourceTree = "<group>"; };
+		AED59FF51CB5394800F49260 /* XCTestErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestErrors.swift; sourceTree = "<group>"; };
 		B1384A411C1B3E8700EDF031 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		B1384A421C1B3E8700EDF031 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		B1384A431C1B3E8700EDF031 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */,
 				DA7714F81CA87DEF001EA745 /* XCTestSuiteRun.swift */,
 				DA7714FA1CA87DFB001EA745 /* XCTestCaseRun.swift */,
+				AED59FF51CB5394800F49260 /* XCTestErrors.swift */,
 				DADB979B1C51BDA2005E68B6 /* XCTestExpectation.swift */,
 				C265F66C1C3AEB6A00520CF9 /* XCTestMain.swift */,
 				AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */,
@@ -282,6 +285,7 @@
 				DA7FB3431CA4EA4000F024F9 /* XCTestSuite.swift in Sources */,
 				DA7714F91CA87DEF001EA745 /* XCTestSuiteRun.swift in Sources */,
 				AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */,
+				AED59FF61CB5394800F49260 /* XCTestErrors.swift in Sources */,
 				C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This introduces error domain and error code constants, match the naming used by Apple XCTest under Swift 3.

Note that the `failureWhileWaiting` error code is not currently used. I tried to coax Apple XCTest into producing an error with that code, but was unable to, so I filed a [radar](http://openradar.appspot.com/25604155) to help understand what's going on. @mike-ferris-apple do you have any insight here?