### PR TITLE
[Tests] Set LD_LIBRARY_PATH when running tests

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -76,6 +76,7 @@ else:
         '-I', foundation_dir,
         '-I', core_foundation_dir,
     ])
+    config.environment['LD_LIBRARY_PATH'] = foundation_dir
 
 # Having prepared the swiftc command, we set the substitution.
 config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))


### PR DESCRIPTION
https://github.com/apple/swift/pull/2609 introduced a change to the default behavior of the Swift driver, which now uses the gold linker unless specified otherwise. This caused a linker error in swift-corelibs-xctest's test suite, which this commit fixes.

/cc @compnerd -- does this seem like a reasonable fix? To be honest, I'm not sure why such a change would be necessary for gold but not bfd.