### PR TITLE
[Tests] Automatically substitute [[@LINE]] numbers

### DIFF
--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -14,7 +14,7 @@
 // CHECK: Test Suite 'MisuseTestCase' started at \d+:\d+:\d+\.\d+
 class MisuseTestCase: XCTestCase {
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:21: error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails : Failed due to unwaited expectations.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+4]]: error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails : Failed due to unwaited expectations.
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreMade_butNotWaitedFor_fails() {
         self.expectation(withDescription: "the first expectation")
@@ -22,15 +22,15 @@ class MisuseTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:28: error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+3]]: error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
         self.waitForExpectations(withTimeout: 0.1)
     }
 
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:38: error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
-// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:48: error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+6]]: error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
+// CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+15]]: error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationIsFulfilledMultipleTimes_fails() {
         let expectation = self.expectation(withDescription: "rob")

--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -87,5 +87,10 @@ class CompareTestCase(unittest.TestCase):
         expected = _tmpfile('c: foo\nc: ^ bar \nc: baz $\n')
         compare.compare(actual, expected, check_prefix='c:')
 
+    def test_line_number_substitution(self):
+        actual = _tmpfile('beep 1\nboop 5\n')
+        expected = _tmpfile('c: beep [[@LINE]]\nc: boop [[@LINE+3]]')
+        compare.compare(actual, expected, check_prefix='c: ')
+
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -11,6 +11,7 @@
 import re
 
 from .error import XCTestCheckerError
+from .line import replace_offsets
 
 
 def _actual_lines(path):
@@ -40,7 +41,8 @@ def _expected_lines_and_line_numbers(path, check_prefix):
 
             components = line.split(check_prefix)
             if len(components) == 2:
-                yield components[1].strip(), line_number
+                yield (replace_offsets(components[1].strip(), line_number),
+                       line_number)
             elif len(components) > 2:
                 # Include a newline, then the file name and line number in the
                 # exception in order to have it appear as an inline failure in

--- a/Tests/Functional/xctest_checker/xctest_checker/line.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/line.py
@@ -1,0 +1,41 @@
+# xctest_checker/line.py - Replaces [[@LINE]] with line numbers -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import re
+
+
+def replace_offsets(line, line_number):
+    """
+    Replace all line directives in the given line with the given line number.
+
+    Line directives come in two forms:
+    1. "[[@LINE]]", with no offset.
+    2. "[[@LINE+10]]" or "[[@LINE-3]]", with a positive or negative offset.
+    """
+    pattern = re.compile(r'\[\[@LINE(?P<offset>[+-]\d+)?\]\]')
+
+    result = line
+    for match in pattern.finditer(line):
+        offset_string = match.groupdict()['offset']
+        if offset_string is None:
+            offset_string = '0'
+        try:
+            offset = int(offset_string)
+        except ValueError:
+            # Re-raise the error, but with a friendlier explanation of what
+            # went wrong.
+            raise ValueError(
+                'Invalid line offset: "{}". Line offsets must be numerical, '
+                'such as "[[@LINE+10]]" or "[[@LINE-2]]"'.format(
+                    match.group()))
+        result = result.replace(match.group(), str(line_number + offset))
+
+    return result
+


### PR DESCRIPTION
Enhance xctest_checker such that it substitutes the string `"[[@LINE]]"` and `"[[@LINE+<offset>]]"` with the current line number of the source file when performing checks.

This allows us to add and remove arbitary lines in the functional test suite without manually updating line numbers in most cases. Line offsets will still need to be updated when the distance between the CHECK and the test failure changes.

To test the offsets out, use them in one of the asynchronous tests.