### PR TITLE
Revert "Rename Predicate to NSPredicate"

### DIFF
--- a/Sources/XCTest/Private/XCPredicateExpectation.swift
+++ b/Sources/XCTest/Private/XCPredicateExpectation.swift
@@ -18,13 +18,13 @@
 #endif
 
 internal class XCPredicateExpectation: XCTestExpectation {
-    internal let predicate: NSPredicate
+    internal let predicate: Predicate
     internal let object: AnyObject
     internal var timer: Timer?
     internal let handler: XCPredicateExpectationHandler?
     private let evaluationInterval = 0.01
     
-    internal init(predicate: NSPredicate, object: AnyObject, description: String, file: StaticString, line: UInt, testCase: XCTestCase, handler: XCPredicateExpectationHandler? = nil) {
+    internal init(predicate: Predicate, object: AnyObject, description: String, file: StaticString, line: UInt, testCase: XCTestCase, handler: XCPredicateExpectationHandler? = nil) {
         self.predicate = predicate
         self.object = object
         self.handler = handler

--- a/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
@@ -226,7 +226,7 @@ public extension XCTestCase {
     ///   first successful evaluation will fulfill the expectation. If provided,
     ///   the handler can override that behavior which leaves the caller
     ///   responsible for fulfilling the expectation.
-    func expectation(for predicate: NSPredicate, evaluatedWith object: AnyObject, file: StaticString = #file, line: UInt = #line, handler: XCPredicateExpectationHandler? = nil) -> XCTestExpectation {
+    func expectation(for predicate: Predicate, evaluatedWith object: AnyObject, file: StaticString = #file, line: UInt = #line, handler: XCPredicateExpectationHandler? = nil) -> XCTestExpectation {
         let expectation = XCPredicateExpectation(
             predicate: predicate,
             object: object,


### PR DESCRIPTION
Reverts apple/swift-corelibs-xctest#158, blocked by https://github.com/apple/swift-package-manager/pull/611