### PR TITLE
Standardize usage of the term "test case" in the code and documentation

### DIFF
--- a/Documentation/Linux.md
+++ b/Documentation/Linux.md
@@ -23,7 +23,7 @@ class TestNSURL : XCTestCase {
 }
 ```
 
-Also, this version of XCTest does not use the external test runner binary. Instead, create your own executable which links `libXCTest.so`. In your `main.swift`, invoke the `XCTMain` function with an array of the test cases classes that you wish to run, wrapped by the `testCase` helper function. For example:
+Also, this version of XCTest does not use the external test runner binary. Instead, create your own executable which links `libXCTest.so`. In your `main.swift`, invoke the `XCTMain` function with an array of the tests from the `XCTestCase` subclasses that you wish to run, wrapped by the `testCase` helper function. For example:
 
 ```swift
 XCTMain([testCase(TestNSString.allTests), testCase(TestNSArray.allTests), testCase(TestNSDictionary.allTests)])
@@ -32,7 +32,7 @@ XCTMain([testCase(TestNSString.allTests), testCase(TestNSArray.allTests), testCa
 The `XCTMain` function does not return, and will cause your test app to exit with either `0` for success or `1` for failure. Command line arguments given to the executable can be used to select a particular test or test case to execute. For example:
 
 ```sh
-./FooTests FooTestCase/testFoo  # Run a single test method
+./FooTests FooTestCase/testFoo  # Run a single test case
 ./FooTests FooTestCase          # Run all the tests in FooTestCase
 ```
 

--- a/Sources/XCTest/TestFiltering.swift
+++ b/Sources/XCTest/TestFiltering.swift
@@ -37,20 +37,19 @@ internal struct TestFiltering {
 
     static func filterTests(_ entries: [XCTestCaseEntry], filter: TestFilter) -> [XCTestCaseEntry] {
         return entries
-            .map { testCase, tests in
-                return (testCase, tests.filter { filter(testCase, $0.0) } )
+            .map { testCaseClass, testCaseMethods in
+                return (testCaseClass, testCaseMethods.filter { filter(testCaseClass, $0.0) } )
             }
-            .filter { testCase, tests in
-                return !tests.isEmpty
+            .filter { _, testCaseMethods in
+                return !testCaseMethods.isEmpty
             }
     }
 }
 
-/// A selected test can be an entire test case, or a single test method
-/// within a test case.
+/// A selected test can be a single test case, or an entire class of test cases
 private struct SelectedTest {
-    let testCaseName: String
-    let testName: String?
+    let testCaseClassName: String
+    let testCaseMethodName: String?
 }
 
 private extension SelectedTest {
@@ -58,17 +57,17 @@ private extension SelectedTest {
         let components = selectedTestName.characters.split(separator: "/").map(String.init)
         switch components.count {
         case 1:
-            testCaseName = components[0]
-            testName = nil
+            testCaseClassName = components[0]
+            testCaseMethodName = nil
         case 2:
-            testCaseName = components[0]
-            testName = components[1]
+            testCaseClassName = components[0]
+            testCaseMethodName = components[1]
         default:
             return nil
         }
     }
 
-    func matches(testCase: XCTestCase.Type, testName: String) -> Bool {
-        return String(reflecting: testCase) == testCaseName && (self.testName == nil || testName == self.testName)
+    func matches(testCaseClass: XCTestCase.Type, testCaseMethodName: String) -> Bool {
+        return String(reflecting: testCaseClass) == testCaseClassName && (self.testCaseMethodName == nil || testCaseMethodName == self.testCaseMethodName)
     }
 }

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -18,7 +18,7 @@
 #endif
 
 /// This is a compound type used by `XCTMain` to represent tests to run. It combines an
-/// `XCTestCase` subclass type with the list of test methods to invoke on the test case.
+/// `XCTestCase` subclass type with the list of test case methods to invoke on the class.
 /// This type is intended to be produced by the `testCase` helper function.
 /// - seealso: `testCase`
 /// - seealso: `XCTMain`
@@ -28,6 +28,10 @@ public typealias XCTestCaseEntry = (testCaseClass: XCTestCase.Type, allTests: [(
 // order for XCTAssert functions to report failures.
 internal var XCTCurrentTestCase: XCTestCase?
 
+/// An instance of this class represents an individual test case which can be
+/// run by the framework. This class is normally subclassed and extended with
+/// methods containing the tests to run.
+/// - seealso: `XCTMain`
 public class XCTestCase: XCTest {
     private let testClosure: XCTestCase throws -> Void
 

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -42,9 +42,9 @@
 ///
 ///     XCTMain([ testCase(TestFoo.allTests) ])
 ///
-/// Command line arguments can be used to select a particular test or test case to execute. For example:
+/// Command line arguments can be used to select a particular test case or class to execute. For example:
 ///
-///     ./FooTests FooTestCase/testFoo  # Run a single test method
+///     ./FooTests FooTestCase/testFoo  # Run a single test case
 ///     ./FooTests FooTestCase          # Run all the tests in FooTestCase
 ///
 /// - Parameter testCases: An array of test cases run, each produced by a call to the `testCase` function
@@ -75,10 +75,10 @@
     }
 
     let filter = TestFiltering(selectedTestName: selectedTestName)
-    for (testCaseType, tests) in TestFiltering.filterTests(testCases, filter: filter.selectedTestFilter) {
-        let testCaseSuite = XCTestSuite(name: "\(testCaseType)")
-        for (testName, testClosure) in tests {
-            let testCase = testCaseType.init(name: testName, testClosure: testClosure)
+    for (testCaseClass, testCaseMethods) in TestFiltering.filterTests(testCases, filter: filter.selectedTestFilter) {
+        let testCaseSuite = XCTestSuite(name: "\(testCaseClass)")
+        for (testName, testClosure) in testCaseMethods {
+            let testCase = testCaseClass.init(name: testName, testClosure: testClosure)
             testCaseSuite.addTest(testCase)
         }
         currentTestSuite.addTest(testCaseSuite)

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -44,7 +44,7 @@ class SkippedTestCase: XCTestCase {
     }
 
     func test_skipped() {
-        XCTFail("This test method should not be executed.")
+        XCTFail("This test case should not be executed.")
     }
 }
 
@@ -65,7 +65,7 @@ class ExecutedTestCase: XCTestCase {
     }
 
     func test_skipped() {
-        XCTFail("This test method should not be executed.")
+        XCTFail("This test case should not be executed.")
     }
 }
 

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -1,9 +1,9 @@
 // RUN: %{swiftc} %s -o %{built_tests_dir}/SelectedTest
-// RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_method || true
-// RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case || true
+// RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_case || true
+// RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case_class || true
 // RUN: %{built_tests_dir}/SelectedTest > %T/all || true
-// RUN: %{xctest_checker} -p "// CHECK-METHOD:" %T/one_test_method %s
-// RUN: %{xctest_checker} -p "// CHECK-TESTCASE:" %T/one_test_case %s
+// RUN: %{xctest_checker} -p "// CHECK-METHOD:" %T/one_test_case %s
+// RUN: %{xctest_checker} -p "// CHECK-CLASS:" %T/one_test_case_class %s
 // RUN: %{xctest_checker} -p "// CHECK-ALL:" %T/all %s
 
 #if os(Linux) || os(FreeBSD)
@@ -13,7 +13,7 @@
 #endif
 
 // CHECK-METHOD: Test Suite 'Selected tests' started at \d+:\d+:\d+\.\d+
-// CHECK-TESTCASE: Test Suite 'Selected tests' started at \d+:\d+:\d+\.\d+
+// CHECK-CLASS: Test Suite 'Selected tests' started at \d+:\d+:\d+\.\d+
 // CHECK-ALL: Test Suite 'All tests' started at \d+:\d+:\d+\.\d+
 // CHECK-ALL: Test Suite '.*\.xctest' started at \d+:\d+:\d+\.\d+
 
@@ -28,24 +28,24 @@ class ExecutedTestCase: XCTestCase {
 // CHECK-METHOD:   Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
 // CHECK-METHOD:   Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
 // CHECK-METHOD:   Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
-// CHECK-TESTCASE: Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
-// CHECK-TESTCASE: Test Case 'ExecutedTestCase.test_bar' started at \d+:\d+:\d+\.\d+
-// CHECK-TESTCASE: Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\).
+// CHECK-CLASS: Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
+// CHECK-CLASS: Test Case 'ExecutedTestCase.test_bar' started at \d+:\d+:\d+\.\d+
+// CHECK-CLASS: Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\).
 // CHECK-ALL:      Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' started at \d+:\d+:\d+\.\d+
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\).
     func test_bar() {}
 
-// CHECK-TESTCASE: Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
-// CHECK-TESTCASE: Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
+// CHECK-CLASS: Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
+// CHECK-CLASS: Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
     func test_foo() {}
 }
 // CHECK-METHOD:   Test Suite 'ExecutedTestCase' passed at \d+:\d+:\d+\.\d+
 // CHECK-METHOD:   \t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK-TESTCASE: Test Suite 'ExecutedTestCase' passed at \d+:\d+:\d+\.\d+
-// CHECK-TESTCASE: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK-CLASS: Test Suite 'ExecutedTestCase' passed at \d+:\d+:\d+\.\d+
+// CHECK-CLASS: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-ALL:      Test Suite 'ExecutedTestCase' passed at \d+:\d+:\d+\.\d+
 // CHECK-ALL:      \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
@@ -70,8 +70,8 @@ XCTMain([
 
 // CHECK-METHOD:   Test Suite 'Selected tests' passed at \d+:\d+:\d+\.\d+
 // CHECK-METHOD:   \t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
-// CHECK-TESTCASE: Test Suite 'Selected tests' passed at \d+:\d+:\d+\.\d+
-// CHECK-TESTCASE: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK-CLASS: Test Suite 'Selected tests' passed at \d+:\d+:\d+\.\d+
+// CHECK-CLASS: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-ALL:      Test Suite '.*\.xctest' passed at \d+:\d+:\d+\.\d+
 // CHECK-ALL:      \t Executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-ALL:      Test Suite 'All tests' passed at \d+:\d+:\d+\.\d+


### PR DESCRIPTION
While thinking about the terminology we've been using to talk about tests for this framework, I realized that the term "test case" is being used to mean two distinct things:

1) A single test to be executed by the framework (i.e. an `XCTestCase` instance)
2) An `XCTestCase` subclass, including all of its test methods

After thinking about it more carefully and looking through the Apple XCTest header comments<sup>[*](#note1)</sup>, I've come to the conclusion that #1 is the correct usage. This PR is an attempt to improve our consistency around this.

Looking for feedback on both the underlying assumptions and the specific changes I'm proposing here!

<a name="note1">* Note</a>: Assuming folks agree with this usage suggestion, I'll be opening a Radar also, as there are a couple of points where the same confusion can be detected in the Apple XCTest headers.