### PR TITLE
[SR-1355] Add Performance Measurement APIs

### DIFF
--- a/Sources/XCTest/PerformanceMeter.swift
+++ b/Sources/XCTest/PerformanceMeter.swift
@@ -1,0 +1,190 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  PerformanceMeter.swift
+//  Measures the performance of a block of code and reports the results.
+//
+
+#if os(Linux) || os(FreeBSD)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
+/// Describes a type that is capable of measuring some aspect of code performance
+/// over time.
+internal protocol PerformanceMetric {
+    /// Called once per iteration immediately before the tested code is executed. 
+    /// The metric should do whatever work is required to begin a new measurement.
+    func startMeasuring()
+
+    /// Called once per iteration immediately after the tested code is executed.
+    /// The metric should do whatever work is required to finalize measurement.
+    func stopMeasuring()
+
+    /// Called once, after all measurements have been taken, to provide feedback
+    /// about the collected measurements.
+    /// - Returns: Measurement results to present to the user.
+    func calculateResults() -> String
+
+    /// Called once, after all measurements have been taken, to determine whether
+    /// the measurements should be treated as a test failure or not.
+    /// - Returns: A diagnostic message if the results indicate failure, else nil.
+    func failureMessage() -> String?
+}
+
+internal protocol PerformanceMeterDelegate {
+    func recordMeasurements(results: String, file: StaticString, line: UInt)
+    func recordFailure(description: String, file: StaticString, line: UInt)
+    func recordAPIViolation(description: String, file: StaticString, line: UInt)
+}
+
+/// - Bug: This class is intended to be `internal` but is public to work around
+/// a toolchain bug on Linux. See `XCTestCase._performanceMeter` for more info.
+public final class PerformanceMeter {
+    enum Error: ErrorProtocol, CustomStringConvertible {
+        case noMetrics
+        case unknownMetric(metricName: String)
+        case startMeasuringAlreadyCalled
+        case stopMeasuringAlreadyCalled
+        case startMeasuringNotCalled
+        case stopBeforeStarting
+
+        var description: String {
+            switch self {
+            case .noMetrics: return "At least one metric must be provided to measure."
+            case .unknownMetric(let name): return "Unknown metric: \(name)"
+            case .startMeasuringAlreadyCalled: return "Already called startMeasuring() once this iteration."
+            case .stopMeasuringAlreadyCalled: return "Already called stopMeasuring() once this iteration."
+            case .startMeasuringNotCalled: return "startMeasuring() must be called during the block."
+            case .stopBeforeStarting: return "Cannot stop measuring before starting measuring."
+            }
+        }
+    }
+
+    internal var didFinishMeasuring: Bool {
+        return state == .measurementFinished || state == .measurementAborted
+    }
+
+    private enum State {
+        case iterationUnstarted
+        case iterationStarted
+        case iterationFinished
+        case measurementFinished
+        case measurementAborted
+    }
+    private var state: State = .iterationUnstarted
+
+    private let metrics: [PerformanceMetric]
+    private let delegate: PerformanceMeterDelegate
+    private let invocationFile: StaticString
+    private let invocationLine: UInt
+
+    private init(metrics: [PerformanceMetric], delegate: PerformanceMeterDelegate, file: StaticString, line: UInt) {
+        self.metrics = metrics
+        self.delegate = delegate
+        self.invocationFile = file
+        self.invocationLine = line
+    }
+
+    static func measureMetrics(_ metricNames: [String], delegate: PerformanceMeterDelegate, file: StaticString = #file, line: UInt = #line, for block: @noescape (PerformanceMeter) -> Void) {
+        do {
+            let metrics = try self.metrics(forNames: metricNames)
+            let meter = PerformanceMeter(metrics: metrics, delegate: delegate, file: file, line: line)
+            meter.measure(block)
+        } catch let e {
+            delegate.recordAPIViolation(description: String(e), file: file, line: line)
+        }
+    }
+
+    func startMeasuring(file: StaticString = #file, line: UInt = #line) {
+        guard state == .iterationUnstarted else {
+            state = .measurementAborted
+            return recordAPIViolation(.startMeasuringAlreadyCalled, file: file, line: line)
+        }
+        state = .iterationStarted
+        metrics.forEach { $0.startMeasuring() }
+    }
+
+    func stopMeasuring(file: StaticString = #file, line: UInt = #line) {
+        guard state != .iterationUnstarted else {
+            return recordAPIViolation(.stopBeforeStarting, file: file, line: line)
+        }
+
+        guard state != .iterationFinished else {
+            return recordAPIViolation(.stopMeasuringAlreadyCalled, file: file, line: line)
+        }
+
+        state = .iterationFinished
+        metrics.forEach { $0.stopMeasuring() }
+    }
+
+    func abortMeasuring() {
+        state = .measurementAborted
+    }
+
+
+    private static func metrics(forNames names: [String]) throws -> [PerformanceMetric] {
+        guard !names.isEmpty else { throw Error.noMetrics }
+
+        let metricsMapping = [WallClockTimeMetric.name : WallClockTimeMetric.self]
+
+        return try names.map({
+            guard let metricType = metricsMapping[$0] else { throw Error.unknownMetric(metricName: $0) }
+            return metricType.init()
+        })
+    }
+
+    private var numberOfIterations: Int {
+        return 10
+    }
+
+    private func measure(_ block: @noescape (PerformanceMeter) -> Void) {
+        for _ in (0..<numberOfIterations) {
+            state = .iterationUnstarted
+
+            block(self)
+            stopMeasuringIfNeeded()
+
+            if state == .measurementAborted { return }
+
+            if state == .iterationUnstarted {
+                recordAPIViolation(.startMeasuringNotCalled, file: invocationFile, line: invocationLine)
+                return
+            }
+        }
+        state = .measurementFinished
+
+        recordResults()
+        recordFailures()
+    }
+
+    private func stopMeasuringIfNeeded() {
+        if state == .iterationStarted {
+            stopMeasuring()
+        }
+    }
+
+    private func recordResults() {
+        for metric in metrics {
+            delegate.recordMeasurements(results: metric.calculateResults(), file: invocationFile, line: invocationLine)
+        }
+    }
+
+    private func recordFailures() {
+        metrics.flatMap({ $0.failureMessage() }).forEach { message in
+            delegate.recordFailure(description: message, file: invocationFile, line: invocationLine)
+        }
+    }
+
+    private func recordAPIViolation(_ error: Error, file: StaticString, line: UInt) {
+        state = .measurementAborted
+        delegate.recordAPIViolation(description: String(error), file: file, line: line)
+    }
+}

