### PR TITLE
Adjusted usage of NSComparisonResult cases to Darwin API

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -284,7 +284,7 @@ extension XCTestCase {
 
             // Otherwise, wait another fraction of a second.
             runLoop.runUntilDate(NSDate(timeIntervalSinceNow: 0.01))
-        } while NSDate().compare(timeoutDate) == NSComparisonResult.OrderedAscending
+        } while NSDate().compare(timeoutDate) == NSComparisonResult.orderedAscending
 
         if unfulfilledDescriptions.count > 0 {
             // Not all expectations were fulfilled. Append a failure

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -41,7 +41,7 @@ class PredicateExpectationsTestCase: XCTestCase {
         let predicate = NSPredicate(block: {
             evaluatedObject, bindings in
             if let evaluatedDate = evaluatedObject as? NSDate {
-                return evaluatedDate.compare(NSDate()) == NSComparisonResult.OrderedAscending
+                return evaluatedDate.compare(NSDate()) == NSComparisonResult.orderedAscending
             }
             return false
         })
@@ -55,7 +55,7 @@ class PredicateExpectationsTestCase: XCTestCase {
         let halfSecLaterDate = NSDate(timeIntervalSinceNow: 0.01)
         let predicate = NSPredicate(block: { evaluatedObject, bindings in
             if let evaluatedDate = evaluatedObject as? NSDate {
-                return evaluatedDate.compare(NSDate()) == NSComparisonResult.OrderedDescending
+                return evaluatedDate.compare(NSDate()) == NSComparisonResult.orderedDescending
             }
             return false
         })

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -44,7 +44,7 @@ class PredicateHandlerTestCase: XCTestCase {
         let halfSecLaterDate = NSDate(timeIntervalSinceNow: 0.2)
         let predicate = NSPredicate(block: { evaluatedObject, bindings in
             if let evaluatedDate = evaluatedObject as? NSDate {
-                return evaluatedDate.compare(NSDate()) == NSComparisonResult.OrderedAscending
+                return evaluatedDate.compare(NSDate()) == NSComparisonResult.orderedAscending
             }
             return false
         })


### PR DESCRIPTION
This is a follow-up PR for [#356 Changed API of comparison/sort/enumeration/qos options to match Darwin version](https://github.com/apple/swift-corelibs-foundation/pull/356) in swift-corelibs-foundation