### PR TITLE
Add Dispatch overlay to test configuration

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -81,12 +81,16 @@ else:
     # swift-corelibs-foundation is using it.
     libdispatch_src_dir = os.getenv('LIBDISPATCH_SRC_DIR')
     libdispatch_build_dir = os.getenv('LIBDISPATCH_BUILD_DIR')
-    if (libdispatch_src_dir is not None) and (libdispatch_build_dir is not None):
-        swift_exec.extend([
-            '-Xcc', '-fblocks',
-            '-I', libdispatch_src_dir,
-            '-L', libdispatch_build_dir,
-        ])
+    libdispatch_overlay_dir = os.getenv('LIBDISPATCH_OVERLAY_DIR')
+    if ((libdispatch_src_dir is not None) 
+        and (libdispatch_build_dir is not None)
+        and (libdispatch_overlay_dir is not None)):
+            swift_exec.extend([
+                '-Xcc', '-fblocks',
+                '-I', libdispatch_src_dir,
+                '-I', libdispatch_overlay_dir,
+                '-L', libdispatch_build_dir,
+            ])
 
 # Having prepared the swiftc command, we set the substitution.
 config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))

--- a/build_script.py
+++ b/build_script.py
@@ -237,9 +237,13 @@ class GenericUnixStrategy:
             symlink_force(os.path.join(args.libdispatch_build_dir, "src", ".libs", "libdispatch.so"),
                 foundation_build_dir)
         if args.libdispatch_src_dir and args.libdispatch_build_dir:
-            libdispatch_src_args = "LIBDISPATCH_SRC_DIR={libdispatch_src_dir} LIBDISPATCH_BUILD_DIR={libdispatch_build_dir}".format(
-                libdispatch_src_dir=os.path.abspath(args.libdispatch_src_dir),
-                libdispatch_build_dir=os.path.join(args.libdispatch_build_dir, 'src', '.libs'))
+            libdispatch_src_args = ( 
+               "LIBDISPATCH_SRC_DIR={libdispatch_src_dir} "
+               "LIBDISPATCH_BUILD_DIR={libdispatch_build_dir} "
+               "LIBDISPATCH_OVERLAY_DIR={libdispatch_overlay_dir}".format(
+                   libdispatch_src_dir=os.path.abspath(args.libdispatch_src_dir),
+                   libdispatch_build_dir=os.path.join(args.libdispatch_build_dir, 'src', '.libs'),
+                   libdispatch_overlay_dir=os.path.join(args.libdispatch_build_dir, 'src', 'swift')))
         else:
             libdispatch_src_args = ""
 


### PR DESCRIPTION
When merging the NSURLSession code into Foundation, we hit the following issue in building the XCTest tests:
```
1.	While type-checking declaration 0x58c5ed8 at /home/baileyc/swift-corelibs-xctest/Tests/Functional/ListTests/main.swift:30:5
2.	While type-checking expression at [/home/baileyc/swift-corelibs-xctest/Tests/Functional/ListTests/main.swift:30:24 - line:30:128] RangeText="try! JSONSerialization.jsonObject(with: Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[2])))"
3.	While loading members for declaration 0x5d052d0 at <invalid loc>
4.	While deserializing 'init' (ConstructorDecl #11177) 
5.	While deserializing decl #27528 (PARAM_DECL)
6.	While deserializing decl #34459 (XREF)
7.	Cross-reference to module 'Dispatch'
	... DispatchData
```
This is caused because the new Swift 3.0 overly isn't available to the XCTest tests at build/test time.

This PR adds the location for the build-time Dispatch overlay into the include path.