--- a/Sources/XCTest/PrintObserver.swift
+++ b/Sources/XCTest/PrintObserver.swift
@@ -75,3 +75,9 @@ internal class PrintObserver: XCTestObservation {
         return String(round(timeInterval * 1000.0) / 1000.0)
     }
 }
+
+extension PrintObserver: _XCTestObservation {
+    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: UInt) {
+        printAndFlush("\(file):\(line): Test Case '\(testCase.name)' measured \(results)")
+    }
+}

--- a/Sources/XCTest/WallClockTimeMetric.swift
+++ b/Sources/XCTest/WallClockTimeMetric.swift
@@ -1,0 +1,86 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  WallClockTimeMetric.swift
+//  Performance metric measuring how long it takes code to execute
+//
+
+#if os(Linux) || os(FreeBSD)
+    import Foundation
+#else
+    import SwiftFoundation
+#endif
+
+/// This metric uses the system uptime to keep track of how much time passes
+/// between starting and stopping measuring.
+internal final class WallClockTimeMetric: PerformanceMetric {
+    static let name = "org.swift.XCTPerformanceMetric_WallClockTime"
+
+    typealias Measurement = NSTimeInterval
+    private var startTime: NSTimeInterval?
+    var measurements: [Measurement] = []
+
+    func startMeasuring() {
+        startTime = currentTime()
+    }
+
+    func stopMeasuring() {
+        guard let startTime = startTime else { fatalError("Must start measuring before stopping measuring") }
+        let stopTime = currentTime()
+        measurements.append(stopTime-startTime)
+    }
+
+    private let maxRelativeStandardDeviation = 10.0
+    private let standardDeviationNegligibilityThreshold = 0.1
+
+    func calculateResults() -> String {
+        let results = [
+                          String(format: "average: %.3f", measurements.average),
+                          String(format: "relative standard deviation: %.3f%%", measurements.relativeStandardDeviation),
+                          "values: [\(measurements.map({ String(format: "%.6f", $0) }).joined(separator: ", "))]",
+                          "performanceMetricID:\(self.dynamicType.name)",
+                          String(format: "maxPercentRelativeStandardDeviation: %.3f%%", maxRelativeStandardDeviation),
+                          String(format: "maxStandardDeviation: %.3f", standardDeviationNegligibilityThreshold),
+                          ]
+        return "[Time, seconds] \(results.joined(separator: ", "))"
+    }
+
+    func failureMessage() -> String? {
+        // The relative standard deviation of the measurements is \d+.\d{3}% which is higher than the max allowed of \d+.\d{3}%.
+        let relativeStandardDeviation = measurements.relativeStandardDeviation
+        if (relativeStandardDeviation > maxRelativeStandardDeviation &&
+            measurements.standardDeviation > standardDeviationNegligibilityThreshold) {
+            return String(format: "The relative standard deviation of the measurements is %.3f%% which is higher than the max allowed of %.3f%%.", relativeStandardDeviation, maxRelativeStandardDeviation)
+        }
+
+        return nil
+    }
+
+    private func currentTime() -> NSTimeInterval {
+        return NSProcessInfo.processInfo().systemUptime
+    }
+}
+
+
+private extension Collection where Index: IntegerLiteralConvertible, Iterator.Element == WallClockTimeMetric.Measurement {
+    var average: WallClockTimeMetric.Measurement {
+        return self.reduce(0, combine: +) / Double(count.toIntMax())
+    }
+
+    var standardDeviation: WallClockTimeMetric.Measurement {
+        let average = self.average
+        let squaredDifferences = self.map({ pow($0 - average, 2.0) })
+        let variance = squaredDifferences.reduce(0, combine: +) / Double(count.toIntMax()-1)
+        return sqrt(variance)
+    }
+
+    var relativeStandardDeviation: Double {
+        return (standardDeviation*100) / average
+    }
+}

