### PR TITLE
Update for SE-0025 ('private' and 'fileprivate')

### DIFF
--- a/Sources/XCTest/Private/PrintObserver.swift
+++ b/Sources/XCTest/Private/PrintObserver.swift
@@ -66,7 +66,7 @@ internal class PrintObserver: XCTestObservation {
         return formatter
     }()
 
-    private func printAndFlush(_ message: String) {
+    fileprivate func printAndFlush(_ message: String) {
         print(message)
         fflush(stdout)
     }


### PR DESCRIPTION
[SE-0025](https://github.com/apple/swift-evolution/blob/master/proposals/0025-scoped-access-level.md) makes `private` restrict access to a lexical scope; the Swift 2 behavior is now named `fileprivate`. At the time of this pull request, the compiler treats both `private` and `fileprivate` as having `fileprivate` semantics, but that will soon change.

Supersedes #124; the latest amendment to SE-0025 permits some accesses that the original model (or at least our interpretation of it) would have forbidden.