### PR TITLE
Revert "update tests for SE-0110" and "update for SE-0110"

### DIFF
--- a/Sources/XCTest/Private/TestFiltering.swift
+++ b/Sources/XCTest/Private/TestFiltering.swift
@@ -28,17 +28,17 @@ internal struct TestFiltering {
     }
 
     private func excludeAllFilter() -> TestFilter {
-        return { _, _ in false }
+        return { _ in false }
     }
 
     private func includeAllFilter() -> TestFilter {
-        return { _, _ in true }
+        return { _ in true }
     }
 
     static func filterTests(_ entries: [XCTestCaseEntry], filter: TestFilter) -> [XCTestCaseEntry] {
         return entries
             .map { testCaseClass, testCaseMethods in
-                return (testCaseClass, testCaseMethods.filter { s, _ in filter(testCaseClass, s) } )
+                return (testCaseClass, testCaseMethods.filter { filter(testCaseClass, $0.0) } )
             }
             .filter { _, testCaseMethods in
                 return !testCaseMethods.isEmpty

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -165,14 +165,14 @@ open class XCTestCase: XCTest {
 /// the signature required by `XCTMain`
 /// - seealso: `XCTMain`
 public func testCase<T: XCTestCase>(_ allTests: [(String, (T) -> () throws -> Void)]) -> XCTestCaseEntry {
-    let tests: [(String, (XCTestCase) throws -> Void)] = allTests.map { ($0, test($1)) }
+    let tests: [(String, (XCTestCase) throws -> Void)] = allTests.map { ($0.0, test($0.1)) }
     return (T.self, tests)
 }
 
 /// Wrapper function for the non-throwing variant of tests.
 /// - seealso: `XCTMain`
 public func testCase<T: XCTestCase>(_ allTests: [(String, (T) -> () -> Void)]) -> XCTestCaseEntry {
-    let tests: [(String, (XCTestCase) throws -> Void)] = allTests.map { ($0, test($1)) }
+    let tests: [(String, (XCTestCase) throws -> Void)] = allTests.map { ($0.0, test($0.1)) }
     return (T.self, tests)
 }
 

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -20,7 +20,7 @@ class PredicateHandlerTestCase: XCTestCase {
     func test_predicateIsTrue_handlerReturnsTrue_passes() {
         let predicate = Predicate(value: true)
         let object = NSObject()
-        self.expectation(for: predicate, evaluatedWith: object, handler: {
+        self.expectation(for: predicate, evaluatedWith: object, handler: { _ in
             return true
         })
         waitForExpectations(timeout: 0.1)
@@ -31,7 +31,7 @@ class PredicateHandlerTestCase: XCTestCase {
     func test_predicateIsTrue_handlerReturnsFalse_fails() {
         let predicate = Predicate(value: true)
         let object = NSObject()
-        self.expectation(for: predicate, evaluatedWith: object, handler: {
+        self.expectation(for: predicate, evaluatedWith: object, handler: { _ in
             return false
         })
         waitForExpectations(timeout: 0.1)
@@ -48,7 +48,7 @@ class PredicateHandlerTestCase: XCTestCase {
             }
             return false
         })
-        expectation(for: predicate, evaluatedWith: halfSecLaterDate, handler: {
+        expectation(for: predicate, evaluatedWith: halfSecLaterDate, handler: { _ in
             XCTFail("Should not call the predicate expectation handler")
             return true
         })


### PR DESCRIPTION
This reverts commits b6c120020d2ad1973dcb3ae18f49ba445368351f and dd879dd7dc6c5cc8a404bbc5aac33e2c16d89740.

---

This should only be merged after https://github.com/apple/swift/pull/3922 is merged.