### PR TITLE
Use Linux Glibc and Foundation on Android

### DIFF
--- a/Sources/XCTest/PrintObserver.swift
+++ b/Sources/XCTest/PrintObserver.swift
@@ -11,7 +11,7 @@
 //  Prints test progress to stdout.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Sources/XCTest/XCNotificationExpectationHandler.swift
+++ b/Sources/XCTest/XCNotificationExpectationHandler.swift
@@ -12,7 +12,7 @@
 //  observed.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -11,7 +11,7 @@
 //  Base class for test cases
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -12,7 +12,7 @@
 //  for running tests and some infrastructure for running them.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Glibc
     import Foundation
 #else

--- a/Sources/XCTest/XCTestObservation.swift
+++ b/Sources/XCTest/XCTestObservation.swift
@@ -11,7 +11,7 @@
 //  Hooks for being notified about progress during a test run.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Sources/XCTest/XCTestObservationCenter.swift
+++ b/Sources/XCTest/XCTestObservationCenter.swift
@@ -11,7 +11,7 @@
 //  Notification center for test run progress events.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Sources/XCTest/XCTestRun.swift
+++ b/Sources/XCTest/XCTestRun.swift
@@ -11,7 +11,7 @@
 //  A test run collects information about the execution of a test.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Sources/XCTest/XCTestSuiteRun.swift
+++ b/Sources/XCTest/XCTestSuiteRun.swift
@@ -11,7 +11,7 @@
 //  A test run for an `XCTestSuite`.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Sources/XCTest/XCWaitCompletionHandler.swift
+++ b/Sources/XCTest/XCWaitCompletionHandler.swift
@@ -12,7 +12,7 @@
 //  fulfilled times out.
 //
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import Foundation
 #else
     import SwiftFoundation

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/Asynchronous > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
     import Foundation
 #else

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/Handler > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
     import Foundation
 #else

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/Misuse > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/Asynchronous-Notifications > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
     import Foundation
 #else

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/Asynchronous-Notifications-Handler > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
     import Foundation
 #else

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/ErrorHandling > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/FailingTestSuite > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/FailureMessagesTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/NegativeAccuracyTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/All > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
     import Foundation
 #else

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/Selected Selected.ExecutedTestCase/test_executed > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
     import Foundation
 #else

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -6,7 +6,7 @@
 // RUN: %{xctest_checker} -p "// CHECK-TESTCASE:" %T/one_test_case %s
 // RUN: %{xctest_checker} -p "// CHECK-ALL:" %T/all %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/SingleFailingTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -2,7 +2,7 @@
 // RUN: %{built_tests_dir}/TestCaseLifecycle > %t || true
 // RUN: %{xctest_checker} %t %s
 
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
     import XCTest
 #else
     import SwiftXCTest


### PR DESCRIPTION
Expand the Linux/FreeBSD check to include Android. The "Android" OS will be supported by the next snapshot (which this commit will also be a part of).

---

corelibs-xctest won't work on Android yet, even after this change. For it to work, we'll need to port corelibs-foundation as well. Still, consider this a bit of preliminary work.