### PR TITLE
[build_script] Remove grep since it always passes

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -109,8 +109,7 @@ class DarwinStrategy:
             "-configuration {style_options} "
             "SWIFT_EXEC=\"{swiftc}\" "
             "SWIFT_LINK_OBJC_RUNTIME=YES "
-            "SYMROOT=\"{build_dir}\" OBJROOT=\"{build_dir}\" "
-            "| grep -v \"    export\"".format(
+            "SYMROOT=\"{build_dir}\" OBJROOT=\"{build_dir}\" ".format(
                 swiftc=swiftc,
                 build_dir=build_dir,
                 style_options=style_options,


### PR DESCRIPTION
`xcodebuild` always prints "export" once it begins building an Xcode project or workspace, regardless of whether that build eventually passes or fails. This results in the `grep` statement succeeding, and thus causing the build script to pass, even when the build fails.

The `grep` statement was originally added to make the build output more human readable, not change the exit code of any builds. Remove it for now.

---

`grep` originally added here: https://github.com/apple/swift-corelibs-xctest/pull/97

Discussion on its removal here: https://github.com/apple/swift-corelibs-xctest/pull/166