### PR TITLE
Add class-level `setUp` and `tearDown` methods on `XCTestCase`

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -129,6 +129,14 @@ public class XCTestCase: XCTest {
             fatalError("Terminating execution due to test failure")
         }
     }
+
+    /// Setup method called before the invocation of any test method in the
+    /// class.
+    public class func setUp() {}
+
+    /// Teardown method called after the invocation of every test method in the
+    /// class.
+    public class func tearDown() {}
 }
 
 /// Wrapper function allowing an array of static test case methods to fit

--- a/Sources/XCTest/XCTestCaseSuite.swift
+++ b/Sources/XCTest/XCTestCaseSuite.swift
@@ -1,0 +1,48 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestCaseSuite.swift
+//  A test suite associated with a paticular test case class.
+//
+
+#if os(Linux) || os(FreeBSD)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
+/// A test suite which is associated with a particular test case class. It will
+/// call `setUp` and `tearDown` on the class itself before and after invoking
+/// all of the test cases making up the class.
+internal class XCTestCaseSuite: XCTestSuite {
+    private let testCaseClass: XCTestCase.Type?
+
+    init(testCaseEntry: XCTestCaseEntry) {
+        let testCaseClass = testCaseEntry.testCaseClass
+        self.testCaseClass = testCaseClass
+        super.init(name: String(testCaseClass))
+
+        for (testName, testClosure) in testCaseEntry.allTests {
+            let testCase = testCaseClass.init(name: testName, testClosure: testClosure)
+            addTest(testCase)
+        }
+    }
+
+    override func setUp() {
+        if let testCaseClass = testCaseClass {
+            testCaseClass.setUp()
+        }
+    }
+
+    override func tearDown() {
+        if let testCaseClass = testCaseClass {
+            testCaseClass.tearDown()
+        }
+    }
+}

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -75,14 +75,9 @@
     }
 
     let filter = TestFiltering(selectedTestName: selectedTestName)
-    for (testCaseClass, testCaseMethods) in TestFiltering.filterTests(testCases, filter: filter.selectedTestFilter) {
-        let testCaseSuite = XCTestSuite(name: "\(testCaseClass)")
-        for (testName, testClosure) in testCaseMethods {
-            let testCase = testCaseClass.init(name: testName, testClosure: testClosure)
-            testCaseSuite.addTest(testCase)
-        }
-        currentTestSuite.addTest(testCaseSuite)
-    }
+    TestFiltering.filterTests(testCases, filter: filter.selectedTestFilter)
+        .map(XCTestCaseSuite.init)
+        .forEach(currentTestSuite.addTest)
 
     rootTestSuite.run()
 

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -21,6 +21,12 @@ class SetUpTearDownTestCase: XCTestCase {
 
     var value = 0
 
+    // CHECK: In class setUp\(\)
+    override class func setUp() {
+        super.setUp()
+        print("In class \(#function)")
+    }
+
     override func setUp() {
         super.setUp()
         print("In \(#function)")
@@ -40,6 +46,12 @@ class SetUpTearDownTestCase: XCTestCase {
     func test_hasValueFromSetUp() {
         print("In \(#function)")
         XCTAssertEqual(value, 42)
+    }
+
+    // CHECK: In class tearDown\(\)
+    override class func tearDown() {
+        super.tearDown()
+        print("In class \(#function)")
     }
 }
 // CHECK: Test Suite 'SetUpTearDownTestCase' passed at \d+:\d+:\d+\.\d+

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		510957A91CA878410091D1A1 /* XCNotificationExpectationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510957A81CA878410091D1A1 /* XCNotificationExpectationHandler.swift */; };
+		AE33888B1CD3D72500C39B1C /* XCTestCaseSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE33888A1CD3D72500C39B1C /* XCTestCaseSuite.swift */; };
 		AE7DD6091C8E81A0006FC722 /* ArgumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */; };
 		AE7DD60A1C8E81A0006FC722 /* TestFiltering.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */; };
 		AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */; };
@@ -41,6 +42,7 @@
 /* Begin PBXFileReference section */
 		510957A81CA878410091D1A1 /* XCNotificationExpectationHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCNotificationExpectationHandler.swift; sourceTree = "<group>"; };
 		5B5D86DB1BBC74AD00234F36 /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE33888A1CD3D72500C39B1C /* XCTestCaseSuite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseSuite.swift; sourceTree = "<group>"; };
 		AE7DD6061C8DC6C0006FC722 /* Functional */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Functional; sourceTree = "<group>"; };
 		AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgumentParser.swift; sourceTree = "<group>"; };
 		AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFiltering.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */,
 				DACC94411C8B87B900EC85F5 /* XCWaitCompletionHandler.swift */,
 				510957A81CA878410091D1A1 /* XCNotificationExpectationHandler.swift */,
+				AE33888A1CD3D72500C39B1C /* XCTestCaseSuite.swift */,
 			);
 			path = XCTest;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 				AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */,
 				AED59FF61CB5394800F49260 /* XCTestErrors.swift in Sources */,
 				C265F6721C3AEB6A00520CF9 /* XCTestMain.swift in Sources */,
+				AE33888B1CD3D72500C39B1C /* XCTestCaseSuite.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This adds support for `setUp` and `tearDown` class methods on `XCTestCase` which Apple XCTest has, and we were still missing. These are called by a private `XCTestSuite` subclass which is configured explicitly with the test case class whose tests are in the suite.