### PR TITLE
Rename *LiteralConvertible conformances to ExpressibleBy*Literal

### DIFF
--- a/Sources/XCTest/Private/WallClockTimeMetric.swift
+++ b/Sources/XCTest/Private/WallClockTimeMetric.swift
@@ -67,7 +67,7 @@ internal final class WallClockTimeMetric: PerformanceMetric {
 }
 
 
-private extension Collection where Index: IntegerLiteralConvertible, Iterator.Element == WallClockTimeMetric.Measurement {
+private extension Collection where Index: ExpressibleByIntegerLiteral, Iterator.Element == WallClockTimeMetric.Measurement {
     var average: WallClockTimeMetric.Measurement {
         return self.reduce(0, combine: +) / Double(count.toIntMax())
     }


### PR DESCRIPTION
In accordance with SE-0115 and apple/swift#3474.