### PR TITLE
[SR-1417] Add non-optional overloads of XCTAssertEqual and XCTAssertN…

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -156,6 +156,17 @@ public func XCTAssert(_ expression: @autoclosure () throws -> Boolean, _ message
     XCTAssertTrue(expression, message, file: file, line: line)
 }
 
+public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
+        let (value1, value2) = (try expression1(), try expression2())
+        if value1 == value2 {
+            return .success
+        } else {
+            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+        }
+    }
+}
+
 public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
@@ -284,6 +295,17 @@ public func XCTAssertNil(_ expression: @autoclosure () throws -> Any?, _ message
             return .success
         } else {
             return .expectedFailure("\"\(value!)\"")
+        }
+    }
+}
+
+public func XCTAssertNotEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
+        let (value1, value2) = (try expression1(), try expression2())
+        if value1 != value2 {
+            return .success
+        } else {
+            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
         }
     }
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -64,7 +64,7 @@ class ErrorHandling: XCTestCase {
     }
     
 // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+11]]: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("Optional\("an error message"\)"\) is not equal to \("Optional\(""\)"\) -
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+11]]: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("an error message"\) is not equal to \(""\) -
 // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
     func test_throwsErrorInAssertionButFailsWhenCheckingError() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -18,6 +18,7 @@ class FailureMessagesTestCase: XCTestCase {
     static var allTests = {
         return [
             ("testAssert", testAssert),
+            ("testAssertEqualValues", testAssertEqualValues),
             ("testAssertEqualOptionals", testAssertEqualOptionals),
             ("testAssertEqualArraySlices", testAssertEqualArraySlices),
             ("testAssertEqualContiguousArrays", testAssertEqualContiguousArrays),
@@ -30,6 +31,7 @@ class FailureMessagesTestCase: XCTestCase {
             ("testAssertLessThan", testAssertLessThan),
             ("testAssertLessThanOrEqual", testAssertLessThanOrEqual),
             ("testAssertNil", testAssertNil),
+            ("testAssertNotEqualValues", testAssertNotEqualValues),
             ("testAssertNotEqualOptionals", testAssertNotEqualOptionals),
             ("testAssertNotEqualArraySlices", testAssertNotEqualArraySlices),
             ("testAssertNotEqualContiguousArrays", testAssertNotEqualContiguousArrays),
@@ -49,13 +51,20 @@ class FailureMessagesTestCase: XCTestCase {
         XCTAssert(false, "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualValues' started at \d+:\d+:\d+\.\d+
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualValues : XCTAssertEqual failed: \("1"\) is not equal to \("2"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualValues' failed \(\d+\.\d+ seconds\).
+    func testAssertEqualValues() {
+        XCTAssertEqual(1, 2, "message", file: "test.swift")
+    }
+
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertEqualOptionals() {
-        XCTAssertEqual(1, 2, "message", file: "test.swift")
+        XCTAssertEqual(Optional(1), Optional(2), "message", file: "test.swift")
     }
-
+    
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
@@ -133,13 +142,20 @@ class FailureMessagesTestCase: XCTestCase {
         XCTAssertNil("helloworld", "message", file: "test.swift")
     }
 
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualValues' started at \d+:\d+:\d+\.\d+
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualValues : XCTAssertNotEqual failed: \("1"\) is equal to \("1"\) - message
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualValues' failed \(\d+\.\d+ seconds\).
+    func testAssertNotEqualValues() {
+        XCTAssertNotEqual(1, 1, "message", file: "test.swift")
+    }
+
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
     func testAssertNotEqualOptionals() {
-        XCTAssertNotEqual(1, 1, "message", file: "test.swift")
+        XCTAssertNotEqual(Optional(1), Optional(1), "message", file: "test.swift")
     }
-
+    
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
@@ -197,11 +213,11 @@ class FailureMessagesTestCase: XCTestCase {
     }
 }
 // CHECK: Test Suite 'FailureMessagesTestCase' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 24 tests, with 24 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(FailureMessagesTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 24 tests, with 24 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 22 tests, with 22 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 24 tests, with 24 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -64,7 +64,7 @@ class FailureMessagesTestCase: XCTestCase {
     func testAssertEqualOptionals() {
         XCTAssertEqual(Optional(1), Optional(2), "message", file: "test.swift")
     }
-    
+
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
@@ -155,7 +155,7 @@ class FailureMessagesTestCase: XCTestCase {
     func testAssertNotEqualOptionals() {
         XCTAssertNotEqual(Optional(1), Optional(1), "message", file: "test.swift")
     }
-    
+
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).


### PR DESCRIPTION
…otEqual

Previously, the only version of the functions that accepted values was the one that implicitly wraps them into Optionals. This generated a confusing error message when the assert failed. Having a separate overload that accepts non-optional types ensures that the correct description is printed when the assert fails.