--- a/Sources/XCTest/XCTestCase+Performance.swift
+++ b/Sources/XCTest/XCTestCase+Performance.swift
@@ -1,0 +1,166 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTestCase+Performance.swift
+//  Methods on XCTestCase for testing the performance of code blocks.
+//
+
+/// Records wall clock time in seconds between `startMeasuring`/`stopMeasuring`.
+public let XCTPerformanceMetric_WallClockTime = WallClockTimeMetric.name
+
+/// The following methods are called from within a test method to carry out 
+/// performance testing on blocks of code.
+public extension XCTestCase {
+
+    /// The names of the performance metrics to measure when invoking `measure(block:)`. 
+    /// Returns `XCTPerformanceMetric_WallClockTime` by default. Subclasses can
+    /// override this to change the behavior of `measure(block:)`
+    class func defaultPerformanceMetrics() -> [String] {
+        return [XCTPerformanceMetric_WallClockTime]
+    }
+
+    /// Call from a test method to measure resources (`defaultPerformanceMetrics()`)
+    /// used by the block in the current process.
+    ///
+    ///     func testPerformanceOfMyFunction() {
+    ///         measure {
+    ///             // Do that thing you want to measure.
+    ///             MyFunction();
+    ///         }
+    ///     }
+    ///
+    /// - Parameter block: A block whose performance to measure.
+    /// - Bug: The `block` param should have no external label, but there seems
+    ///   to be a swiftc bug that causes issues when such a parameter comes
+    ///   after a defaulted arg. See https://bugs.swift.org/browse/SR-1483 This
+    ///   API incompatibility with Apple XCTest can be worked around in practice 
+    ///   by using trailing closure syntax when calling this method.
+    /// - ToDo: The `block` param should be marked @noescape once Apple XCTest
+    ///   has been updated to do so rdar://26224596
+    /// - Note: Whereas Apple XCTest determines the file and line number of
+    ///   measurements by using symbolication, this implementation opts to take
+    ///   `file` and `line` as parameters instead. As a result, the interface to
+    ///   these methods are not exactly identical between these environments. To 
+    ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
+    ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
+    func measure(file: StaticString = #file, line: UInt = #line, block: () -> Void) {
+        measureMetrics(self.dynamicType.defaultPerformanceMetrics(),
+                       automaticallyStartMeasuring: true,
+                       file: file,
+                       line: line,
+                       for: block)
+    }
+
+    /// Call from a test method to measure resources (XCTPerformanceMetrics) used
+    /// by the block in the current process. Each metric will be measured across 
+    /// calls to the block. The number of times the block will be called is undefined
+    /// and may change in the future. For one example of why, as long as the requested
+    /// performance metrics do not interfere with each other the API will measure 
+    /// all metrics across the same calls to the block. If the performance metrics
+    /// may interfere the API will measure them separately.
+    ///
+    ///     func testMyFunction2_WallClockTime() {
+    ///         measureMetrics(self.dynamicType.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) {
+    ///
+    ///             // Do setup work that needs to be done for every iteration but
+    ///             // you don't want to measure before the call to `startMeasuring()`
+    ///             SetupSomething();
+    ///             self.startMeasuring()
+    ///
+    ///             // Do that thing you want to measure.
+    ///             MyFunction()
+    ///             self.stopMeasuring()
+    ///
+    ///             // Do teardown work that needs to be done for every iteration 
+    ///             // but you don't want to measure after the call to `stopMeasuring()`
+    ///             TeardownSomething()
+    ///         }
+    ///     }
+    ///
+    /// Caveats:
+    /// * If `true` was passed for `automaticallyStartMeasuring` and `startMeasuring()`
+    ///   is called anyway, the test will fail.
+    /// * If `false` was passed for `automaticallyStartMeasuring` then `startMeasuring()`
+    ///   must be called once and only once before the end of the block or the test will fail.
+    /// * If `stopMeasuring()` is called multiple times during the block the test will fail.
+    ///
+    /// - Parameter metrics: An array of Strings (XCTPerformanceMetrics) to measure. 
+    ///     Providing an unrecognized string is a test failure.
+    /// - Parameter automaticallyStartMeasuring: If `false`, `XCTestCase` will 
+    ///     not take any measurements until -startMeasuring is called.
+    /// - Parameter block: A block whose performance to measure.
+    /// - ToDo: The `block` param should be marked @noescape once Apple XCTest
+    ///     has been updated to do so. rdar://26224596
+    /// - Note: Whereas Apple XCTest determines the file and line number of
+    ///   measurements by using symbolication, this implementation opts to take
+    ///   `file` and `line` as parameters instead. As a result, the interface to
+    ///   these methods are not exactly identical between these environments. To
+    ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
+    ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
+    func measureMetrics(_ metrics: [String], automaticallyStartMeasuring: Bool, file: StaticString = #file, line: UInt = #line, for block: () -> Void) {
+        guard _performanceMeter == nil else {
+            return recordAPIViolation(description: "Can only record one set of metrics per test method.", file: file, line: line)
+        }
+
+        PerformanceMeter.measureMetrics(metrics, delegate: self, file: file, line: line) { meter in
+            self._performanceMeter = meter
+            if automaticallyStartMeasuring {
+                meter.startMeasuring()
+            }
+            block()
+        }
+    }
+
+    /// Call this from within a measure block to set the beginning of the critical 
+    /// section. Measurement of metrics will start at this point.
+    /// - Note: Whereas Apple XCTest determines the file and line number of
+    ///   measurements by using symbolication, this implementation opts to take
+    ///   `file` and `line` as parameters instead. As a result, the interface to
+    ///   these methods are not exactly identical between these environments. To
+    ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
+    ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
+    func startMeasuring(file: StaticString = #file, line: UInt = #line) {
+        guard let performanceMeter = _performanceMeter where !performanceMeter.didFinishMeasuring else {
+            return recordAPIViolation(description: "Cannot start measuring. startMeasuring() is only supported from a block passed to measureMetrics(...).", file: file, line: line)
+        }
+        performanceMeter.startMeasuring(file: file, line: line)
+    }
+
+    /// Call this from within a measure block to set the ending of the critical 
+    /// section. Measurement of metrics will stop at this point.
+    /// - Note: Whereas Apple XCTest determines the file and line number of
+    ///   measurements by using symbolication, this implementation opts to take
+    ///   `file` and `line` as parameters instead. As a result, the interface to
+    ///   these methods are not exactly identical between these environments. To
+    ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
+    ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
+    func stopMeasuring(file: StaticString = #file, line: UInt = #line) {
+        guard let performanceMeter = _performanceMeter where !performanceMeter.didFinishMeasuring else {
+            return recordAPIViolation(description: "Cannot stop measuring. stopMeasuring() is only supported from a block passed to measureMetrics(...).", file: file, line: line)
+        }
+        performanceMeter.stopMeasuring(file: file, line: line)
+    }
+}
+
+extension XCTestCase: PerformanceMeterDelegate {
+    internal func recordAPIViolation(description: String, file: StaticString, line: UInt) {
+        recordFailure(withDescription: "API violation - \(description)",
+                      inFile: String(file),
+                      atLine: line,
+                      expected: false)
+    }
+
+    internal func recordMeasurements(results: String, file: StaticString, line: UInt) {
+        XCTestObservationCenter.shared().testCase(self, didMeasurePerformanceResults: results, file: file, line: line)
+    }
+
+    internal func recordFailure(description: String, file: StaticString, line: UInt) {
+        recordFailure(withDescription: "failed: " + description, inFile: String(file), atLine: line, expected: true)
+    }
+}

