### PR TITLE
Add @discardableResult annotation to applicable public API methods.

### DIFF
--- a/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/XCTestCase+Asynchronous.swift
@@ -39,7 +39,7 @@ public extension XCTestCase {
     ///   between these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    func expectation(description: String, file: StaticString = #file, line: UInt = #line) -> XCTestExpectation {
+    @discardableResult func expectation(description: String, file: StaticString = #file, line: UInt = #line) -> XCTestExpectation {
         let expectation = XCTestExpectation(
             description: description,
             file: file,
@@ -164,7 +164,7 @@ public extension XCTestCase {
     ///   notification is observed. It will not be invoked on timeout. Use the
     ///   handler to further investigate if the notification fulfills the
     ///   expectation.
-    func expectation(forNotification notificationName: String, object objectToObserve: AnyObject?, handler: XCNotificationExpectationHandler? = nil) -> XCTestExpectation {
+    @discardableResult func expectation(forNotification notificationName: String, object objectToObserve: AnyObject?, handler: XCNotificationExpectationHandler? = nil) -> XCTestExpectation {
         let objectDescription = objectToObserve == nil ? "any object" : "\(objectToObserve!)"
         let expectation = self.expectation(description: "Expect notification '\(notificationName)' from " + objectDescription)
         // Start observing the notification with specified name and object.
@@ -226,7 +226,7 @@ public extension XCTestCase {
     ///   first successful evaluation will fulfill the expectation. If provided,
     ///   the handler can override that behavior which leaves the caller
     ///   responsible for fulfilling the expectation.
-    func expectation(for predicate: NSPredicate, evaluatedWith object: AnyObject, file: StaticString = #file, line: UInt = #line, handler: XCPredicateExpectationHandler? = nil) -> XCTestExpectation {
+    @discardableResult func expectation(for predicate: NSPredicate, evaluatedWith object: AnyObject, file: StaticString = #file, line: UInt = #line, handler: XCPredicateExpectationHandler? = nil) -> XCTestExpectation {
         let expectation = XCPredicateExpectation(
             predicate: predicate,
             object: object,


### PR DESCRIPTION
This maintains consistency with the Darwin XCTest APIs. This also cleans up some warnings in the functional test suite which were being generated because this annotation wasn't present.

I'll note that there's a case to be made that `expectation(description:file:line:)` should *not* have `@discardableResult`, because the expectation it produces can only be fulfilled by invoking a method on the returned value. Nonetheless, I think it's better to keep the APIs in sync for right now and revisit in the future.