### PR TITLE
[Performance] Pass correct file/line to methods

### DIFF
--- a/Sources/XCTest/Private/PerformanceMeter.swift
+++ b/Sources/XCTest/Private/PerformanceMeter.swift
@@ -186,7 +186,7 @@ public final class PerformanceMeter {
 
     private func stopMeasuringIfNeeded() {
         if state == .iterationStarted {
-            stopMeasuring()
+            stopMeasuring(file: invocationFile, line: invocationLine)
         }
     }
 

--- a/Sources/XCTest/Public/XCTestCase+Performance.swift
+++ b/Sources/XCTest/Public/XCTestCase+Performance.swift
@@ -111,7 +111,7 @@ public extension XCTestCase {
         PerformanceMeter.measureMetrics(metrics, delegate: self, file: file, line: line) { meter in
             self._performanceMeter = meter
             if automaticallyStartMeasuring {
-                meter.startMeasuring()
+                meter.startMeasuring(file: file, line: line)
             }
             block()
         }


### PR DESCRIPTION
Were these two callsites to fail for some reason, they would display the file and line number for an internal piece of swift-corelibs-xctest source code, rather than the callsite in the user's test. Thread through the user calliste file and line to fix the issue.

In practice, these two callsites cannot possibly fail:

- The call to `startMeasuring()` occurs before the user has any chance to affect the measurement process, so the meter could not possibly be in an invalid state.
- The call to `stopMeasuring()` is only done if measuring is in progress.

Since these cannot fail, it's impossible to write tests for this code... still, if the structure of this code changes in the future, this commit could prevent issues from popping up.

/cc @briancroom 