--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -60,6 +60,14 @@ public class XCTestCase: XCTest {
     ///   https://bugs.swift.org/browse/SR-1129 for details.
     public var _allExpectations = [XCTestExpectation]()
 
+    /// An internal object implementing performance measurements.
+    /// - Note: FIXME: This is meant to be a `internal var`, but is marked as
+    ///   `public` here to work around a Swift compiler bug on Linux. To ensure
+    ///   compatibility of tests between swift-corelibs-xctest and Apple XCTest,
+    ///   this property should not be modified. See
+    ///   https://bugs.swift.org/browse/SR-1129 for details.
+    public var _performanceMeter: PerformanceMeter?
+
     public override var testRunClass: AnyClass? {
         return XCTestCaseRun.self
     }
@@ -118,6 +126,8 @@ public class XCTestCase: XCTest {
             inFile: filePath,
             atLine: lineNumber,
             expected: expected)
+
+        _performanceMeter?.abortMeasuring()
 
         // FIXME: Apple XCTest does not throw a fatal error and crash the test
         //        process, it merely prevents the remainder of a testClosure

--- a/Sources/XCTest/XCTestObservation.swift
+++ b/Sources/XCTest/XCTestObservation.swift
@@ -77,3 +77,13 @@ public extension XCTestObservation {
     func testSuiteDidFinish(_ testSuite: XCTestSuite) {}
     func testBundleDidFinish(_ testBundle: NSBundle) {}
 }
+
+/// Expanded version of `XCTestObservation` used internally to respond to
+/// additional events not publicly exposed.
+internal protocol _XCTestObservation: XCTestObservation {
+    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults: String, file: StaticString, line: UInt)
+}
+
+internal extension _XCTestObservation {
+    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults: String, file: StaticString, line: UInt) {}
+}

