### PR TITLE
Add 'open' to all public classes and their members.

### DIFF
--- a/Sources/XCTest/Public/XCAbstractTest.swift
+++ b/Sources/XCTest/Public/XCAbstractTest.swift
@@ -15,20 +15,20 @@
 /// An abstract base class for testing. `XCTestCase` and `XCTestSuite` extend
 /// `XCTest` to provide for creating, managing, and executing tests. Most
 /// developers will not need to subclass `XCTest` directly.
-public class XCTest {
+open class XCTest {
     /// Test's name. Must be overridden by subclasses.
-    public var name: String {
+    open var name: String {
         fatalError("Must be overridden by subclasses.")
     }
 
     /// Number of test cases. Must be overridden by subclasses.
-    public var testCaseCount: UInt {
+    open var testCaseCount: UInt {
         fatalError("Must be overridden by subclasses.")
     }
 
     /// The `XCTestRun` subclass that will be instantiated when the test is run
     /// to hold the test's results. Must be overridden by subclasses.
-    public var testRunClass: AnyClass? {
+    open var testRunClass: AnyClass? {
         fatalError("Must be overridden by subclasses.")
     }
 
@@ -39,17 +39,17 @@ public class XCTest {
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, you should not set this property. See
     ///   https://bugs.swift.org/browse/SR-1129 for details.
-    public public(set) var testRun: XCTestRun? = nil
+    open open(set) var testRun: XCTestRun? = nil
 
     /// The method through which tests are executed. Must be overridden by
     /// subclasses.
-    public func perform(_ run: XCTestRun) {
+    open func perform(_ run: XCTestRun) {
         fatalError("Must be overridden by subclasses.")
     }
 
     /// Creates an instance of the `testRunClass` and passes it as a parameter
     /// to `perform()`.
-    public func run() {
+    open func run() {
         guard let testRunType = testRunClass as? XCTestRun.Type else {
             fatalError("XCTest.testRunClass must be a kind of XCTestRun.")
         }
@@ -59,11 +59,11 @@ public class XCTest {
 
     /// Setup method called before the invocation of each test method in the
     /// class.
-    public func setUp() {}
+    open func setUp() {}
 
     /// Teardown method called after the invocation of each test method in the
     /// class.
-    public func tearDown() {}
+    open func tearDown() {}
 
     // FIXME: This initializer is required due to a Swift compiler bug on Linux.
     //        It should be removed once the bug is fixed.

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -32,12 +32,12 @@ internal var XCTCurrentTestCase: XCTestCase?
 /// run by the framework. This class is normally subclassed and extended with
 /// methods containing the tests to run.
 /// - seealso: `XCTMain`
-public class XCTestCase: XCTest {
+open class XCTestCase: XCTest {
     private let testClosure: (XCTestCase) throws -> Void
 
     /// The name of the test case, consisting of its class name and the method
     /// name it will run.
-    public override var name: String {
+    open override var name: String {
         return _name
     }
     /// A private setter for the name of this test case.
@@ -48,7 +48,7 @@ public class XCTestCase: XCTest {
     ///   https://bugs.swift.org/browse/SR-1129 for details.
     public var _name: String
 
-    public override var testCaseCount: UInt {
+    open override var testCaseCount: UInt {
         return 1
     }
 
@@ -68,11 +68,11 @@ public class XCTestCase: XCTest {
     ///   https://bugs.swift.org/browse/SR-1129 for details.
     public var _performanceMeter: PerformanceMeter?
 
-    public override var testRunClass: AnyClass? {
+    open override var testRunClass: AnyClass? {
         return XCTestCaseRun.self
     }
 
-    public override func perform(_ run: XCTestRun) {
+    open override func perform(_ run: XCTestRun) {
         guard let testRun = run as? XCTestCaseRun else {
             fatalError("Wrong XCTestRun class.")
         }
@@ -96,7 +96,7 @@ public class XCTestCase: XCTest {
 
     /// Invoking a test performs its setUp, invocation, and tearDown. In
     /// general this should not be called directly.
-    public func invokeTest() {
+    open func invokeTest() {
         setUp()
         do {
             try testClosure(self)
@@ -120,7 +120,7 @@ public class XCTestCase: XCTest {
     /// - Parameter expected: `true` if the failure being reported was the
     ///   result of a failed assertion, `false` if it was the result of an
     ///   uncaught exception.
-    public func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: UInt, expected: Bool) {
+    open func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: UInt, expected: Bool) {
         testRun?.recordFailure(
             withDescription: description,
             inFile: filePath,
@@ -142,13 +142,13 @@ public class XCTestCase: XCTest {
 
     /// Setup method called before the invocation of any test method in the
     /// class.
-    public class func setUp() {}
+    open class func setUp() {}
 
     /// Teardown method called after the invocation of every test method in the
     /// class.
-    public class func tearDown() {}
+    open class func tearDown() {}
 
-    public var continueAfterFailure: Bool {
+    open var continueAfterFailure: Bool {
         get {
             return true
         }

--- a/Sources/XCTest/Public/XCTestCaseRun.swift
+++ b/Sources/XCTest/Public/XCTestCaseRun.swift
@@ -12,18 +12,18 @@
 //
 
 /// A test run for an `XCTestCase`.
-public class XCTestCaseRun: XCTestRun {
-    public override func start() {
+open class XCTestCaseRun: XCTestRun {
+    open override func start() {
         super.start()
         XCTestObservationCenter.shared().testCaseWillStart(testCase)
     }
 
-    public override func stop() {
+    open override func stop() {
         super.stop()
         XCTestObservationCenter.shared().testCaseDidFinish(testCase)
     }
 
-    public override func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: UInt, expected: Bool) {
+    open override func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: UInt, expected: Bool) {
         super.recordFailure(
             withDescription: "\(test.name) : \(description)",
             inFile: filePath,

--- a/Sources/XCTest/Public/XCTestRun.swift
+++ b/Sources/XCTest/Public/XCTestRun.swift
@@ -20,19 +20,19 @@
 /// A test run collects information about the execution of a test. Failures in
 /// explicit test assertions are classified as "expected", while failures from
 /// unrelated or uncaught exceptions are classified as "unexpected".
-public class XCTestRun {
+open class XCTestRun {
     /// The test instance provided when the test run was initialized.
     public let test: XCTest
 
     /// The time at which the test run was started, or nil.
-    public private(set) var startDate: Date?
+    open private(set) var startDate: Date?
 
     /// The time at which the test run was stopped, or nil.
-    public private(set) var stopDate: Date?
+    open private(set) var stopDate: Date?
 
     /// The number of seconds that elapsed between when the run was started and
     /// when it was stopped.
-    public var totalDuration: TimeInterval {
+    open var totalDuration: TimeInterval {
         if let stop = stopDate, let start = startDate {
             return stop.timeIntervalSince(start)
         } else {
@@ -43,33 +43,33 @@ public class XCTestRun {
     /// In an `XCTestCase` run, the number of seconds that elapsed between when
     /// the run was started and when it was stopped. In an `XCTestSuite` run,
     /// the combined `testDuration` of each test case in the suite.
-    public var testDuration: TimeInterval {
+    open var testDuration: TimeInterval {
         return totalDuration
     }
 
     /// The number of tests in the run.
-    public var testCaseCount: UInt {
+    open var testCaseCount: UInt {
         return test.testCaseCount
     }
 
     /// The number of test executions recorded during the run.
-    public private(set) var executionCount: UInt = 0
+    open private(set) var executionCount: UInt = 0
 
     /// The number of test failures recorded during the run.
-    public private(set) var failureCount: UInt = 0
+    open private(set) var failureCount: UInt = 0
 
     /// The number of uncaught exceptions recorded during the run.
-    public private(set) var unexpectedExceptionCount: UInt = 0
+    open private(set) var unexpectedExceptionCount: UInt = 0
 
     /// The total number of test failures and uncaught exceptions recorded
     /// during the run.
-    public var totalFailureCount: UInt {
+    open var totalFailureCount: UInt {
         return failureCount + unexpectedExceptionCount
     }
 
     /// `true` if all tests in the run completed their execution without
     /// recording any failures, otherwise `false`.
-    public var hasSucceeded: Bool {
+    open var hasSucceeded: Bool {
         guard isStopped else {
             return false
         }
@@ -84,7 +84,7 @@ public class XCTestRun {
     }
 
     /// Start a test run. Must not be called more than once.
-    public func start() {
+    open func start() {
         guard !isStarted else {
             fatalError("Invalid attempt to start a test run that has " +
                        "already been started: \(self)")
@@ -99,7 +99,7 @@ public class XCTestRun {
 
     /// Stop a test run. Must not be called unless the run has been started.
     /// Must not be called more than once.
-    public func stop() {
+    open func stop() {
         guard isStarted else {
             fatalError("Invalid attempt to stop a test run that has " +
                        "not yet been started: \(self)")

--- a/Sources/XCTest/Public/XCTestSuite.swift
+++ b/Sources/XCTest/Public/XCTestSuite.swift
@@ -19,11 +19,11 @@
 ///     suite.addTest(myTest)
 ///     suite.testCaseCount // 1
 ///     suite.run()
-public class XCTestSuite: XCTest {
-    public private(set) var tests = [XCTest]()
+open class XCTestSuite: XCTest {
+    open private(set) var tests = [XCTest]()
 
     /// The name of this test suite.
-    override public var name: String {
+    open override var name: String {
         return _name
     }
     /// A private setter for the name of this test suite.
@@ -35,15 +35,15 @@ public class XCTestSuite: XCTest {
     public let _name: String
 
     /// The number of test cases in this suite.
-    public override var testCaseCount: UInt {
+    open override var testCaseCount: UInt {
         return tests.reduce(0) { $0 + $1.testCaseCount }
     }
 
-    public override var testRunClass: AnyClass? {
+    open override var testRunClass: AnyClass? {
         return XCTestSuiteRun.self
     }
 
-    public override func perform(_ run: XCTestRun) {
+    open override func perform(_ run: XCTestRun) {
         guard let testRun = run as? XCTestSuiteRun else {
             fatalError("Wrong XCTestRun class.")
         }
@@ -64,7 +64,7 @@ public class XCTestSuite: XCTest {
 
     /// Adds a test (either an `XCTestSuite` or an `XCTestCase` to this
     /// collection.
-    public func addTest(_ test: XCTest) {
+    open func addTest(_ test: XCTest) {
         tests.append(test)
     }
 }

--- a/Sources/XCTest/Public/XCTestSuiteRun.swift
+++ b/Sources/XCTest/Public/XCTestSuiteRun.swift
@@ -18,34 +18,34 @@
 #endif
 
 /// A test run for an `XCTestSuite`.
-public class XCTestSuiteRun: XCTestRun {
+open class XCTestSuiteRun: XCTestRun {
     /// The combined `testDuration` of each test case run in the suite.
-    public override var totalDuration: TimeInterval {
+    open override var totalDuration: TimeInterval {
         return testRuns.reduce(TimeInterval(0.0)) { $0 + $1.totalDuration }
     }
 
     /// The combined execution count of each test case run in the suite.
-    public override var executionCount: UInt {
+    open override var executionCount: UInt {
         return testRuns.reduce(0) { $0 + $1.executionCount }
     }
 
     /// The combined failure count of each test case run in the suite.
-    public override var failureCount: UInt {
+    open override var failureCount: UInt {
         return testRuns.reduce(0) { $0 + $1.failureCount }
     }
 
     /// The combined unexpected failure count of each test case run in the
     /// suite.
-    public override var unexpectedExceptionCount: UInt {
+    open override var unexpectedExceptionCount: UInt {
         return testRuns.reduce(0) { $0 + $1.unexpectedExceptionCount }
     }
 
-    public override func start() {
+    open override func start() {
         super.start()
         XCTestObservationCenter.shared().testSuiteWillStart(testSuite)
     }
 
-    public override func stop() {
+    open override func stop() {
         super.stop()
         XCTestObservationCenter.shared().testSuiteDidFinish(testSuite)
     }
@@ -53,11 +53,11 @@ public class XCTestSuiteRun: XCTestRun {
     /// The test run for each of the tests in this suite.
     /// Depending on what kinds of tests this suite is composed of, these could
     /// be some combination of `XCTestCaseRun` and `XCTestSuiteRun` objects.
-    public private(set) var testRuns = [XCTestRun]()
+    open private(set) var testRuns = [XCTestRun]()
 
     /// Add a test run to the collection of `testRuns`.
     /// - Note: It is rare to call this method outside of XCTest itself.
-    public func addTestRun(_ testRun: XCTestRun) {
+    open func addTestRun(_ testRun: XCTestRun) {
         testRuns.append(testRun)
     }
 


### PR DESCRIPTION
This can probably be refined by the XCTest team in a later commit.

In preparation for landing [SE-0117](https://github.com/apple/swift-evolution/blob/master/proposals/0117-non-public-subclassable-by-default.md).