### PR TITLE
[SR-1589] Add non-throwing testCase() wrapper function.

### DIFF
--- a/Sources/XCTest/XCTestCase.swift
+++ b/Sources/XCTest/XCTestCase.swift
@@ -178,3 +178,20 @@ private func test<T: XCTestCase>(_ testFunc: (T) -> () throws -> Void) -> (XCTes
         try testFunc(testCase)()
     }
 }
+
+/// Wrapper function for the non-throwing variant of tests.
+/// - seealso: `XCTMain`
+public func testCase<T: XCTestCase>(_ allTests: [(String, (T) -> () -> Void)]) -> XCTestCaseEntry {
+    let tests: [(String, (XCTestCase) throws -> Void)] = allTests.map { ($0.0, test($0.1)) }
+    return (T.self, tests)
+}
+
+private func test<T: XCTestCase>(_ testFunc: (T) -> () -> Void) -> (XCTestCase) throws -> Void {
+    return { testCaseType in
+        guard let testCase = testCaseType as? T else {
+            fatalError("Attempt to invoke test on class \(T.self) with incompatible instance type \(testCaseType.dynamicType)")
+        }
+
+        try testFunc(testCase)()
+    }
+}


### PR DESCRIPTION
 - This is useful in clients which would like to use Swift type inference to
   define the `allTests` array. If none of the tests in the class throw, Swift
   will infer the type of that array as `(String, (T) -> () -> ())` which is not
   convertible to the type expected by the `testCase` method.

 - Resolves: https://bugs.swift.org/browse/SR-1589