### PR TITLE
[Performance] Remove redundant state update

### DIFF
--- a/Sources/XCTest/Private/PerformanceMeter.swift
+++ b/Sources/XCTest/Private/PerformanceMeter.swift
@@ -124,7 +124,6 @@ public final class PerformanceMeter {
 
     func startMeasuring(file: StaticString = #file, line: UInt = #line) {
         guard state == .iterationUnstarted else {
-            state = .measurementAborted
             return recordAPIViolation(.startMeasuringAlreadyCalled, file: file, line: line)
         }
         state = .iterationStarted


### PR DESCRIPTION
`PerformanceMeter.state` is updated from within the `recordAPIViolation()` method, so there's no need to update it prior to calling that method as well.

/cc @briancroom