### PR TITLE
[Tests] Use line number offsets for assertions

### DIFF
--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -16,7 +16,7 @@
 // CHECK: Test Suite 'ExpectationsTestCase' started at \d+:\d+:\d+\.\d+
 class ExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:23: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnUnfulfilledExpectation_fails() {
         expectation(withDescription: "foo")
@@ -24,7 +24,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:32: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+5]]: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
     func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
         expectation(withDescription: "bar")
@@ -52,7 +52,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:63: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+8]]: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnExpectationFulfilledAfterTheTimeout_fails() {
         let expectation = self.expectation(withDescription: "hog")
@@ -72,7 +72,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:79: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
+// CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
         expectation(withDescription: "dog")

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -16,7 +16,7 @@
 // CHECK: Test Suite 'HandlerTestCase' started at \d+:\d+:\d+\.\d+
 class HandlerTestCase: XCTestCase {
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Handler/main.swift:25: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
+// CHECK: .*/Tests/Functional/Asynchronous/Handler/main.swift:[[@LINE+6]]: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreNotFulfilled_handlerCalled_andFails() {
         self.expectation(withDescription: "fog")

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -46,7 +46,7 @@ class NotificationExpectationsTestCase: XCTestCase {
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:54: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'expectedName' from any object
+// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:[[@LINE+5]]: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'expectedName' from any object
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' failed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithIncorrectName_fails() {
         expectation(forNotification: "expectedName", object: nil)
@@ -55,7 +55,7 @@ class NotificationExpectationsTestCase: XCTestCase {
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:66: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'notificationWithIncorrectObjectTest' from dummyObject
+// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:[[@LINE+8]]: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'notificationWithIncorrectObjectTest' from dummyObject
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' failed \(\d+\.\d+ seconds\).
     func test_observeNotificationWithIncorrectObject_fails() {
         let notificationName = "notificationWithIncorrectObjectTest"

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -16,7 +16,7 @@
 // CHECK: Test Suite 'NotificationHandlerTestCase' started at \d+:\d+:\d+\.\d+
 class NotificationHandlerTestCase: XCTestCase {
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:27: error: NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'returnFalse' from any object
+// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:[[@LINE+8]]: error: NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'returnFalse' from any object
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' failed \(\d+\.\d+ seconds\).
     func test_notificationNameIsObserved_handlerReturnsFalse_andFails() {
         expectation(forNotification: "returnFalse", object: nil, handler: {
@@ -39,7 +39,7 @@ class NotificationHandlerTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:\d+: error: NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'note' from any object
+// CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:[[@LINE+7]]: error: NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'note' from any object
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' failed \(\d+\.\d+ seconds\).
     func test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled() {
         expectation(forNotification: "note", object: nil, handler: { _ in

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -25,7 +25,7 @@ class PredicateExpectationsTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift:34: error: PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9A-Fa-f]{1,16}>` for object <NSObject: 0x[0-9A-Fa-f]{1,16}>
+    // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift:[[@LINE+6]]: error: PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9A-Fa-f]{1,16}>` for object <NSObject: 0x[0-9A-Fa-f]{1,16}>
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails' failed \(\d+\.\d+ seconds\).
     func test_immediatelyFalsePredicateAndObject_fails() {
         let predicate = NSPredicate(value: false)

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -26,7 +26,7 @@ class PredicateHandlerTestCase: XCTestCase {
         waitForExpectations(withTimeout: 0.1)
     }
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Handler/main.swift:37: error: PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9a-fA-F]{1,16}>` for object <NSObject: 0x[0-9a-fA-F]{1,16}>
+    // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Handler/main.swift:[[@LINE+8]]: error: PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9a-fA-F]{1,16}>` for object <NSObject: 0x[0-9a-fA-F]{1,16}>
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails' failed \(\d+\.\d+ seconds\).
     func test_predicateIsTrue_handlerReturnsFalse_fails() {
         let predicate = NSPredicate(value: true)
@@ -38,7 +38,7 @@ class PredicateHandlerTestCase: XCTestCase {
     }
     
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Handler/main.swift:55: error: PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9a-fA-F]{1,16}>` for object \d{4}-\d{2}-\d{2} \d+:\d+:\d+ \+\d+
+    // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Handler/main.swift:[[@LINE+14]]: error: PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9a-fA-F]{1,16}>` for object \d{4}-\d{2}-\d{2} \d+:\d+:\d+ \+\d+
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails' failed \(\d+\.\d+ seconds\).
     func test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails() {
         let halfSecLaterDate = NSDate(timeIntervalSinceNow: 0.2)

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -41,7 +41,7 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error -
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error -
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
     func test_shouldButDoesNotThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesNotThrowError())
@@ -64,7 +64,7 @@ class ErrorHandling: XCTestCase {
     }
     
 // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) -
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+11]]: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) -
 // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
     func test_throwsErrorInAssertionButFailsWhenCheckingError() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
@@ -98,7 +98,7 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:\d+: error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "anError\("did not actually return"\)" -
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "anError\("did not actually return"\)" -
 // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -45,14 +45,14 @@ class FailingTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'FailingTestCase.test_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
+// CHECK: .*/FailingTestSuite/main.swift:[[@LINE+3]]: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
 // CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)
     }
 
 // CHECK: Test Case 'FailingTestCase.test_fails_with_message' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/FailingTestSuite/main.swift:\d+: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
+// CHECK: .*/FailingTestSuite/main.swift:[[@LINE+3]]: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
 // CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
     func test_fails_with_message() {
         XCTAssert(false, "Foo bar.")

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -43,154 +43,154 @@ class FailureMessagesTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssert' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:49: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
     func testAssert() {
         XCTAssert(false, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:56: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertEqualOptionals() {
         XCTAssertEqual(1, 2, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:63: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
     func testAssertEqualArraySlices() {
         XCTAssertEqual([1][0..<1], [2][0..<1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:70: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
     func testAssertEqualContiguousArrays() {
         XCTAssertEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 2), "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:77: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\).
     func testAssertEqualArrays() {
         XCTAssertEqual([1], [2], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:84: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertEqualDictionaries() {
         XCTAssertEqual([1:2], [3:4], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:91: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
     func testAssertEqualWithAccuracy() {
         XCTAssertEqualWithAccuracy(1, 2, accuracy: 0.1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:98: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\).
     func testAssertFalse() {
         XCTAssertFalse(true, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:105: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\).
     func testAssertGreaterThan() {
         XCTAssertGreaterThan(0, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:112: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\).
     func testAssertGreaterThanOrEqual() {
         XCTAssertGreaterThanOrEqual(-1, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:119: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\).
     func testAssertLessThan() {
         XCTAssertLessThan(0, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:126: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\).
     func testAssertLessThanOrEqual() {
         XCTAssertLessThanOrEqual(1, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:133: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\).
     func testAssertNil() {
         XCTAssertNil("helloworld", "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:140: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualOptionals() {
         XCTAssertNotEqual(1, 1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:147: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualArraySlices() {
         XCTAssertNotEqual([1][0..<1], [1][0..<1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:154: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualContiguousArrays() {
         XCTAssertNotEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 1), "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:161: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualArrays() {
         XCTAssertNotEqual([1], [1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:168: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualDictionaries() {
         XCTAssertNotEqual([1:1], [1:1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:175: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualWithAccuracy() {
         XCTAssertNotEqualWithAccuracy(1, 1, 0.1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:182: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
     func testAssertNotNil() {
         XCTAssertNotNil(nil, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:189: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\).
     func testAssertTrue() {
         XCTAssertTrue(false, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testFail' started at \d+:\d+:\d+\.\d+
-// CHECK: test.swift:196: error: FailureMessagesTestCase.testFail : failed - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testFail : failed - message
 // CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\).
     func testFail() {
         XCTFail("message", file: "test.swift")

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -31,7 +31,7 @@ class NegativeAccuracyTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
+// CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
     func test_equalWithAccuracy_fails() {
         XCTAssertEqualWithAccuracy(0, 0.2, accuracy: -0.1)
@@ -44,7 +44,7 @@ class NegativeAccuracyTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/NegativeAccuracyTestCase/main.swift:\d+: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
+// CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
     func test_notEqualWithAccuracy_fails() {
         XCTAssertNotEqualWithAccuracy(1, 2, -1)

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -65,7 +65,7 @@ class Observation: XCTestCase {
     }
 
 // CHECK: Test Case 'Observation.test_one' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/Observation/All/main.swift:\d+: error: Observation.test_one : failed - fail!
+// CHECK: .*/Observation/All/main.swift:[[@LINE+12]]: error: Observation.test_one : failed - fail!
 // CHECK: Test Case 'Observation.test_one' failed \(\d+\.\d+ seconds\).
     func test_one() {
         XCTAssertEqual(observer.startedBundlePaths.count, 1)

--- a/Tests/Functional/Performance/Misuse/main.swift
+++ b/Tests/Functional/Performance/Misuse/main.swift
@@ -16,18 +16,18 @@ class PerformanceMisuseTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails' started at \d+:\d+:\d+\.\d+
     func test_whenMeasuringMultipleInOneTest_fails() {
-        // CHECK: .*/Misuse/main.swift:20: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails' measured.*
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails' measured.*
         measure {}
-        // CHECK: .*/Misuse/main.swift:22: error: PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails : API violation - Can only record one set of metrics per test method.
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails : API violation - Can only record one set of metrics per test method.
         measure {}
-        // CHECK: .*/Misuse/main.swift:24: error: PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails : API violation - Can only record one set of metrics per test method.
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails : API violation - Can only record one set of metrics per test method.
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {}
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails' failed \(\d+\.\d+ seconds\).
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails' started at \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndNotStartingOrEnding_fails() {
-        // CHECK: .*/Misuse/main.swift:31: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails : API violation - startMeasuring\(\) must be called during the block.
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails : API violation - startMeasuring\(\) must be called during the block.
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {}
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails' failed \(\d+\.\d+ seconds\).
@@ -35,7 +35,7 @@ class PerformanceMisuseTestCase: XCTestCase {
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails' started at \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndStoppingWithoutStarting_fails() {
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
-            // CHECK: .*/Misuse/main.swift:39: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails : API violation - Cannot stop measuring before starting measuring.
+            // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails : API violation - Cannot stop measuring before starting measuring.
             self.stopMeasuring()
         }
     }
@@ -45,7 +45,7 @@ class PerformanceMisuseTestCase: XCTestCase {
     func test_whenMeasuringMetricsAndStartingTwice_fails() {
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
-            // CHECK: .*/Misuse/main.swift:49: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStartingTwice_fails : API violation - Already called startMeasuring\(\) once this iteration.
+            // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStartingTwice_fails : API violation - Already called startMeasuring\(\) once this iteration.
             self.startMeasuring()
         }
     }
@@ -56,7 +56,7 @@ class PerformanceMisuseTestCase: XCTestCase {
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
             self.stopMeasuring()
-            // CHECK: .*/Misuse/main.swift:60: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingTwice_fails : API violation - Already called stopMeasuring\(\) once this iteration.
+            // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingTwice_fails : API violation - Already called stopMeasuring\(\) once this iteration.
             self.stopMeasuring()
         }
     }
@@ -64,46 +64,46 @@ class PerformanceMisuseTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_startMeasuringOutsideOfBlock_fails() {
-        // CHECK: .*/Misuse/main.swift:68: error: PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails : API violation - Cannot start measuring. startMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails : API violation - Cannot start measuring. startMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         startMeasuring()
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails' failed \(\d+\.\d+ seconds\).
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_stopMeasuringOutsideOfBlock_fails() {
-        // CHECK: .*/Misuse/main.swift:75: error: PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails : API violation - Cannot stop measuring. stopMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails : API violation - Cannot stop measuring. stopMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         stopMeasuring()
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails' failed \(\d+\.\d+ seconds\).
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_startMeasuringAfterBlock_fails() {
-        // CHECK: .*/Misuse/main.swift:82: Test Case 'PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails' measured.*
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: Test Case 'PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails' measured.*
         measure {}
-        // CHECK: .*/Misuse/main.swift:84: error: PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails : API violation - Cannot start measuring. startMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails : API violation - Cannot start measuring. startMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         startMeasuring()
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails' failed \(\d+\.\d+ seconds\).
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_stopMeasuringAfterBlock_fails() {
-        // CHECK: .*/Misuse/main.swift:91: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails' measured.*
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails' measured.*
         measure {}
-        // CHECK: .*/Misuse/main.swift:93: error: PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails : API violation - Cannot stop measuring. stopMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails : API violation - Cannot stop measuring. stopMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         stopMeasuring()
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails' failed \(\d+\.\d+ seconds\).
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringNoMetrics_fails' started at \d+:\d+:\d+\.\d+
     func test_measuringNoMetrics_fails() {
-        // CHECK: .*/Misuse/main.swift:100: error: PerformanceMisuseTestCase.test_measuringNoMetrics_fails : API violation - At least one metric must be provided to measure.
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_measuringNoMetrics_fails : API violation - At least one metric must be provided to measure.
         measureMetrics([], automaticallyStartMeasuring: true) {}
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringNoMetrics_fails' failed \(\d+\.\d+ seconds\).
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' started at \d+:\d+:\d+\.\d+
     func test_measuringUnknownMetric_fails() {
-        // CHECK: .*/Misuse/main.swift:107: error: PerformanceMisuseTestCase.test_measuringUnknownMetric_fails : API violation - Unknown metric: UnladenAirspeedVelocity
+        // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_measuringUnknownMetric_fails : API violation - Unknown metric: UnladenAirspeedVelocity
         measureMetrics(["UnladenAirspeedVelocity"], automaticallyStartMeasuring: true) {}
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' failed \(\d+\.\d+ seconds\).

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -17,7 +17,7 @@
 class PerformanceTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Performance/main.swift:24: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' measured \[Time, seconds\] .*
+    // CHECK: .*/Performance/main.swift:[[@LINE+4]]: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' measured \[Time, seconds\] .*
     // CHECK: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' passed \(\d+\.\d+ seconds\).
     func test_measureBlockIteratesTenTimes() {
         var iterationCount = 0
@@ -28,7 +28,7 @@ class PerformanceTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Performance/main.swift:35: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' measured \[Time, seconds\] .*
+    // CHECK: .*/Performance/main.swift:[[@LINE+4]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' measured \[Time, seconds\] .*
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' passed \(\d+\.\d+ seconds\).
     func test_measuresMetricsWithAutomaticStartAndStop() {
         var iterationCount = 0
@@ -39,7 +39,7 @@ class PerformanceTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Performance/main.swift:45: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' measured \[Time, seconds\] .*
+    // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' measured \[Time, seconds\] .*
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' passed \(\d+\.\d+ seconds\).
     func test_measuresMetricsWithManualStartAndStop() {
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
@@ -49,7 +49,7 @@ class PerformanceTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Performance/main.swift:55: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' measured \[Time, seconds\] .*
+    // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' measured \[Time, seconds\] .*
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' passed \(\d+\.\d+ seconds\).
     func test_measuresMetricsWithoutExplicitStop() {
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
@@ -64,7 +64,7 @@ class PerformanceTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/Performance/main.swift:70: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[\d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
+    // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[\d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
     // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' passed \(\d+\.\d+ seconds\).
     func test_printsValuesAfterMeasuring() {
         measure {}
@@ -75,7 +75,7 @@ class PerformanceTestCase: XCTestCase {
         var iterationCount = 0
         measure {
             iterationCount += 1
-            // CHECK: .*/Performance/main.swift:79: error: PerformanceTestCase.test_abortsMeasurementsAfterTestFailure : XCTAssertLessThan failed: \("3"\) is not less than \("3"\) -
+            // CHECK: .*/Performance/main.swift:[[@LINE+1]]: error: PerformanceTestCase.test_abortsMeasurementsAfterTestFailure : XCTAssertLessThan failed: \("3"\) is not less than \("3"\) -
             XCTAssertLessThan(iterationCount, 3)
         }
         XCTAssertEqual(iterationCount, 3)
@@ -85,8 +85,8 @@ class PerformanceTestCase: XCTestCase {
     // CHECK: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' started at \d+:\d+:\d+\.\d+
     func test_measuresWallClockTimeInBlock() {
         var hasWaited = false
-        // CHECK: .*/Performance/main.swift:90: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[1.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
-        // CHECK: .*/Performance/main.swift:90: error: PerformanceTestCase.test_measuresWallClockTimeInBlock : failed: The relative standard deviation of the measurements is \d+.\d{3}% which is higher than the max allowed of \d+.\d{3}%.
+        // CHECK: .*/Performance/main.swift:[[@LINE+2]]: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[1.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}, 0.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
+        // CHECK: .*/Performance/main.swift:[[@LINE+1]]: error: PerformanceTestCase.test_measuresWallClockTimeInBlock : failed: The relative standard deviation of the measurements is \d+.\d{3}% which is higher than the max allowed of \d+.\d{3}%.
         measure {
             if !hasWaited {
                 NSThread.sleepForTimeInterval(1)

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -20,7 +20,7 @@ class SingleFailingTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'SingleFailingTestCase.test_fails' started at \d+:\d+:\d+\.\d+
-    // CHECK: .*/SingleFailingTestCase/main.swift:26: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
+    // CHECK: .*/SingleFailingTestCase/main.swift:[[@LINE+3]]: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
     // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
     func test_fails() {
         XCTAssert(false)


### PR DESCRIPTION
Use the line number offsets introduces in https://github.com/apple/swift-corelibs-xctest/pull/112 to make the functional test suite assertions less brittle. Now contributors may add and remove arbitary lines in the functional test suite without manually updating line numbers in most cases. Line offsets will still need to be updated when the distance between the CHECK and the test failure changes.