### PR TITLE
Take advantage of type inference when specifying `allTests` variables.

### DIFF
--- a/Documentation/Linux.md
+++ b/Documentation/Linux.md
@@ -4,7 +4,7 @@ When running on the Objective-C runtime, XCTest is able to find all of your test
 
 ```swift
 class TestNSURL : XCTestCase {
-    static var allTests : [(String, (TestNSURL) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_URLStrings", test_URLStrings),
             ("test_fileURLWithPath_relativeToURL", test_fileURLWithPath_relativeToURL),
@@ -12,7 +12,7 @@ class TestNSURL : XCTestCase {
             ("test_fileURLWithPath_isDirectory", test_fileURLWithPath_isDirectory),
             // Other tests go here
         ]
-    }
+    }()
 
     func test_fileURLWithPath_relativeToURL() {
         // Write your test here. Most of the XCTAssert macros you are familiar with are available.

--- a/Sources/XCTest/XCTestMain.swift
+++ b/Sources/XCTest/XCTestMain.swift
@@ -26,12 +26,12 @@
 /// Example usage:
 ///
 ///     class TestFoo: XCTestCase {
-///         static var allTests : [(String, (TestFoo) -> () throws -> Void)] {
+///         static var allTests = {
 ///             return [
 ///                 ("test_foo", test_foo),
 ///                 ("test_bar", test_bar),
 ///             ]
-///         }
+///         }()
 ///
 ///         func test_foo() {
 ///             // Test things...

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -79,7 +79,7 @@ class ExpectationsTestCase: XCTestCase {
         waitForExpectations(withTimeout: -1.0)
     }
 
-    static var allTests: [(String, (ExpectationsTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_waitingForAnUnfulfilledExpectation_fails", test_waitingForAnUnfulfilledExpectation_fails),
             ("test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails", test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails),
@@ -89,7 +89,7 @@ class ExpectationsTestCase: XCTestCase {
             ("test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes", test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes),
             ("test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails", test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails),
         ]
-    }
+    }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed 7 tests, with 4 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -45,12 +45,12 @@ class HandlerTestCase: XCTestCase {
         XCTAssertTrue(handlerWasCalled)
     }
 
-    static var allTests: [(String, (HandlerTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_whenExpectationsAreNotFulfilled_handlerCalled_andFails", test_whenExpectationsAreNotFulfilled_handlerCalled_andFails),
             ("test_whenExpectationsAreFulfilled_handlerCalled_andPasses", test_whenExpectationsAreFulfilled_handlerCalled_andPasses),
         ]
-    }
+    }()
 }
 // CHECK: Test Suite 'HandlerTestCase' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed 2 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -49,13 +49,13 @@ class MisuseTestCase: XCTestCase {
         self.waitForExpectations(withTimeout: 0.1)
     }
 
-    static var allTests: [(String, (MisuseTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_whenExpectationsAreMade_butNotWaitedFor_fails", test_whenExpectationsAreMade_butNotWaitedFor_fails),
             ("test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails", test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails),
             ("test_whenExpectationIsFulfilledMultipleTimes_fails", test_whenExpectationIsFulfilledMultipleTimes_fails),
         ]
-    }
+    }()
 }
 // CHECK: Test Suite 'MisuseTestCase' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed 3 tests, with 4 failures \(4 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -66,7 +66,7 @@ class NotificationExpectationsTestCase: XCTestCase {
         waitForExpectations(withTimeout: 0.1)
     }
     
-    static var allTests: [(String, (NotificationExpectationsTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
                    ("test_observeNotificationWithName_passes", test_observeNotificationWithName_passes),
                    ("test_observeNotificationWithNameAndObject_passes", test_observeNotificationWithNameAndObject_passes),
@@ -74,7 +74,7 @@ class NotificationExpectationsTestCase: XCTestCase {
                    ("test_observeNotificationWithIncorrectName_fails", test_observeNotificationWithIncorrectName_fails),
                    ("test_observeNotificationWithIncorrectObject_fails", test_observeNotificationWithIncorrectObject_fails),
         ]
-    }
+    }()
 }
 // CHECK: Test Suite 'NotificationExpectationsTestCase' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed 5 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -50,13 +50,13 @@ class NotificationHandlerTestCase: XCTestCase {
         NSNotificationCenter.defaultCenter().postNotificationName("note", object: nil)
     }
     
-    static var allTests: [(String, (NotificationHandlerTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
                    ("test_notificationNameIsObserved_handlerReturnsFalse_andFails", test_notificationNameIsObserved_handlerReturnsFalse_andFails),
                    ("test_notificationNameIsObserved_handlerReturnsTrue_andPasses", test_notificationNameIsObserved_handlerReturnsTrue_andPasses),
                    ("test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled", test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled),
         ]
-    }
+    }()
 }
 // CHECK: Test Suite 'NotificationHandlerTestCase' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed 3 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -63,14 +63,14 @@ class PredicateExpectationsTestCase: XCTestCase {
         waitForExpectations(withTimeout: 0.1)
     }
     
-    static var allTests: [(String, (PredicateExpectationsTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
                    ("test_immediatelyTruePredicateAndObject_passes", test_immediatelyTruePredicateAndObject_passes),
                    ("test_immediatelyFalsePredicateAndObject_fails", test_immediatelyFalsePredicateAndObject_fails),
                    ("test_delayedTruePredicateAndObject_passes", test_delayedTruePredicateAndObject_passes),
                    ("test_immediatelyTrueDelayedFalsePredicateAndObject_passes", test_immediatelyTrueDelayedFalsePredicateAndObject_passes),
         ]
-    }
+    }()
 }
 
 // CHECK: Test Suite 'PredicateExpectationsTestCase' failed at \d+:\d+:\d+\.\d+

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -55,13 +55,13 @@ class PredicateHandlerTestCase: XCTestCase {
         waitForExpectations(withTimeout: 0.1, handler: nil)
     }
     
-    static var allTests: [(String, (PredicateHandlerTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
                    ("test_predicateIsTrue_handlerReturnsTrue_passes", test_predicateIsTrue_handlerReturnsTrue_passes),
                    ("test_predicateIsTrue_handlerReturnsFalse_fails", test_predicateIsTrue_handlerReturnsFalse_fails),
                    ("test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails", test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails),
         ]
-    }
+    }()
 }
 
 // CHECK: Test Suite 'PredicateHandlerTestCase' failed at \d+:\d+:\d+\.\d+

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -13,7 +13,7 @@
 
 // CHECK: Test Suite 'ErrorHandling' started at \d+:\d+:\d+\.\d+
 class ErrorHandling: XCTestCase {
-    static var allTests: [(String, (ErrorHandling) -> () throws -> Void)] {
+    static var allTests = {
         return [
             // Tests for XCTAssertThrowsError
             ("test_shouldButDoesNotThrowErrorInAssertion", test_shouldButDoesNotThrowErrorInAssertion),
@@ -27,7 +27,7 @@ class ErrorHandling: XCTestCase {
             // Tests for throwing assertion expressions
             ("test_assertionExpressionCanThrow", test_assertionExpressionCanThrow),
         ]
-    }
+    }()
     
     func functionThatDoesNotThrowError() throws {
     }

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -13,11 +13,11 @@
 
 // CHECK: Test Suite 'PassingTestCase' started at \d+:\d+:\d+\.\d+
 class PassingTestCase: XCTestCase {
-    static var allTests: [(String, (PassingTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_passes", test_passes),
         ]
-    }
+    }()
 
 // CHECK: Test Case 'PassingTestCase.test_passes' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'PassingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
@@ -30,13 +30,13 @@ class PassingTestCase: XCTestCase {
 
 // CHECK: Test Suite 'FailingTestCase' started at \d+:\d+:\d+\.\d+
 class FailingTestCase: XCTestCase {
-    static var allTests: [(String, (FailingTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_passes", test_passes),
             ("test_fails", test_fails),
             ("test_fails_with_message", test_fails_with_message),
         ]
-    }
+    }()
 
 // CHECK: Test Case 'FailingTestCase.test_passes' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'FailingTestCase.test_passes' passed \(\d+\.\d+ seconds\).

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -15,7 +15,7 @@
 
 // CHECK: Test Suite 'FailureMessagesTestCase' started at \d+:\d+:\d+\.\d+
 class FailureMessagesTestCase: XCTestCase {
-    static var allTests: [(String, (FailureMessagesTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("testAssert", testAssert),
             ("testAssertEqualOptionals", testAssertEqualOptionals),
@@ -40,12 +40,12 @@ class FailureMessagesTestCase: XCTestCase {
             ("testAssertTrue", testAssertTrue),
             ("testFail", testFail),
         ]
-    }
+    }()
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssert' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
-    func testAssert() {
+    func testAssert() throws {
         XCTAssert(false, "message", file: "test.swift")
     }
 

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -15,14 +15,14 @@
 
 // CHECK: Test Suite 'NegativeAccuracyTestCase' started at \d+:\d+:\d+\.\d+
 class NegativeAccuracyTestCase: XCTestCase {
-    static var allTests: [(String, (NegativeAccuracyTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_equalWithAccuracy_passes", test_equalWithAccuracy_passes),
             ("test_equalWithAccuracy_fails", test_equalWithAccuracy_fails),
             ("test_notEqualWithAccuracy_passes", test_notEqualWithAccuracy_passes),
             ("test_notEqualWithAccuracy_fails", test_notEqualWithAccuracy_fails),
         ]
-    }
+    }()
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\).

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -56,13 +56,13 @@ XCTestObservationCenter.shared().addTestObserver(observer)
 
 // CHECK: Test Suite 'Observation' started at \d+:\d+:\d+\.\d+
 class Observation: XCTestCase {
-    static var allTests: [(String, (Observation) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_one", test_one),
             ("test_two", test_two),
             ("test_three", test_three),
         ]
-    }
+    }()
 
 // CHECK: Test Case 'Observation.test_one' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Observation/All/main.swift:[[@LINE+12]]: error: Observation.test_one : failed - fail!

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -37,11 +37,11 @@ let observer = Observer()
 XCTestObservationCenter.shared().addTestObserver(observer)
 
 class SkippedTestCase: XCTestCase {
-    static var allTests: [(String, (SkippedTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_skipped", test_skipped),
         ]
-    }
+    }()
 
     func test_skipped() {
         XCTFail("This test case should not be executed.")
@@ -50,12 +50,12 @@ class SkippedTestCase: XCTestCase {
 
 // CHECK: Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
 class ExecutedTestCase: XCTestCase {
-    static var allTests: [(String, (ExecutedTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_executed", test_executed),
             ("test_skipped", test_skipped),
         ]
-    }
+    }()
 
 // CHECK: Test Case 'ExecutedTestCase.test_executed' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExecutedTestCase.test_executed' passed \(\d+\.\d+ seconds\).

--- a/Tests/Functional/Performance/Misuse/main.swift
+++ b/Tests/Functional/Performance/Misuse/main.swift
@@ -108,7 +108,7 @@ class PerformanceMisuseTestCase: XCTestCase {
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' failed \(\d+\.\d+ seconds\).
 
-    static var allTests: [(String, (PerformanceMisuseTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
                    ("test_whenMeasuringMultipleInOneTest_fails", test_whenMeasuringMultipleInOneTest_fails),
                    ("test_whenMeasuringMetricsAndNotStartingOrEnding_fails", test_whenMeasuringMetricsAndNotStartingOrEnding_fails),
@@ -122,7 +122,7 @@ class PerformanceMisuseTestCase: XCTestCase {
                    ("test_measuringNoMetrics_fails", test_measuringNoMetrics_fails),
                    ("test_measuringUnknownMetric_fails", test_measuringUnknownMetric_fails),
         ]
-    }
+    }()
 }
 // CHECK: Test Suite 'PerformanceMisuseTestCase' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed \d+ tests, with 12 failures \(12 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -96,7 +96,7 @@ class PerformanceTestCase: XCTestCase {
     }
     // CHECK: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' failed \(\d+\.\d+ seconds\).
 
-    static var allTests: [(String, (PerformanceTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
                    ("test_measureBlockIteratesTenTimes", test_measureBlockIteratesTenTimes),
                    ("test_measuresMetricsWithAutomaticStartAndStop", test_measuresMetricsWithAutomaticStartAndStop),
@@ -107,7 +107,7 @@ class PerformanceTestCase: XCTestCase {
                    ("test_abortsMeasurementsAfterTestFailure", test_abortsMeasurementsAfterTestFailure),
                    ("test_measuresWallClockTimeInBlock", test_measuresWallClockTimeInBlock),
         ]
-    }
+    }()
 }
 // CHECK: Test Suite 'PerformanceTestCase' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed \d+ tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -18,12 +18,12 @@
 // CHECK-ALL: Test Suite '.*\.xctest' started at \d+:\d+:\d+\.\d+
 
 class ExecutedTestCase: XCTestCase {
-    static var allTests: [(String, (ExecutedTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_bar", test_bar),
             ("test_foo", test_foo),
         ]
-    }
+    }()
 
 // CHECK-METHOD:   Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
 // CHECK-METHOD:   Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
@@ -52,9 +52,9 @@ class ExecutedTestCase: XCTestCase {
 
 // CHECK-ALL: Test Suite 'SkippedTestCase' started at \d+:\d+:\d+\.\d+
 class SkippedTestCase: XCTestCase {
-    static var allTests: [(String, (SkippedTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [("test_baz", test_baz)]
-    }
+    }()
 
 // CHECK-ALL: Test Case 'SkippedTestCase.test_baz' started at \d+:\d+:\d+\.\d+
 // CHECK-ALL: Test Case 'SkippedTestCase.test_baz' passed \(\d+\.\d+ seconds\).

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -13,11 +13,11 @@
 
 // CHECK: Test Suite 'SingleFailingTestCase' started at \d+:\d+:\d+\.\d+
 class SingleFailingTestCase: XCTestCase {
-    static var allTests: [(String, (SingleFailingTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_fails", test_fails)
         ]
-    }
+    }()
 
     // CHECK: Test Case 'SingleFailingTestCase.test_fails' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/SingleFailingTestCase/main.swift:[[@LINE+3]]: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -13,11 +13,11 @@
 
 // CHECK: Test Suite 'SetUpTearDownTestCase' started at \d+:\d+:\d+\.\d+
 class SetUpTearDownTestCase: XCTestCase {
-    static var allTests: [(String, (SetUpTearDownTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_hasValueFromSetUp", test_hasValueFromSetUp),
         ]
-    }
+    }()
 
     var value = 0
 
@@ -60,12 +60,12 @@ class SetUpTearDownTestCase: XCTestCase {
 
 // CHECK: Test Suite 'NewInstanceForEachTestTestCase' started at \d+:\d+:\d+\.\d+
 class NewInstanceForEachTestTestCase: XCTestCase {
-    static var allTests: [(String, (NewInstanceForEachTestTestCase) -> () throws -> Void)] {
+    static var allTests = {
         return [
             ("test_hasInitializedValue", test_hasInitializedValue),
             ("test_hasInitializedValueInAnotherTest", test_hasInitializedValueInAnotherTest),
         ]
-    }
+    }()
 
     var value = 1
 


### PR DESCRIPTION
This is a followup to [SR-1589](https://bugs.swift.org/browse/SR-1589) and https://github.com/apple/swift-corelibs-xctest/pull/116, applying the change throughout the Corelibs XCTest test suite. I have also updated the documentation examples to indicate that this is the preferred way of declaring `allTests` for users of the library.

Thanks again to @ddunbar for this suggestion! (Although hopefully not too many users will need to write this code themselves anyway once [SR-710](https://bugs.swift.org/browse/SR-710) is ready.)