--- a/Sources/XCTest/XCTestObservationCenter.swift
+++ b/Sources/XCTest/XCTestObservationCenter.swift
@@ -71,9 +71,19 @@ public class XCTestObservationCenter {
         forEachObserver { $0.testBundleDidFinish(testBundle) }
     }
 
+    internal func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: UInt) {
+        forEachInternalObserver { $0.testCase(testCase, didMeasurePerformanceResults: results, file: file, line: line) }
+    }
+
     private func forEachObserver(_ body: @noescape (XCTestObservation) -> Void) {
         for observer in observers {
             body(observer.object)
+        }
+    }
+
+    private func forEachInternalObserver(_ body: @noescape (_XCTestObservation) -> Void) {
+        for observer in observers where observer.object is _XCTestObservation {
+            body(observer.object as! _XCTestObservation)
         }
     }
 }

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -1,0 +1,120 @@
+// RUN: %{swiftc} %s -o %{built_tests_dir}/Performance
+// RUN: %{built_tests_dir}/Performance > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(Linux) || os(FreeBSD)
+    import XCTest
+    import Foundation
+#else
+    import SwiftXCTest
+    import SwiftFoundation
+#endif
+
+// CHECK: Test Suite 'All tests' started at \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'PerformanceTestCase' started at \d+:\d+:\d+\.\d+
+class PerformanceTestCase: XCTestCase {
+
+    // CHECK: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' started at \d+:\d+:\d+\.\d+
+    // CHECK: .*/Performance/main.swift:24: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' measured \[Time, seconds\] .*
+    // CHECK: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' passed \(\d+\.\d+ seconds\).
+    func test_measureBlockIteratesTenTimes() {
+        var iterationCount = 0
+        measure(block: {
+            iterationCount += 1
+        })
+        XCTAssertEqual(iterationCount, 10)
+    }
+
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' started at \d+:\d+:\d+\.\d+
+    // CHECK: .*/Performance/main.swift:35: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' measured \[Time, seconds\] .*
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' passed \(\d+\.\d+ seconds\).
+    func test_measuresMetricsWithAutomaticStartAndStop() {
+        var iterationCount = 0
+        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true, for: {
+            iterationCount += 1
+        })
+        XCTAssertEqual(iterationCount, 10)
+    }
+
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' started at \d+:\d+:\d+\.\d+
+    // CHECK: .*/Performance/main.swift:45: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' measured \[Time, seconds\] .*
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' passed \(\d+\.\d+ seconds\).
+    func test_measuresMetricsWithManualStartAndStop() {
+        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
+            self.startMeasuring()
+            self.stopMeasuring()
+        }
+    }
+
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' started at \d+:\d+:\d+\.\d+
+    // CHECK: .*/Performance/main.swift:55: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' measured \[Time, seconds\] .*
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' passed \(\d+\.\d+ seconds\).
+    func test_measuresMetricsWithoutExplicitStop() {
+        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
+            self.startMeasuring()
+        }
+    }
+
+    // CHECK: Test Case 'PerformanceTestCase.test_hasWallClockAsDefaultPerformanceMetric' started at \d+:\d+:\d+\.\d+
+    // CHECK: Test Case 'PerformanceTestCase.test_hasWallClockAsDefaultPerformanceMetric' passed \(\d+\.\d+ seconds\).
+    func test_hasWallClockAsDefaultPerformanceMetric() {
+        XCTAssertEqual(PerformanceTestCase.defaultPerformanceMetrics(), [XCTPerformanceMetric_WallClockTime])
+    }
+
+    // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' started at \d+:\d+:\d+\.\d+
+    // CHECK: .*/Performance/main.swift:70: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[\d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
+    // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' passed \(\d+\.\d+ seconds\).
+    func test_printsValuesAfterMeasuring() {
+        measure {}
+    }
+
+    // CHECK: Test Case 'PerformanceTestCase.test_abortsMeasurementsAfterTestFailure' started at \d+:\d+:\d+\.\d+
+    func test_abortsMeasurementsAfterTestFailure() {
+        var iterationCount = 0
+        measure {
+            iterationCount += 1
+            // CHECK: .*/Performance/main.swift:79: error: PerformanceTestCase.test_abortsMeasurementsAfterTestFailure : XCTAssertLessThan failed: \("3"\) is not less than \("3"\) -
+            XCTAssertLessThan(iterationCount, 3)
+        }
+        XCTAssertEqual(iterationCount, 3)
+    }
+    // CHECK: Test Case 'PerformanceTestCase.test_abortsMeasurementsAfterTestFailure' failed \(\d+\.\d+ seconds\).
+
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' started at \d+:\d+:\d+\.\d+
+    func test_measuresWallClockTimeInBlock() {
+        var hasWaited = false
+        // CHECK: .*/Performance/main.swift:90: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[1.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
+        // CHECK: .*/Performance/main.swift:90: error: PerformanceTestCase.test_measuresWallClockTimeInBlock : failed: The relative standard deviation of the measurements is \d+.\d{3}% which is higher than the max allowed of \d+.\d{3}%.
+        measure {
+            if !hasWaited {
+                NSThread.sleepForTimeInterval(1)
+                hasWaited = true
+            }
+        }
+    }
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' failed \(\d+\.\d+ seconds\).
+
+    static var allTests: [(String, (PerformanceTestCase) -> () throws -> Void)] {
+        return [
+                   ("test_measureBlockIteratesTenTimes", test_measureBlockIteratesTenTimes),
+                   ("test_measuresMetricsWithAutomaticStartAndStop", test_measuresMetricsWithAutomaticStartAndStop),
+                   ("test_measuresMetricsWithManualStartAndStop", test_measuresMetricsWithManualStartAndStop),
+                   ("test_measuresMetricsWithoutExplicitStop", test_measuresMetricsWithoutExplicitStop),
+                   ("test_hasWallClockAsDefaultPerformanceMetric", test_hasWallClockAsDefaultPerformanceMetric),
+                   ("test_printsValuesAfterMeasuring", test_printsValuesAfterMeasuring),
+                   ("test_abortsMeasurementsAfterTestFailure", test_abortsMeasurementsAfterTestFailure),
+                   ("test_measuresWallClockTimeInBlock", test_measuresWallClockTimeInBlock),
+        ]
+    }
+}
+// CHECK: Test Suite 'PerformanceTestCase' failed at \d+:\d+:\d+\.\d+
+// CHECK: \t Executed \d+ tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+XCTMain([testCase(PerformanceTestCase.allTests)])
+
+// CHECK: Test Suite '.*\.xctest' failed at \d+:\d+:\d+\.\d+
+// CHECK: \t Executed \d+ tests, with \d failures? \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Test Suite 'All tests' failed at \d+:\d+:\d+\.\d+
+// CHECK: \t Executed \d+ tests, with \d failures? \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */; };
 		AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */; };
 		AE9596E11C9692B8001A9EF0 /* XCTestObservationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */; };
