### PR TITLE
Fix warnings introduced by SE-0099

### DIFF
--- a/Sources/XCTest/Private/TestListing.swift
+++ b/Sources/XCTest/Private/TestListing.swift
@@ -63,7 +63,7 @@ extension XCTestSuite: Listable {
     }
 
     private var listingName: String {
-        if let childTestCase = tests.first as? XCTestCase where name == String(childTestCase.dynamicType) {
+        if let childTestCase = tests.first as? XCTestCase, name == String(childTestCase.dynamicType) {
             return "\(moduleName(value: childTestCase)).\(name)"
         } else {
             return name

--- a/Sources/XCTest/Public/XCTestCase+Performance.swift
+++ b/Sources/XCTest/Public/XCTestCase+Performance.swift
@@ -126,7 +126,7 @@ public extension XCTestCase {
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
     func startMeasuring(file: StaticString = #file, line: UInt = #line) {
-        guard let performanceMeter = _performanceMeter where !performanceMeter.didFinishMeasuring else {
+        guard let performanceMeter = _performanceMeter, !performanceMeter.didFinishMeasuring else {
             return recordAPIViolation(description: "Cannot start measuring. startMeasuring() is only supported from a block passed to measureMetrics(...).", file: file, line: line)
         }
         performanceMeter.startMeasuring(file: file, line: line)
@@ -141,7 +141,7 @@ public extension XCTestCase {
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
     func stopMeasuring(file: StaticString = #file, line: UInt = #line) {
-        guard let performanceMeter = _performanceMeter where !performanceMeter.didFinishMeasuring else {
+        guard let performanceMeter = _performanceMeter, !performanceMeter.didFinishMeasuring else {
             return recordAPIViolation(description: "Cannot stop measuring. stopMeasuring() is only supported from a block passed to measureMetrics(...).", file: file, line: line)
         }
         performanceMeter.stopMeasuring(file: file, line: line)

--- a/Sources/XCTest/Public/XCTestRun.swift
+++ b/Sources/XCTest/Public/XCTestRun.swift
@@ -33,7 +33,7 @@ public class XCTestRun {
     /// The number of seconds that elapsed between when the run was started and
     /// when it was stopped.
     public var totalDuration: TimeInterval {
-        if let stop = stopDate, start = startDate {
+        if let stop = stopDate, let start = startDate {
             return stop.timeIntervalSince(start)
         } else {
             return 0.0


### PR DESCRIPTION
Many "where" and other condition clauses have been replaced by commas. Apply the compiler fix-its to fix the warnings.

For details on the proposal, see: https://github.com/apple/swift-evolution/blob/master/proposals/0099-conditionclauses.md