### PR TITLE
Update expectation based API names for API guidelines

### DIFF
--- a/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
@@ -39,7 +39,7 @@ public extension XCTestCase {
     ///   between these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    func expectation(withDescription description: String, file: StaticString = #file, line: UInt = #line) -> XCTestExpectation {
+    func expectation(description: String, file: StaticString = #file, line: UInt = #line) -> XCTestExpectation {
         let expectation = XCTestExpectation(
             description: description,
             file: file,
@@ -74,7 +74,7 @@ public extension XCTestCase {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    func waitForExpectations(withTimeout timeout: TimeInterval, file: StaticString = #file, line: UInt = #line, handler: XCWaitCompletionHandler? = nil) {
+    func waitForExpectations(timeout: TimeInterval, file: StaticString = #file, line: UInt = #line, handler: XCWaitCompletionHandler? = nil) {
         // Mirror Objective-C XCTest behavior; display an unexpected test
         // failure when users wait without having first set expectations.
         // FIXME: Objective-C XCTest raises an exception for most "API
@@ -166,7 +166,7 @@ public extension XCTestCase {
     ///   expectation.
     func expectation(forNotification notificationName: String, object objectToObserve: AnyObject?, handler: XCNotificationExpectationHandler? = nil) -> XCTestExpectation {
         let objectDescription = objectToObserve == nil ? "any object" : "\(objectToObserve!)"
-        let expectation = self.expectation(withDescription: "Expect notification '\(notificationName)' from " + objectDescription)
+        let expectation = self.expectation(description: "Expect notification '\(notificationName)' from " + objectDescription)
         // Start observing the notification with specified name and object.
         var observer: NSObjectProtocol? = nil
         func removeObserver() {

--- a/Sources/XCTest/Public/XCTestErrors.swift
+++ b/Sources/XCTest/Public/XCTestErrors.swift
@@ -17,11 +17,11 @@ public let XCTestErrorDomain = "org.swift.XCTestErrorDomain"
 /// Error codes for errors in the XCTestErrorDomain.
 public enum XCTestErrorCode : Int {
     /// Indicates that one or more expectations failed to be fulfilled in time
-    /// during a call to `waitForExpectations(withTimeout:handler:)`
+    /// during a call to `waitForExpectations(timeout:handler:)`
     case timeoutWhileWaiting
 
     /// Indicates that a test assertion failed while waiting for expectations
-    /// during a call to `waitForExpectations(withTimeout:handler:)`
+    /// during a call to `waitForExpectations(timeout:handler:)`
     /// FIXME: swift-corelibs-xctest does not currently produce this error code.
     case failureWhileWaiting
 }

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -19,64 +19,64 @@ class ExpectationsTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnUnfulfilledExpectation_fails() {
-        expectation(withDescription: "foo")
-        waitForExpectations(withTimeout: 0.2)
+        expectation(description: "foo")
+        waitForExpectations(timeout: 0.2)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+5]]: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
     func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
-        expectation(withDescription: "bar")
-        expectation(withDescription: "baz")
-        waitForExpectations(withTimeout: 0.2)
+        expectation(description: "bar")
+        expectation(description: "baz")
+        waitForExpectations(timeout: 0.2)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
     func test_waitingForAnImmediatelyFulfilledExpectation_passes() {
-        let expectation = self.expectation(withDescription: "flim")
+        let expectation = self.expectation(description: "flim")
         expectation.fulfill()
-        waitForExpectations(withTimeout: 0.2)
+        waitForExpectations(timeout: 0.2)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
     func test_waitingForAnEventuallyFulfilledExpectation_passes() {
-        let expectation = self.expectation(withDescription: "flam")
+        let expectation = self.expectation(description: "flam")
         let timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
             expectation.fulfill()
         }
         RunLoop.current().add(timer, forMode: .defaultRunLoopMode)
-        waitForExpectations(withTimeout: 1.0)
+        waitForExpectations(timeout: 1.0)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+8]]: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
     func test_waitingForAnExpectationFulfilledAfterTheTimeout_fails() {
-        let expectation = self.expectation(withDescription: "hog")
+        let expectation = self.expectation(description: "hog")
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { _ in
             expectation.fulfill()
         }
         RunLoop.current().add(timer, forMode: .defaultRunLoopMode)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' passed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes() {
-        let expectation = self.expectation(withDescription: "smog")
+        let expectation = self.expectation(description: "smog")
         expectation.fulfill()
-        waitForExpectations(withTimeout: 0.0)
+        waitForExpectations(timeout: 0.0)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
     func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
-        expectation(withDescription: "dog")
-        waitForExpectations(withTimeout: -1.0)
+        expectation(description: "dog")
+        waitForExpectations(timeout: -1.0)
     }
 
     static var allTests = {

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -19,10 +19,10 @@ class HandlerTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Handler/main.swift:[[@LINE+6]]: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreNotFulfilled_handlerCalled_andFails() {
-        self.expectation(withDescription: "fog")
+        self.expectation(description: "fog")
 
         var handlerWasCalled = false
-        self.waitForExpectations(withTimeout: 0.2) { error in
+        self.waitForExpectations(timeout: 0.2) { error in
             XCTAssertNotNil(error, "Expectation handlers for unfulfilled expectations should not be nil.")
             XCTAssertEqual(error?.domain, XCTestErrorDomain, "The error domain should be XCTest's own error domain")
             XCTAssertEqual(error?.code, XCTestErrorCode.timeoutWhileWaiting.rawValue, "The error code should indicate that a timeout occurred")
@@ -34,11 +34,11 @@ class HandlerTestCase: XCTestCase {
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' passed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreFulfilled_handlerCalled_andPasses() {
-        let expectation = self.expectation(withDescription: "bog")
+        let expectation = self.expectation(description: "bog")
         expectation.fulfill()
 
         var handlerWasCalled = false
-        self.waitForExpectations(withTimeout: 0.2) { error in
+        self.waitForExpectations(timeout: 0.2) { error in
             XCTAssertNil(error, "Expectation handlers for fulfilled expectations should be nil.")
             handlerWasCalled = true
         }

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -17,15 +17,15 @@ class MisuseTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+4]]: error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails : Failed due to unwaited expectations.
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationsAreMade_butNotWaitedFor_fails() {
-        self.expectation(withDescription: "the first expectation")
-        self.expectation(withDescription: "the second expectation (the file and line number for this one are included in the failure message")
+        self.expectation(description: "the first expectation")
+        self.expectation(description: "the second expectation (the file and line number for this one are included in the failure message")
     }
 
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+3]]: error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
     func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
-        self.waitForExpectations(withTimeout: 0.1)
+        self.waitForExpectations(timeout: 0.1)
     }
 
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started at \d+:\d+:\d+\.\d+
@@ -33,7 +33,7 @@ class MisuseTestCase: XCTestCase {
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+15]]: error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
     func test_whenExpectationIsFulfilledMultipleTimes_fails() {
-        let expectation = self.expectation(withDescription: "rob")
+        let expectation = self.expectation(description: "rob")
         expectation.fulfill()
         expectation.fulfill()
         // FIXME: The behavior here is subtly different from Objective-C XCTest.
@@ -46,7 +46,7 @@ class MisuseTestCase: XCTestCase {
         //        highlights both the lines above and below as failures.
         //        This should be fixed such that the behavior is identical.
         expectation.fulfill()
-        self.waitForExpectations(withTimeout: 0.1)
+        self.waitForExpectations(timeout: 0.1)
     }
 
     static var allTests = {

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -22,7 +22,7 @@ class NotificationExpectationsTestCase: XCTestCase {
         let notificationName = "notificationWithNameTest"
         expectation(forNotification: notificationName, object:nil)
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: notificationName), object: nil)
-        waitForExpectations(withTimeout: 0.0)
+        waitForExpectations(timeout: 0.0)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' started at \d+:\d+:\d+\.\d+
@@ -32,7 +32,7 @@ class NotificationExpectationsTestCase: XCTestCase {
         let dummyObject = NSObject()
         expectation(forNotification: notificationName, object:dummyObject)
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: notificationName), object: dummyObject)
-        waitForExpectations(withTimeout: 0.0)
+        waitForExpectations(timeout: 0.0)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' started at \d+:\d+:\d+\.\d+
@@ -42,7 +42,7 @@ class NotificationExpectationsTestCase: XCTestCase {
         expectation(forNotification: notificationName, object:nil)
         let dummyObject = NSObject()
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: notificationName), object: dummyObject)
-        waitForExpectations(withTimeout: 0.0)
+        waitForExpectations(timeout: 0.0)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' started at \d+:\d+:\d+\.\d+
@@ -51,7 +51,7 @@ class NotificationExpectationsTestCase: XCTestCase {
     func test_observeNotificationWithIncorrectName_fails() {
         expectation(forNotification: "expectedName", object: nil)
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: "actualName"), object: nil)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' started at \d+:\d+:\d+\.\d+
@@ -63,7 +63,7 @@ class NotificationExpectationsTestCase: XCTestCase {
         let anotherDummyObject = NSObject()
         expectation(forNotification: notificationName, object: dummyObject)
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: notificationName), object:anotherDummyObject)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
     
     static var allTests = {

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -24,7 +24,7 @@ class NotificationHandlerTestCase: XCTestCase {
             return false
         })
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: "returnFalse"), object: nil)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
     
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' started at \d+:\d+:\d+\.\d+
@@ -35,7 +35,7 @@ class NotificationHandlerTestCase: XCTestCase {
             return true
         })
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: "returnTrue"), object: nil)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' started at \d+:\d+:\d+\.\d+
@@ -46,7 +46,7 @@ class NotificationHandlerTestCase: XCTestCase {
             XCTFail("Should not call the notification expectation handler")
             return true
         })
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(timeout: 0.1, handler: nil)
         NotificationCenter.defaultCenter().postNotificationName(Notification.Name(rawValue: "note"), object: nil)
     }
     

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -21,7 +21,7 @@ class PredicateExpectationsTestCase: XCTestCase {
         let predicate = Predicate(value: true)
         let object = NSObject()
         expectation(for: predicate, evaluatedWith: object)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails' started at \d+:\d+:\d+\.\d+
@@ -31,7 +31,7 @@ class PredicateExpectationsTestCase: XCTestCase {
         let predicate = Predicate(value: false)
         let object = NSObject()
         expectation(for: predicate, evaluatedWith: object)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_delayedTruePredicateAndObject_passes' started at \d+:\d+:\d+\.\d+
@@ -46,7 +46,7 @@ class PredicateExpectationsTestCase: XCTestCase {
             return false
         })
         expectation(for: predicate, evaluatedWith: halfSecLaterDate)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
     
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyTrueDelayedFalsePredicateAndObject_passes' started at \d+:\d+:\d+\.\d+
@@ -60,7 +60,7 @@ class PredicateExpectationsTestCase: XCTestCase {
             return false
         })
         expectation(for: predicate, evaluatedWith: halfSecLaterDate)
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
     
     static var allTests = {

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -23,7 +23,7 @@ class PredicateHandlerTestCase: XCTestCase {
         self.expectation(for: predicate, evaluatedWith: object, handler: { _ in
             return true
         })
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Handler/main.swift:[[@LINE+8]]: error: PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<Predicate: 0x[0-9a-fA-F]{1,16}>` for object <NSObject: 0x[0-9a-fA-F]{1,16}>
@@ -34,7 +34,7 @@ class PredicateHandlerTestCase: XCTestCase {
         self.expectation(for: predicate, evaluatedWith: object, handler: { _ in
             return false
         })
-        waitForExpectations(withTimeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
     
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails' started at \d+:\d+:\d+\.\d+
@@ -52,7 +52,7 @@ class PredicateHandlerTestCase: XCTestCase {
             XCTFail("Should not call the predicate expectation handler")
             return true
         })
-        waitForExpectations(withTimeout: 0.1, handler: nil)
+        waitForExpectations(timeout: 0.1, handler: nil)
     }
     
     static var allTests = {


### PR DESCRIPTION
 <rdar://problem/26611147> Swift names for… expectation APIs don't match API guidelines

This matches changes we've made in Xcode's XCTest swift overlay.