+		AEC3638F1CE2A6D6007BA936 /* XCTestCase+Performance.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC3638E1CE2A6D6007BA936 /* XCTestCase+Performance.swift */; };
+		AEC3C1851CE2DAAF009BE249 /* WallClockTimeMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC3C1841CE2DAAF009BE249 /* WallClockTimeMetric.swift */; };
+		AED0F7B81CDA324B00A89E8B /* PerformanceMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED0F7B71CDA324B00A89E8B /* PerformanceMeter.swift */; };
 		AED59FF61CB5394800F49260 /* XCTestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED59FF51CB5394800F49260 /* XCTestErrors.swift */; };
 		C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */; };
 		C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */; };
@@ -53,6 +56,9 @@
 		AE7DD60B1C8F0513006FC722 /* XCTestObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestObservation.swift; sourceTree = "<group>"; };
 		AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectWrapper.swift; sourceTree = "<group>"; };
 		AE9596E01C9692B8001A9EF0 /* XCTestObservationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestObservationCenter.swift; sourceTree = "<group>"; };
+		AEC3638E1CE2A6D6007BA936 /* XCTestCase+Performance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Performance.swift"; sourceTree = "<group>"; };
+		AEC3C1841CE2DAAF009BE249 /* WallClockTimeMetric.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallClockTimeMetric.swift; sourceTree = "<group>"; };
+		AED0F7B71CDA324B00A89E8B /* PerformanceMeter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceMeter.swift; sourceTree = "<group>"; };
 		AED59FF51CB5394800F49260 /* XCTestErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestErrors.swift; sourceTree = "<group>"; };
 		B1384A411C1B3E8700EDF031 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		B1384A421C1B3E8700EDF031 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -129,13 +135,16 @@
 			children = (
 				AE7DD6071C8E81A0006FC722 /* ArgumentParser.swift */,
 				AE9596DE1C96911F001A9EF0 /* ObjectWrapper.swift */,
