### PR TITLE
[Tests] Replace %{built_tests_dir} with %T

### DIFF
--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous
-// RUN: %{built_tests_dir}/Asynchronous > %t || true
+// RUN: %{swiftc} %s -o %T/Asynchronous
+// RUN: %T/Asynchronous > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Handler
-// RUN: %{built_tests_dir}/Handler > %t || true
+// RUN: %{swiftc} %s -o %T/Handler
+// RUN: %T/Handler > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Misuse
-// RUN: %{built_tests_dir}/Misuse > %t || true
+// RUN: %{swiftc} %s -o %T/Misuse
+// RUN: %T/Misuse > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous-Notifications
-// RUN: %{built_tests_dir}/Asynchronous-Notifications > %t || true
+// RUN: %{swiftc} %s -o %T/Asynchronous-Notifications
+// RUN: %T/Asynchronous-Notifications > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous-Notifications-Handler
-// RUN: %{built_tests_dir}/Asynchronous-Notifications-Handler > %t || true
+// RUN: %{swiftc} %s -o %T/Asynchronous-Notifications-Handler
+// RUN: %T/Asynchronous-Notifications-Handler > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous-Predicates
-// RUN: %{built_tests_dir}/Asynchronous-Predicates > %t || true
+// RUN: %{swiftc} %s -o %T/Asynchronous-Predicates
+// RUN: %T/Asynchronous-Predicates > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Asynchronous-Predicates-Handler
-// RUN: %{built_tests_dir}/Asynchronous-Predicates-Handler > %t || true
+// RUN: %{swiftc} %s -o %T/Asynchronous-Predicates-Handler
+// RUN: %T/Asynchronous-Predicates-Handler > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/ErrorHandling
-// RUN: %{built_tests_dir}/ErrorHandling > %t || true
+// RUN: %{swiftc} %s -o %T/ErrorHandling
+// RUN: %T/ErrorHandling > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/FailingTestSuite
-// RUN: %{built_tests_dir}/FailingTestSuite > %t || true
+// RUN: %{swiftc} %s -o %T/FailingTestSuite
+// RUN: %T/FailingTestSuite > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/FailureMessagesTestCase
-// RUN: %{built_tests_dir}/FailureMessagesTestCase > %t || true
+// RUN: %{swiftc} %s -o %T/FailureMessagesTestCase
+// RUN: %T/FailureMessagesTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/ListTests/main.swift
+++ b/Tests/Functional/ListTests/main.swift
@@ -1,8 +1,8 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/ListTests
-// RUN: %{built_tests_dir}/ListTests --list-tests > %t_list || true
+// RUN: %{swiftc} %s -o %T/ListTests
+// RUN: %T/ListTests --list-tests > %t_list || true
 // RUN: %{xctest_checker} %t_list %s
-// RUN: %{built_tests_dir}/ListTests --dump-tests-json > %t_json || true
-// RUN: %{built_tests_dir}/ListTests --verify %t_json > %t_verify
+// RUN: %T/ListTests --dump-tests-json > %t_json || true
+// RUN: %T/ListTests --verify %t_json > %t_verify
 // RUN: %{xctest_checker} %t_verify verify_json.expected
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/NegativeAccuracyTestCase
-// RUN: %{built_tests_dir}/NegativeAccuracyTestCase > %t || true
+// RUN: %{swiftc} %s -o %T/NegativeAccuracyTestCase
+// RUN: %T/NegativeAccuracyTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/All
-// RUN: %{built_tests_dir}/All > %t || true
+// RUN: %{swiftc} %s -o %T/All
+// RUN: %T/All > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Selected
-// RUN: %{built_tests_dir}/Selected Selected.ExecutedTestCase/test_executed > %t || true
+// RUN: %{swiftc} %s -o %T/Selected
+// RUN: %T/Selected Selected.ExecutedTestCase/test_executed > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Performance/Misuse/main.swift
+++ b/Tests/Functional/Performance/Misuse/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/PerformanceMisuse
-// RUN: %{built_tests_dir}/PerformanceMisuse > %t || true
+// RUN: %{swiftc} %s -o %T/PerformanceMisuse
+// RUN: %T/PerformanceMisuse > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/Performance
-// RUN: %{built_tests_dir}/Performance > %t || true
+// RUN: %{swiftc} %s -o %T/Performance
+// RUN: %T/Performance > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -1,7 +1,7 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/SelectedTest
-// RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_case || true
-// RUN: %{built_tests_dir}/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case_class || true
-// RUN: %{built_tests_dir}/SelectedTest > %T/all || true
+// RUN: %{swiftc} %s -o %T/SelectedTest
+// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_case || true
+// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case_class || true
+// RUN: %T/SelectedTest > %T/all || true
 // RUN: %{xctest_checker} -p "// CHECK-METHOD:" %T/one_test_case %s
 // RUN: %{xctest_checker} -p "// CHECK-CLASS:" %T/one_test_case_class %s
 // RUN: %{xctest_checker} -p "// CHECK-ALL:" %T/all %s

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/SingleFailingTestCase
-// RUN: %{built_tests_dir}/SingleFailingTestCase > %t || true
+// RUN: %{swiftc} %s -o %T/SingleFailingTestCase
+// RUN: %T/SingleFailingTestCase > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %{built_tests_dir}/TestCaseLifecycle
-// RUN: %{built_tests_dir}/TestCaseLifecycle > %t || true
+// RUN: %{swiftc} %s -o %T/TestCaseLifecycle
+// RUN: %T/TestCaseLifecycle > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -81,11 +81,6 @@ else:
 # Having prepared the swiftc command, we set the substitution.
 config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))
 
-# Add the %built_tests_dir substitution, which is a temporary
-# directory used to store built files.
-built_tests_dir = tempfile.mkdtemp()
-config.substitutions.append(('%{built_tests_dir}', built_tests_dir))
-
 # Add the %xctest_checker substitution, which is a Python script
 # can be used to compare the actual XCTest output to the expected
 # output.


### PR DESCRIPTION
When I first added functional tests in 589b23d, I struggled against `lit`'s design: I attempted to prevent test output from being generated alongside the tests themselves. It wasn't until 8181c16 that I saw the error of my ways: `lit` places test output in the next to the tests in order to make them easier to debug. That commit embraced this design, and excluded the test output from source control.

However, we can do better. The XCTest `lit` tests produce test executables, which the test suite currently attempts to hide in a tmpdir somewhere. These executables are useful: it's nice to be able to re-run an executable at will.

Change the location of the where the executables are generated. Instead of placing them in `%{built_tests_dir}`, place them in an output directory next to the test itself (a concept built into `lit`
and provided by the `%T` substitution). Since we no longer use `%{built_tests_dir}`, remove it.

/cc @ddunbar