### PR TITLE
Update to new name of Bundle.main

### DIFF
--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -50,7 +50,7 @@
 /// - Parameter testCases: An array of test cases run, each produced by a call to the `testCase` function
 /// - seealso: `testCase`
 public func XCTMain(_ testCases: [XCTestCaseEntry]) -> Never {
-    let testBundle = Bundle.main()
+    let testBundle = Bundle.main
 
     let executionMode = ArgumentParser().executionMode
 


### PR DESCRIPTION
This updates XCTest to use the property `Bundle.main` instead of class function `Bundle.main()`, a change which I will push shortly to swift-corelibs-foundation.