### PR TITLE
Print to stderr, not stdout

### DIFF
--- a/Sources/XCTest/Private/PrintObserver.swift
+++ b/Sources/XCTest/Private/PrintObserver.swift
@@ -67,8 +67,8 @@ internal class PrintObserver: XCTestObservation {
     }()
 
     fileprivate func printAndFlush(_ message: String) {
-        print(message)
-        fflush(stdout)
+        fputs("\(message)\n", stderr)
+        fflush(stderr)
     }
 
     private func formatTimeInterval(_ timeInterval: TimeInterval) -> String {

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Asynchronous
-// RUN: %T/Asynchronous > %t || true
+// RUN: %T/Asynchronous &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Handler
-// RUN: %T/Handler > %t || true
+// RUN: %T/Handler &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Misuse
-// RUN: %T/Misuse > %t || true
+// RUN: %T/Misuse &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Asynchronous-Notifications
-// RUN: %T/Asynchronous-Notifications > %t || true
+// RUN: %T/Asynchronous-Notifications &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Asynchronous-Notifications-Handler
-// RUN: %T/Asynchronous-Notifications-Handler > %t || true
+// RUN: %T/Asynchronous-Notifications-Handler &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Asynchronous-Predicates
-// RUN: %T/Asynchronous-Predicates > %t || true
+// RUN: %T/Asynchronous-Predicates &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Asynchronous-Predicates-Handler
-// RUN: %T/Asynchronous-Predicates-Handler > %t || true
+// RUN: %T/Asynchronous-Predicates-Handler &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/ErrorHandling
-// RUN: %T/ErrorHandling > %t || true
+// RUN: %T/ErrorHandling &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/FailingTestSuite
-// RUN: %T/FailingTestSuite > %t || true
+// RUN: %T/FailingTestSuite &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/FailureMessagesTestCase
-// RUN: %T/FailureMessagesTestCase > %t || true
+// RUN: %T/FailureMessagesTestCase &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/ListTests/main.swift
+++ b/Tests/Functional/ListTests/main.swift
@@ -1,8 +1,8 @@
 // RUN: %{swiftc} %s -o %T/ListTests
-// RUN: %T/ListTests --list-tests > %t_list || true
+// RUN: %T/ListTests --list-tests &> %t_list || true
 // RUN: %{xctest_checker} %t_list %s
-// RUN: %T/ListTests --dump-tests-json > %t_json || true
-// RUN: %T/ListTests --verify %t_json > %t_verify
+// RUN: %T/ListTests --dump-tests-json &> %t_json || true
+// RUN: %T/ListTests --verify %t_json &> %t_verify
 // RUN: %{xctest_checker} %t_verify verify_json.expected
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/NegativeAccuracyTestCase
-// RUN: %T/NegativeAccuracyTestCase > %t || true
+// RUN: %T/NegativeAccuracyTestCase &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/All
-// RUN: %T/All > %t || true
+// RUN: %T/All &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Selected
-// RUN: %T/Selected Selected.ExecutedTestCase/test_executed > %t || true
+// RUN: %T/Selected Selected.ExecutedTestCase/test_executed &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Performance/Misuse/main.swift
+++ b/Tests/Functional/Performance/Misuse/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/PerformanceMisuse
-// RUN: %T/PerformanceMisuse > %t || true
+// RUN: %T/PerformanceMisuse &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/Performance
-// RUN: %T/Performance > %t || true
+// RUN: %T/Performance &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -1,7 +1,7 @@
 // RUN: %{swiftc} %s -o %T/SelectedTest
-// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_case || true
-// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case_class || true
-// RUN: %T/SelectedTest > %T/all || true
+// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase/test_foo &> %t/one_test_case || true
+// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase &> %t/one_test_case_class || true
+// RUN: %T/SelectedTest &> %t/all || true
 // RUN: %{xctest_checker} -p "// CHECK-METHOD:" %T/one_test_case %s
 // RUN: %{xctest_checker} -p "// CHECK-CLASS:" %T/one_test_case_class %s
 // RUN: %{xctest_checker} -p "// CHECK-ALL:" %T/all %s

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/SingleFailingTestCase
-// RUN: %T/SingleFailingTestCase > %t || true
+// RUN: %T/SingleFailingTestCase &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/TestCaseLifecycle
-// RUN: %T/TestCaseLifecycle > %t || true
+// RUN: %T/TestCaseLifecycle &> %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(Linux) || os(FreeBSD)


### PR DESCRIPTION
Apple XCTest prints to stderr, whereas Swift XCTest prints to stdout. Some users expect stderr output, so print to stderr. Also, update the tests to capture stderr output.

---

Haven't run these tests locally yet, I'm expecting some initial failures.
