### PR TITLE
[SE-0025] Adapt accessibility for `fileprivate`

### DIFF
--- a/Sources/XCTest/Private/PerformanceMeter.swift
+++ b/Sources/XCTest/Private/PerformanceMeter.swift
@@ -91,7 +91,7 @@ public final class PerformanceMeter {
         return state == .measurementFinished || state == .measurementAborted
     }
 
-    private enum State {
+    fileprivate enum State {
         case iterationUnstarted
         case iterationStarted
         case iterationFinished

--- a/Sources/XCTest/Private/PrintObserver.swift
+++ b/Sources/XCTest/Private/PrintObserver.swift
@@ -66,7 +66,7 @@ internal class PrintObserver: XCTestObservation {
         return formatter
     }()
 
-    private func printAndFlush(_ message: String) {
+    fileprivate func printAndFlush(_ message: String) {
         print(message)
         fflush(stdout)
     }

--- a/Sources/XCTest/Private/TestFiltering.swift
+++ b/Sources/XCTest/Private/TestFiltering.swift
@@ -47,12 +47,12 @@ internal struct TestFiltering {
 }
 
 /// A selected test can be a single test case, or an entire class of test cases
-private struct SelectedTest {
+fileprivate struct SelectedTest {
     let testCaseClassName: String
     let testCaseMethodName: String?
 }
 
-private extension SelectedTest {
+fileprivate extension SelectedTest {
     init?(selectedTestName: String) {
         let components = selectedTestName.characters.split(separator: "/").map(String.init)
         switch components.count {

--- a/Sources/XCTest/Private/WallClockTimeMetric.swift
+++ b/Sources/XCTest/Private/WallClockTimeMetric.swift
@@ -67,7 +67,7 @@ internal final class WallClockTimeMetric: PerformanceMetric {
 }
 
 
-private extension Collection where Index: IntegerLiteralConvertible, Iterator.Element == WallClockTimeMetric.Measurement {
+fileprivate extension Collection where Index: IntegerLiteralConvertible, Iterator.Element == WallClockTimeMetric.Measurement {
     var average: WallClockTimeMetric.Measurement {
         return self.reduce(0, combine: +) / Double(count.toIntMax())
     }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -10,7 +10,7 @@
 //  XCTAssert.swift
 //
 
-private enum _XCTAssertion {
+fileprivate enum _XCTAssertion {
     case equal
     case equalWithAccuracy
     case greaterThan
@@ -46,7 +46,7 @@ private enum _XCTAssertion {
     }
 }
 
-private enum _XCTAssertionResult {
+fileprivate enum _XCTAssertionResult {
     case success
     case expectedFailure(String?)
     case unexpectedFailure(ErrorProtocol)

--- a/Sources/XCTest/Public/XCTestObservationCenter.swift
+++ b/Sources/XCTest/Public/XCTestObservationCenter.swift
@@ -88,7 +88,7 @@ public class XCTestObservationCenter {
     }
 }
 
-private extension XCTestObservation {
+fileprivate extension XCTestObservation {
     var wrapper: ObjectWrapper<XCTestObservation> {
         return ObjectWrapper(object: self, objectIdentifier: ObjectIdentifier(self))
     }


### PR DESCRIPTION
The standard migration path for SE-0025 is to find-and-replace all uses of `private` with `fileprivate`. However, this expands accessibility beyond the necessary minimum. This commit uses compiler errors to determine the minimum set of changes.

This should only be tested/merged once https://github.com/apple/swift/pull/3000 has landed in apple/swift. Thanks to @CodaFi for making it easy to enable the new `fileprivate` errors -- to discover the necessary changes I applied the following change to https://github.com/apple/swift/pull/3000 (since that pull request now aliases `private` to `fileprivate` for migration purposes):

```diff
diff --git a/lib/AST/NameLookup.cpp b/lib/AST/NameLookup.cpp
index bee6b2f..149c8a4 100644
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1017,7 +1017,7 @@ static bool checkAccessibility(const DeclContext *useDC,
 
   switch (access) {
   case Accessibility::Private:
-//      return useDC == sourceDC || useDC->isChildContextOf(sourceDC);
+     return useDC == sourceDC || useDC->isChildContextOf(sourceDC);
   case Accessibility::FilePrivate:
     return useDC->getModuleScopeContext() == sourceDC->getModuleScopeContext();
   case Accessibility::Internal: {
```

We could probably refactor a bit after this pull request, to reduce API from `fileprivate` to `private` where possible.