-				AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */,
+				AED0F7B71CDA324B00A89E8B /* PerformanceMeter.swift */,
 				DA7714FC1CA8D057001EA745 /* PrintObserver.swift */,
+				AE7DD6081C8E81A0006FC722 /* TestFiltering.swift */,
+				AEC3C1841CE2DAAF009BE249 /* WallClockTimeMetric.swift */,
 				C265F6691C3AEB6A00520CF9 /* XCTAssert.swift */,
 				DA7FB38E1CA4EE3800F024F9 /* XCAbstractTest.swift */,
 				DA7FB3421CA4EA4000F024F9 /* XCTestSuite.swift */,
 				DA7732471CA87278007E31FD /* XCTestRun.swift */,
 				C265F66A1C3AEB6A00520CF9 /* XCTestCase.swift */,
+				AEC3638E1CE2A6D6007BA936 /* XCTestCase+Performance.swift */,
 				DA7714F81CA87DEF001EA745 /* XCTestSuiteRun.swift */,
 				DA7714FA1CA87DFB001EA745 /* XCTestCaseRun.swift */,
 				AED59FF51CB5394800F49260 /* XCTestErrors.swift */,
@@ -282,6 +291,8 @@
 				510957A91CA878410091D1A1 /* XCNotificationExpectationHandler.swift in Sources */,
 				AE7DD60C1C8F0513006FC722 /* XCTestObservation.swift in Sources */,
 				DA7FB38F1CA4EE3800F024F9 /* XCAbstractTest.swift in Sources */,
+				AED0F7B81CDA324B00A89E8B /* PerformanceMeter.swift in Sources */,
+				AEC3C1851CE2DAAF009BE249 /* WallClockTimeMetric.swift in Sources */,
 				C265F6701C3AEB6A00520CF9 /* XCTestCase.swift in Sources */,
 				DADB979C1C51BDA2005E68B6 /* XCTestExpectation.swift in Sources */,
 				51DA1EA41CC19C9000F75EB7 /* XCPredicateExpectation.swift in Sources */,
