### PR TITLE
[Tests] Allow xctest_checker to read from stdin

### DIFF
--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -28,13 +28,13 @@ class CompareTestCase(unittest.TestCase):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: baz\nc: bar\n')
         with self.assertRaises(XCTestCheckerError):
-            compare.compare(actual, expected, check_prefix='c: ')
+            compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
     def test_too_few_expected_raises_and_first_line_in_error(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: bar\n')
         with self.assertRaises(XCTestCheckerError) as cm:
-            compare.compare(actual, expected, check_prefix='c: ')
+            compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
         self.assertIn('{}:{}'.format(expected, 1), cm.exception.message)
 
@@ -42,55 +42,55 @@ class CompareTestCase(unittest.TestCase):
         actual = _tmpfile('foo\nbar\n')
         expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
         with self.assertRaises(XCTestCheckerError) as cm:
-            compare.compare(actual, expected, check_prefix='c: ')
+            compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
         self.assertIn('{}:{}'.format(expected, 3), cm.exception.message)
 
     def test_match_does_not_raise(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: bar\nc: baz\n')
-        compare.compare(actual, expected, check_prefix='c: ')
+        compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
     def test_match_with_inline_check_does_not_raise(self):
         actual = _tmpfile('bling\nblong\n')
         expected = _tmpfile('meep meep // c: bling\nmeep\n// c: blong\n')
-        compare.compare(actual, expected, check_prefix='// c: ')
+        compare.compare(open(actual, 'r'), expected, check_prefix='// c: ')
 
     def test_check_prefix_twice_in_the_same_line_raises_with_line(self):
         actual = _tmpfile('blorp\nbleep\n')
         expected = _tmpfile('c: blorp\nc: bleep c: blammo\n')
         with self.assertRaises(XCTestCheckerError) as cm:
-            compare.compare(actual, expected, check_prefix='c: ')
+            compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
         self.assertIn('{}:{}'.format(expected, 2), cm.exception.message)
 
     def test_check_prefix_in_run_line_ignored(self):
         actual = _tmpfile('flim\n')
         expected = _tmpfile('// RUN: xctest_checker --prefix "c: "\nc: flim\n')
-        compare.compare(actual, expected, check_prefix='c: ')
+        compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
     def test_includes_file_name_and_line_of_expected_in_error(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c: foo\nc: baz\nc: bar\n')
         with self.assertRaises(XCTestCheckerError) as cm:
-            compare.compare(actual, expected, check_prefix='c: ')
+            compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
         self.assertIn("{}:{}:".format(expected, 2), cm.exception.message)
 
     def test_matching_ignores_leading_and_trailing_whitespace(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
         expected = _tmpfile('c:  foo\nc: bar \nc: baz\n')
-        compare.compare(actual, expected, check_prefix='c:')
+        compare.compare(open(actual, 'r'), expected, check_prefix='c:')
 
     def test_can_explicitly_match_leading_and_trailing_whitespace(self):
         actual = _tmpfile('foo\n bar\nbaz \n')
         expected = _tmpfile('c: foo\nc: ^ bar \nc: baz $\n')
-        compare.compare(actual, expected, check_prefix='c:')
+        compare.compare(open(actual, 'r'), expected, check_prefix='c:')
 
     def test_line_number_substitution(self):
         actual = _tmpfile('beep 1\nboop 5\n')
         expected = _tmpfile('c: beep [[@LINE]]\nc: boop [[@LINE+3]]')
-        compare.compare(actual, expected, check_prefix='c: ')
+        compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -14,13 +14,12 @@ from .error import XCTestCheckerError
 from .line import replace_offsets
 
 
-def _actual_lines(path):
+def _actual_lines(file_handle):
     """
-    Returns a generator that yields each line in the file at the given path.
+    Returns a generator that yields each line in the file.
     """
-    with open(path) as f:
-        for line in f:
-            yield line
+    for line in file_handle:
+        yield line
 
 
 def _expected_lines_and_line_numbers(path, check_prefix):

--- a/Tests/Functional/xctest_checker/xctest_checker/main.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/main.py
@@ -12,14 +12,40 @@
 from __future__ import absolute_import
 
 import argparse
+import textwrap
 
 from . import compare
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('actual', help='A path to a file containing the '
-                                       'actual output of an XCTest run.')
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent("""
+            Compare the text output of an XCTest executable with the text
+            that's expected."""),
+        epilog=textwrap.dedent("""
+            In general, %(prog)s should not be invoked directly. Instead,
+            use the Swift built script to build swift-corelibs-xctest and run
+            its tests, which in turn use %(prog)s.
+
+            However, you may find it useful to run %(prog)s directly when
+            debugging the test suite. To compare the actual output of an
+            executable against the expected output, you may run the following:
+
+                Tests/Functional/MyTestCase/Output/MyTestCase | \\
+                    %(prog)s - Tests/Functional/MyTestCase/main.swift
+
+            This pipes the output from the "MyTestCase" executable into
+            %(prog)s, which compares that output to the expected output from
+            "MyTestCase/main.swift".
+            """))
+    parser.add_argument(
+        'actual',
+        type=argparse.FileType('r'),
+        default='-',
+        help='A path to a file containing the actual output of an XCTest '
+             'run, or an input stream of the output. If no argument is '
+             'specified, reads from stdin by default.')
     parser.add_argument('expected', help='A path to a file containing the '
                                          'expected output of an XCTest run.')
     parser.add_argument('-p', '--check-prefix',


### PR DESCRIPTION
It's sometimes useful to run xctest_checker directly when debugging the test suite. To make it easier to compare the actual output of an executable against the expected output, allow xctest_checker to read from stdin. This makes the following possible:

```
Tests/Functional/MyTestCase/Output/MyTestCase | xctest_checker.py - Tests/Functional/MyTestCase/main.swift
```

This pipes the output from the "MyTestCase" executable into xctest_checker, which compares that output to the expected output from "MyTestCase/main.swift".