### PR TITLE
[build] Add an rpath of $ORIGIN.

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -155,6 +155,9 @@ class GenericUnixStrategy:
                 source_paths=" ".join(sourcePaths)))
         run("{swiftc} -emit-library {build_dir}/XCTest.o "
             "-L {foundation_build_dir} -lswiftGlibc -lswiftCore -lFoundation -lm "
+            # We embed an rpath of `$ORIGIN` to ensure other referenced
+            # libraries (like `Foundation`) can be found solely via XCTest.
+            "-Xlinker -rpath=\\$ORIGIN "
             "-o {build_dir}/libXCTest.so".format(
                 swiftc=swiftc,
                 build_dir=build_dir,


### PR DESCRIPTION
 - This allows XCTest to find Foundation adjacent to itself, and fixes runtime
   linker problems when using Gold, which automatically uses DT_RUNPATH instead
   of DT_RPATH and so no longer inherits the search path into the Swift runtime
   libraries location used at build time on the client (which `swiftc` currently
   automatically injects).

 - Fixes SR-1631.