### PR TITLE
Disable implicit dependency finding and parallelized builds for Xcode schemes

### DIFF
--- a/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTest.xcscheme
+++ b/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTest.xcscheme
@@ -3,9 +3,23 @@
    LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B5D885C1BBC938800234F36"
+               BuildableName = "SwiftFoundation.framework"
+               BlueprintName = "SwiftFoundation"
+               ReferencedContainer = "container:../swift-corelibs-foundation/Foundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -29,6 +43,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
+            BuildableName = "SwiftXCTest.framework"
+            BlueprintName = "SwiftXCTest"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestFunctionalTests.xcscheme
+++ b/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestFunctionalTests.xcscheme
@@ -3,9 +3,37 @@
    LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B5D885C1BBC938800234F36"
+               BuildableName = "SwiftFoundation.framework"
+               BlueprintName = "SwiftFoundation"
+               ReferencedContainer = "container:../swift-corelibs-foundation/Foundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B5D86DA1BBC74AD00234F36"
+               BuildableName = "SwiftXCTest.framework"
+               BlueprintName = "SwiftXCTest"
+               ReferencedContainer = "container:XCTest.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -29,6 +57,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DAA333B51C267AD6000CC115"
+            BuildableName = "SwiftXCTestFunctionalTests"
+            BlueprintName = "SwiftXCTestFunctionalTests"
+            ReferencedContainer = "container:XCTest.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>


### PR DESCRIPTION
This is an attempt to resolve intermittent build failures that have the appearance of being caused by a race condition, as in the latest OS X CI run on #77.

Even if this doesn't directly fix that CI issue, it's probably a good idea to make this change anyway. Corelibs Foundation has these flags off also, and we have very little to gain from parallelized target builds due to the shape of our dependency graph.