### PR TITLE
Update APIs to match some tweaking for Swift3 in Xcode's XCTest.

### DIFF
--- a/Sources/XCTest/XCTestSuite.swift
+++ b/Sources/XCTest/XCTestSuite.swift
@@ -65,7 +65,7 @@ public class XCTestSuite: XCTest {
         setUp()
         for test in tests {
             test.run()
-            testRun.addTest(test.testRun!)
+            testRun.addTestRun(test.testRun!)
         }
         tearDown()
         run.stop()

--- a/Sources/XCTest/XCTestSuiteRun.swift
+++ b/Sources/XCTest/XCTestSuiteRun.swift
@@ -57,7 +57,7 @@ public class XCTestSuiteRun: XCTestRun {
 
     /// Add a test run to the collection of `testRuns`.
     /// - Note: It is rare to call this method outside of XCTest itself.
-    public func addTest(_ testRun: XCTestRun) {
+    public func addTestRun(_ testRun: XCTestRun) {
         testRuns.append(testRun)
     }
 


### PR DESCRIPTION
This pull request changes 1 API (XCTestSuiteRun's addTest() method, changing it to addTestRun()) to match a similar change that is being made in Xcode's XCTest for Swift 3.

In this particular case, the importer just got it wrong. The Objective-C selector is addTestRun:. Until Xcode ships for Swift 3, this will be an inconsistency in the API, but this is a more or less never used API outside the implementation of XCTest.