@@ -294,6 +305,7 @@
 				DA7714FB1CA87DFB001EA745 /* XCTestCaseRun.swift in Sources */,
 				C265F66F1C3AEB6A00520CF9 /* XCTAssert.swift in Sources */,
 				DA7FB3431CA4EA4000F024F9 /* XCTestSuite.swift in Sources */,
+				AEC3638F1CE2A6D6007BA936 /* XCTestCase+Performance.swift in Sources */,
 				DA7714F91CA87DEF001EA745 /* XCTestSuiteRun.swift in Sources */,
 				AE9596DF1C96911F001A9EF0 /* ObjectWrapper.swift in Sources */,
 				AED59FF61CB5394800F49260 /* XCTestErrors.swift in Sources */,


### PR DESCRIPTION
# What's in this pull request
This is an initial implementation of the XCTest performance measurement APIs. All public facing APIs from Apple XCTest are present, but not all behaviors are implemented at this point. It is currently possible to measure the wall clock time that a given block of code takes to execute, and see the measured times, the mean value, and the relative standard deviation in the printed test output.

The core behaviors mimic those described in the Apple XCTest framework headers, supplemented by information presented in the [Testing in Xcode 6 WWDC session](https://developer.apple.com/videos/play/wwdc2014/414/).

* The code being measured is always executed exactly 10 times (assuming no test failures occur)
* A test failure is triggered if the relative standard deviation of the times measured is greater than 10%, and the standard deviation value is greater than 0.1

This does not include any support for recording baseline values or triggering test failures due to a regression relative to a baseline.

Resolves [SR-1355](https://bugs.swift.org/browse/SR-1355).

# Code structure
Although the build system does not currently facilitate the use of multiple Swift modules, I have structured the code with modularity in mind. The `PerformanceMeter.swift` and `WallClockTimeMetric.swift` contain the heart of the implementation and have (almost) no dependence on other parts of the XCTest library. `XCTestCase+Performance.swift` contains the public APIs which delegate to the `PerformanceMeter` class.

# Test coverage
There are extensive functional tests covering of API misuse scenarios and basic measurement output, however many finer points (e.g. standard deviation calculation and situations triggering failure) have only cursory tests due to the lack of a usable unit testing infrastructure (see [this PR](https://github.com/apple/swift-corelibs-xctest/pull/61#issuecomment-207822336) for previous discussion about this.)

I attempted to make the tests robust, however due to the time-sensitive nature of the APIs under test, there is an increased possibility of flakiness that could appear when running in a CI environment. I would greatly appreciate feedback on this aspect of the test cases and what approaches we could take to minimize the risk of false negative results. I would also like to hear feedback on the `test_measuresWallClockTimeInBlock` test case in `Performance/main.swift`, which currently includes a 1-second sleep in order to 
test that time passing is being measured.

# Error reporting
I took pains to implement failure reporting due to API misuse, just as Apple XCTest does. One element of this is reporting the file and line number where the misuse occurred. I have taken cues from @modocache's `XCTestExpectation` implementation and added `file` and `line` params where necessary to capture that information. The current implementation records test failures for API misuse, allowing test suite execution to continue at the cost of some additional bookkeeping code. An alternative would be to simply `fatalError` in these scenarios, since they are clearly programmer error. I would appreciate others' input on these options.

# Time measurement
I am no expert in benchmarking, so I am not especially confident in the optimal mechanism for measuring the passage of time for this purpose, however after some cursory research, I settled on using `NSProcessInfo`'s `systemUptime` property, which ultimately calls down to `mach_absolute_time` on Darwin, and `clock_gettime` with `CLOCK_MONOTONIC` on Linux. As far as I can tell, these are the appropriate primitives to use for this purpose in these environments. One potential source of error is introduced in that the time values are being converted to `Double`, but I'm unsure of the practical impact of that.

--
While not complete, this is still a significant step towards feature parity with Apple XCTest, and should be sufficient to start gathering feedback on future implementation directions. In particular, it should put us in a good position to productively carry on discussions like [this one](https://lists.swift.org/pipermail/swift-corelibs-dev/Week-of-Mon-20151207/000115.html) from @drewcrawford which have great potential to improve the value that these tools provide.

cc @ddunbar @paulofaria