### PR TITLE
Make libdispatch available to Tests/Functional if built

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -77,6 +77,15 @@ else:
         '-I', core_foundation_dir,
     ])
     config.environment['LD_LIBRARY_PATH'] = foundation_dir
+    # as well as libdispatch if Foundation is using it
+    libdispatch_src_dir = os.getenv('LIBDISPATCH_SRC_DIR')
+    libdispatch_build_dir = os.getenv('LIBDISPATCH_BUILD_DIR')
+    if (libdispatch_src_dir is not None) and (libdispatch_build_dir is not None):
+        swift_exec.extend([
+            '-Xcc', '-fblocks',
+            '-I', libdispatch_src_dir,
+            '-L', libdispatch_build_dir,
+        ])
 
 # Having prepared the swiftc command, we set the substitution.
 config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))


### PR DESCRIPTION
When libdispatch is build into Foundation, XCTest needs access to it. The XCTest build has already been updated to handle that, and runtime linkage works for the full toolchain because Foundation has an rpath of ORIGIN, and libdispatch and libFoundation are in the same directory.

These changes are for the XCTest tests, which can't use the toolchain because its not built yet. They add the build time flags to the tests, and creates a symlink from the Foundation build directory to the libdispatch library so that its picked up on the rpath of ORIGIN. This is similar to the approach being taken in Swift PM already.