### PR TITLE
[xctest_checker] Inline expectations

### DIFF
--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -19,9 +19,9 @@ class SingleFailingTestCase: XCTestCase {
         ]
     }
 
-// CHECK: Test Case 'SingleFailingTestCase.test_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/SingleFailingTestCase/main.swift:26: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
-// CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'SingleFailingTestCase.test_fails' started at \d+:\d+:\d+\.\d+
+    // CHECK: .*/SingleFailingTestCase/main.swift:26: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
+    // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)
     }

--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 
 from xctest_checker import compare
+from xctest_checker.error import XCTestCheckerError
 
 
 def _tmpfile(content):
@@ -26,30 +27,52 @@ class CompareTestCase(unittest.TestCase):
     def test_no_match_raises(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: baz\nc: bar\n')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(XCTestCheckerError):
             compare.compare(actual, expected, check_prefix='c: ')
 
-    def test_too_few_expected_raises(self):
+    def test_too_few_expected_raises_and_first_line_in_error(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: bar\n')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(XCTestCheckerError) as cm:
             compare.compare(actual, expected, check_prefix='c: ')
 
-    def test_too_many_expected_raises(self):
+        self.assertIn('{}:{}'.format(expected, 1), cm.exception.message)
+
+    def test_too_many_expected_raises_and_excess_check_line_in_error(self):
         actual = _tmpfile('foo\nbar\n')
         expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(XCTestCheckerError) as cm:
             compare.compare(actual, expected, check_prefix='c: ')
+
+        self.assertIn('{}:{}'.format(expected, 3), cm.exception.message)
 
     def test_match_does_not_raise(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
         compare.compare(actual, expected, check_prefix='c: ')
 
+    def test_match_with_inline_check_does_not_raise(self):
+        actual = _tmpfile('bling\nblong\n')
+        expected = _tmpfile('meep meep // c: bling\nmeep\n// c: blong\n')
+        compare.compare(actual, expected, check_prefix='// c: ')
+
+    def test_check_prefix_twice_in_the_same_line_raises_with_line(self):
+        actual = _tmpfile('blorp\nbleep\n')
+        expected = _tmpfile('c: blorp\nc: bleep c: blammo\n')
+        with self.assertRaises(XCTestCheckerError) as cm:
+            compare.compare(actual, expected, check_prefix='c: ')
+
+        self.assertIn('{}:{}'.format(expected, 2), cm.exception.message)
+
+    def test_check_prefix_in_run_line_ignored(self):
+        actual = _tmpfile('flim\n')
+        expected = _tmpfile('// RUN: xctest_checker --prefix "c: "\nc: flim\n')
+        compare.compare(actual, expected, check_prefix='c: ')
+
     def test_includes_file_name_and_line_of_expected_in_error(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: baz\nc: bar\n')
-        with self.assertRaises(AssertionError) as cm:
+        with self.assertRaises(XCTestCheckerError) as cm:
             compare.compare(actual, expected, check_prefix='c: ')
 
         self.assertIn("{}:{}:".format(expected, 2), cm.exception.message)

--- a/Tests/Functional/xctest_checker/xctest_checker/error.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/error.py
@@ -1,0 +1,19 @@
+# xctest_checker/error.py - Errors that display nicely in Xcode -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+class XCTestCheckerError(Exception):
+    """
+    An exception that indicates an xctest_checker-based functional test should
+    fail. Formats exception messages such that they render inline in Xcode.
+    """
+    def __init__(self, path, line_number, message):
+        super(XCTestCheckerError, self).__init__(
+            '\n{}:{}: {}'.format(path, line_number, message))


### PR DESCRIPTION
Enhance xctest_checker such that it can parse "CHECK" prefixes that are in the middle of a line (instead of just at the very beginning).

In addition, use a common `XCTestCheckerError` to ensure all functional test suite failures are displayed inline in Xcode.

---

This splits the first part of #68 out into its own pull request. It also only changes one functional test, in order to minimize merge conflicts.