### PR TITLE
[SR-1901] Remove workarounds for private symbols

### DIFF
--- a/Sources/XCTest/Public/XCAbstractTest.swift
+++ b/Sources/XCTest/Public/XCAbstractTest.swift
@@ -34,12 +34,7 @@ open class XCTest {
 
     /// The test run object that executed the test, an instance of
     /// testRunClass. If the test has not yet been run, this will be nil.
-    /// - Note: FIXME: This property is meant to be `private(set)`. It is
-    ///   publicly settable for now due to a Swift compiler bug on Linux. To
-    ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
-    ///   XCTest, you should not set this property. See
-    ///   https://bugs.swift.org/browse/SR-1129 for details.
-    open open(set) var testRun: XCTestRun? = nil
+    open private(set) var testRun: XCTestRun? = nil
 
     /// The method through which tests are executed. Must be overridden by
     /// subclasses.

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -41,22 +41,17 @@ open class XCTestCase: XCTest {
         return _name
     }
     /// A private setter for the name of this test case.
-    /// - Note: FIXME: This property should be readonly, but currently has to
-    ///   be publicly settable due to a Swift compiler bug on Linux. To ensure
-    ///   compatibility of tests between swift-corelibs-xctest and Apple XCTest,
-    ///   this property should not be modified. See
-    ///   https://bugs.swift.org/browse/SR-1129 for details.
-    public var _name: String
+    private var _name: String
 
     open override var testCaseCount: UInt {
         return 1
     }
 
     /// The set of expectations made upon this test case.
-    final internal var _allExpectations = [XCTestExpectation]()
+    internal var _allExpectations = [XCTestExpectation]()
 
     /// An internal object implementing performance measurements.
-    final internal var _performanceMeter: PerformanceMeter?
+    internal var _performanceMeter: PerformanceMeter?
 
     open override var testRunClass: AnyClass? {
         return XCTestCaseRun.self

--- a/Sources/XCTest/Public/XCTestSuite.swift
+++ b/Sources/XCTest/Public/XCTestSuite.swift
@@ -27,12 +27,7 @@ open class XCTestSuite: XCTest {
         return _name
     }
     /// A private setter for the name of this test suite.
-    /// - Note: FIXME: This property should be readonly, but currently has to
-    ///   be publicly settable due to a Swift compiler bug on Linux. To ensure
-    ///   compatibility of tests between swift-corelibs-xctest and Apple XCTest,
-    ///   this property should not be modified. See
-    ///   https://bugs.swift.org/browse/SR-1129 for details.
-    public let _name: String
+    private let _name: String
 
     /// The number of test cases in this suite.
     open override var testCaseCount: UInt {


### PR DESCRIPTION
[SR-1901](https://bugs.swift.org/browse/SR-1901) has been fixed, we no longer need these workarounds.

---

Thanks @eeckstein!! ❤️ 