### PR TITLE
Remove obsolete AnyObject cast

### DIFF
--- a/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
@@ -170,7 +170,7 @@ public extension XCTestCase {
         // Start observing the notification with specified name and object.
         var observer: NSObjectProtocol? = nil
         func removeObserver() {
-            if let observer = observer as? AnyObject {
+            if let observer = observer {
                 NotificationCenter.default.removeObserver(observer)
             }
         }


### PR DESCRIPTION
This cast is no longer needed, and produces a warning indicating that it always succeeds.