### PR TITLE
remove trailing period after "N seconds"

### DIFF
--- a/Sources/XCTest/Private/PrintObserver.swift
+++ b/Sources/XCTest/Private/PrintObserver.swift
@@ -38,10 +38,7 @@ internal class PrintObserver: XCTestObservation {
     func testCaseDidFinish(_ testCase: XCTestCase) {
         let testRun = testCase.testRun!
         let verb = testRun.hasSucceeded ? "passed" : "failed"
-        // FIXME: Apple XCTest does not print a period after "(N seconds)".
-        //        The trailing period here should be removed and the functional
-        //        test suite should be updated.
-        printAndFlush("Test Case '\(testCase.name)' \(verb) (\(formatTimeInterval(testRun.totalDuration)) seconds).")
+        printAndFlush("Test Case '\(testCase.name)' \(verb) (\(formatTimeInterval(testRun.totalDuration)) seconds)")
     }
 
     func testSuiteDidFinish(_ testSuite: XCTestSuite) {

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -17,7 +17,7 @@
 class ExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: foo
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnUnfulfilledExpectation_fails' failed \(\d+\.\d+ seconds\)
     func test_waitingForAnUnfulfilledExpectation_fails() {
         expectation(description: "foo")
         waitForExpectations(timeout: 0.2)
@@ -25,7 +25,7 @@ class ExpectationsTestCase: XCTestCase {
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+5]]: error: ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: bar, baz
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails' failed \(\d+\.\d+ seconds\)
     func test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails() {
         expectation(description: "bar")
         expectation(description: "baz")
@@ -33,7 +33,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnImmediatelyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\)
     func test_waitingForAnImmediatelyFulfilledExpectation_passes() {
         let expectation = self.expectation(description: "flim")
         expectation.fulfill()
@@ -41,7 +41,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnEventuallyFulfilledExpectation_passes' passed \(\d+\.\d+ seconds\)
     func test_waitingForAnEventuallyFulfilledExpectation_passes() {
         let expectation = self.expectation(description: "flam")
         let timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
@@ -53,7 +53,7 @@ class ExpectationsTestCase: XCTestCase {
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+8]]: error: ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: hog
-// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExpectationsTestCase.test_waitingForAnExpectationFulfilledAfterTheTimeout_fails' failed \(\d+\.\d+ seconds\)
     func test_waitingForAnExpectationFulfilledAfterTheTimeout_fails() {
         let expectation = self.expectation(description: "hog")
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { _ in
@@ -64,7 +64,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes' passed \(\d+\.\d+ seconds\)
     func test_whenTimeoutIsImmediate_andAllExpectationsAreFulfilled_passes() {
         let expectation = self.expectation(description: "smog")
         expectation.fulfill()
@@ -73,7 +73,7 @@ class ExpectationsTestCase: XCTestCase {
 
 // CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Expectations/main.swift:[[@LINE+4]]: error: ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails : Asynchronous wait failed - Exceeded timeout of -1.0 seconds, with unfulfilled expectations: dog
-// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExpectationsTestCase.test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails' failed \(\d+\.\d+ seconds\)
     func test_whenTimeoutIsImmediate_butNotAllExpectationsAreFulfilled_fails() {
         expectation(description: "dog")
         waitForExpectations(timeout: -1.0)

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -17,7 +17,7 @@
 class HandlerTestCase: XCTestCase {
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Handler/main.swift:[[@LINE+6]]: error: HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails : Asynchronous wait failed - Exceeded timeout of 0.2 seconds, with unfulfilled expectations: fog
-// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreNotFulfilled_handlerCalled_andFails' failed \(\d+\.\d+ seconds\)
     func test_whenExpectationsAreNotFulfilled_handlerCalled_andFails() {
         self.expectation(description: "fog")
 
@@ -32,7 +32,7 @@ class HandlerTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'HandlerTestCase.test_whenExpectationsAreFulfilled_handlerCalled_andPasses' passed \(\d+\.\d+ seconds\)
     func test_whenExpectationsAreFulfilled_handlerCalled_andPasses() {
         let expectation = self.expectation(description: "bog")
         expectation.fulfill()

--- a/Tests/Functional/Asynchronous/Misuse/main.swift
+++ b/Tests/Functional/Asynchronous/Misuse/main.swift
@@ -15,7 +15,7 @@
 class MisuseTestCase: XCTestCase {
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+4]]: error: MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails : Failed due to unwaited expectations.
-// CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'MisuseTestCase.test_whenExpectationsAreMade_butNotWaitedFor_fails' failed \(\d+\.\d+ seconds\)
     func test_whenExpectationsAreMade_butNotWaitedFor_fails() {
         self.expectation(description: "the first expectation")
         self.expectation(description: "the second expectation (the file and line number for this one are included in the failure message")
@@ -23,7 +23,7 @@ class MisuseTestCase: XCTestCase {
 
 // CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+3]]: error: MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails : API violation - call made to wait without any expectations having been set.
-// CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'MisuseTestCase.test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails' failed \(\d+\.\d+ seconds\)
     func test_whenNoExpectationsAreMade_butTheyAreWaitedFor_fails() {
         self.waitForExpectations(timeout: 0.1)
     }
@@ -31,7 +31,7 @@ class MisuseTestCase: XCTestCase {
 // CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+6]]: error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
 // CHECK: .*/Tests/Functional/Asynchronous/Misuse/main.swift:[[@LINE+15]]: error: MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails : API violation - multiple calls made to XCTestExpectation.fulfill\(\) for rob.
-// CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'MisuseTestCase.test_whenExpectationIsFulfilledMultipleTimes_fails' failed \(\d+\.\d+ seconds\)
     func test_whenExpectationIsFulfilledMultipleTimes_fails() {
         let expectation = self.expectation(description: "rob")
         expectation.fulfill()

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -16,7 +16,7 @@
 // CHECK: Test Suite 'NotificationExpectationsTestCase' started at \d+:\d+:\d+\.\d+
 class NotificationExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithName_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithName_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithName_passes' passed \(\d+\.\d+ seconds\)
     func test_observeNotificationWithName_passes() {
         let notificationName = "notificationWithNameTest"
         expectation(forNotification: notificationName, object:nil)
@@ -25,7 +25,7 @@ class NotificationExpectationsTestCase: XCTestCase {
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_passes' passed \(\d+\.\d+ seconds\)
     func test_observeNotificationWithNameAndObject_passes() {
         let notificationName = "notificationWithNameAndObjectTest"
         let dummyObject = NSObject()
@@ -35,7 +35,7 @@ class NotificationExpectationsTestCase: XCTestCase {
     }
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithNameAndObject_butExpectingNoObject_passes' passed \(\d+\.\d+ seconds\)
     func test_observeNotificationWithNameAndObject_butExpectingNoObject_passes() {
         let notificationName = "notificationWithNameAndObject_expectNoObjectTest"
         expectation(forNotification: notificationName, object:nil)
@@ -46,7 +46,7 @@ class NotificationExpectationsTestCase: XCTestCase {
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:[[@LINE+5]]: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'expectedName' from any object
-// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectName_fails' failed \(\d+\.\d+ seconds\)
     func test_observeNotificationWithIncorrectName_fails() {
         expectation(forNotification: "expectedName", object: nil)
         NotificationCenter.default.post(name: Notification.Name(rawValue: "actualName"), object: nil)
@@ -55,7 +55,7 @@ class NotificationExpectationsTestCase: XCTestCase {
     
 // CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift:[[@LINE+8]]: error: NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'notificationWithIncorrectObjectTest' from dummyObject
-// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationExpectationsTestCase.test_observeNotificationWithIncorrectObject_fails' failed \(\d+\.\d+ seconds\)
     func test_observeNotificationWithIncorrectObject_fails() {
         let notificationName = "notificationWithIncorrectObjectTest"
         let dummyObject: NSString = "dummyObject"

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -17,7 +17,7 @@
 class NotificationHandlerTestCase: XCTestCase {
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:[[@LINE+8]]: error: NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'returnFalse' from any object
-// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsFalse_andFails' failed \(\d+\.\d+ seconds\)
     func test_notificationNameIsObserved_handlerReturnsFalse_andFails() {
         expectation(forNotification: "returnFalse", object: nil, handler: {
             notification in
@@ -28,7 +28,7 @@ class NotificationHandlerTestCase: XCTestCase {
     }
     
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObserved_handlerReturnsTrue_andPasses' passed \(\d+\.\d+ seconds\)
     func test_notificationNameIsObserved_handlerReturnsTrue_andPasses() {
         expectation(forNotification: "returnTrue", object: nil, handler: {
             notification in
@@ -40,7 +40,7 @@ class NotificationHandlerTestCase: XCTestCase {
 
 // CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Tests/Functional/Asynchronous/Notifications/Handler/main.swift:[[@LINE+7]]: error: NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect notification 'note' from any object
-// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NotificationHandlerTestCase.test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled' failed \(\d+\.\d+ seconds\)
     func test_notificationNameIsObservedAfterTimeout_handlerIsNotCalled() {
         expectation(forNotification: "note", object: nil, handler: { _ in
             XCTFail("Should not call the notification expectation handler")

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -16,7 +16,7 @@
 // CHECK: Test Suite 'PredicateExpectationsTestCase' started at \d+:\d+:\d+\.\d+
 class PredicateExpectationsTestCase: XCTestCase {
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyTruePredicateAndObject_passes' started at \d+:\d+:\d+\.\d+
-    // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyTruePredicateAndObject_passes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyTruePredicateAndObject_passes' passed \(\d+\.\d+ seconds\)
     func test_immediatelyTruePredicateAndObject_passes() {
         let predicate = NSPredicate(value: true)
         let object = NSObject()
@@ -26,7 +26,7 @@ class PredicateExpectationsTestCase: XCTestCase {
 
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift:[[@LINE+6]]: error: PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9A-Fa-f]{1,16}>` for object <NSObject: 0x[0-9A-Fa-f]{1,16}>
-    // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyFalsePredicateAndObject_fails' failed \(\d+\.\d+ seconds\)
     func test_immediatelyFalsePredicateAndObject_fails() {
         let predicate = NSPredicate(value: false)
         let object = NSObject()
@@ -35,7 +35,7 @@ class PredicateExpectationsTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_delayedTruePredicateAndObject_passes' started at \d+:\d+:\d+\.\d+
-    // CHECK: Test Case 'PredicateExpectationsTestCase.test_delayedTruePredicateAndObject_passes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PredicateExpectationsTestCase.test_delayedTruePredicateAndObject_passes' passed \(\d+\.\d+ seconds\)
     func test_delayedTruePredicateAndObject_passes() {
         var didEvaluate = false
         let predicate = NSPredicate(block: { evaluatedObject, bindings in
@@ -47,7 +47,7 @@ class PredicateExpectationsTestCase: XCTestCase {
     }
     
     // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyTrueDelayedFalsePredicateAndObject_passes' started at \d+:\d+:\d+\.\d+
-    // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyTrueDelayedFalsePredicateAndObject_passes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PredicateExpectationsTestCase.test_immediatelyTrueDelayedFalsePredicateAndObject_passes' passed \(\d+\.\d+ seconds\)
     func test_immediatelyTrueDelayedFalsePredicateAndObject_passes() {
         var didEvaluate = false
         let predicate = NSPredicate(block: { evaluatedObject, bindings in

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -16,7 +16,7 @@
 // CHECK: Test Suite 'PredicateHandlerTestCase' started at \d+:\d+:\d+\.\d+
 class PredicateHandlerTestCase: XCTestCase {
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsTrue_passes' started at \d+:\d+:\d+\.\d+
-    // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsTrue_passes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsTrue_passes' passed \(\d+\.\d+ seconds\)
     func test_predicateIsTrue_handlerReturnsTrue_passes() {
         let predicate = NSPredicate(value: true)
         let object = NSObject()
@@ -27,7 +27,7 @@ class PredicateHandlerTestCase: XCTestCase {
     }
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Handler/main.swift:[[@LINE+8]]: error: PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9a-fA-F]{1,16}>` for object <NSObject: 0x[0-9a-fA-F]{1,16}>
-    // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrue_handlerReturnsFalse_fails' failed \(\d+\.\d+ seconds\)
     func test_predicateIsTrue_handlerReturnsFalse_fails() {
         let predicate = NSPredicate(value: true)
         let object = NSObject()
@@ -39,7 +39,7 @@ class PredicateHandlerTestCase: XCTestCase {
     
     // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Tests/Functional/Asynchronous/Predicates/Handler/main.swift:[[@LINE+14]]: error: PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails : Asynchronous wait failed - Exceeded timeout of 0.1 seconds, with unfulfilled expectations: Expect `<NSPredicate: 0x[0-9a-fA-F]{1,16}>` for object \d{4}-\d{2}-\d{2} \d+:\d+:\d+ \+\d+
-    // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PredicateHandlerTestCase.test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails' failed \(\d+\.\d+ seconds\)
     func test_predicateIsTrueAfterTimeout_handlerIsNotCalled_fails() {
         let halfSecLaterDate = NSDate(timeIntervalSinceNow: 0.2)
         let predicate = NSPredicate(block: { evaluatedObject, bindings in

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -42,13 +42,13 @@ class ErrorHandling: XCTestCase {
 
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion : XCTAssertThrowsError failed: did not throw error -
-// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' failed \(\d+\.\d+ seconds\)
     func test_shouldButDoesNotThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesNotThrowError())
     }
     
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorInAssertion' passed \(\d+\.\d+ seconds\)
     func test_shouldThrowErrorInAssertion() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
             guard let thrownError = error as? SomeError else {
@@ -65,7 +65,7 @@ class ErrorHandling: XCTestCase {
     
 // CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+11]]: error: ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError : XCTAssertEqual failed: \("an error message"\) is not equal to \(""\) -
-// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ErrorHandling.test_throwsErrorInAssertionButFailsWhenCheckingError' failed \(\d+\.\d+ seconds\)
     func test_throwsErrorInAssertionButFailsWhenCheckingError() {
         XCTAssertThrowsError(try functionThatDoesThrowError()) { error in
             guard let thrownError = error as? SomeError else {
@@ -82,13 +82,13 @@ class ErrorHandling: XCTestCase {
 
 // CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' started at \d+:\d+:\d+\.\d+
 // CHECK: \<EXPR\>:0: error: ErrorHandling.test_canAndDoesThrowErrorFromTestMethod : threw error "anError\("an error message"\)"
-// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ErrorHandling.test_canAndDoesThrowErrorFromTestMethod' failed \(\d+\.\d+ seconds\)
     func test_canAndDoesThrowErrorFromTestMethod() throws {
         try functionThatDoesThrowError()
     }
     
 // CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ErrorHandling.test_canButDoesNotThrowErrorFromTestMethod' passed \(\d+\.\d+ seconds\)
     func test_canButDoesNotThrowErrorFromTestMethod() throws {
         try functionThatDoesNotThrowError()
     }
@@ -99,7 +99,7 @@ class ErrorHandling: XCTestCase {
 
 // CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_assertionExpressionCanThrow : XCTAssertEqual threw error "anError\("did not actually return"\)" -
-// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ErrorHandling.test_assertionExpressionCanThrow' failed \(\d+\.\d+ seconds\)
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)
     }

--- a/Tests/Functional/FailingTestSuite/main.swift
+++ b/Tests/Functional/FailingTestSuite/main.swift
@@ -20,7 +20,7 @@ class PassingTestCase: XCTestCase {
     }()
 
 // CHECK: Test Case 'PassingTestCase.test_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'PassingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'PassingTestCase.test_passes' passed \(\d+\.\d+ seconds\)
     func test_passes() {
         XCTAssert(true)
     }
@@ -39,21 +39,21 @@ class FailingTestCase: XCTestCase {
     }()
 
 // CHECK: Test Case 'FailingTestCase.test_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'FailingTestCase.test_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailingTestCase.test_passes' passed \(\d+\.\d+ seconds\)
     func test_passes() {
         XCTAssert(true)
     }
 
 // CHECK: Test Case 'FailingTestCase.test_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/FailingTestSuite/main.swift:[[@LINE+3]]: error: FailingTestCase.test_fails : XCTAssertTrue failed - $
-// CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailingTestCase.test_fails' failed \(\d+\.\d+ seconds\)
     func test_fails() {
         XCTAssert(false)
     }
 
 // CHECK: Test Case 'FailingTestCase.test_fails_with_message' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/FailingTestSuite/main.swift:[[@LINE+3]]: error: FailingTestCase.test_fails_with_message : XCTAssertTrue failed - Foo bar.
-// CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailingTestCase.test_fails_with_message' failed \(\d+\.\d+ seconds\)
     func test_fails_with_message() {
         XCTAssert(false, "Foo bar.")
     }

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -46,168 +46,168 @@ class FailureMessagesTestCase: XCTestCase {
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssert' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssert : XCTAssertTrue failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssert' failed \(\d+\.\d+ seconds\)
     func testAssert() throws {
         XCTAssert(false, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualValues' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualValues : XCTAssertEqual failed: \("1"\) is not equal to \("2"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualValues' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualValues' failed \(\d+\.\d+ seconds\)
     func testAssertEqualValues() {
         XCTAssertEqual(1, 2, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualOptionals : XCTAssertEqual failed: \("Optional\(1\)"\) is not equal to \("Optional\(2\)"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualOptionals' failed \(\d+\.\d+ seconds\)
     func testAssertEqualOptionals() {
         XCTAssertEqual(Optional(1), Optional(2), "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArraySlices : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArraySlices' failed \(\d+\.\d+ seconds\)
     func testAssertEqualArraySlices() {
         XCTAssertEqual([1][0..<1], [2][0..<1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualContiguousArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualContiguousArrays' failed \(\d+\.\d+ seconds\)
     func testAssertEqualContiguousArrays() {
         XCTAssertEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 2), "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualArrays : XCTAssertEqual failed: \("\[1\]"\) is not equal to \("\[2\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualArrays' failed \(\d+\.\d+ seconds\)
     func testAssertEqualArrays() {
         XCTAssertEqual([1], [2], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualDictionaries : XCTAssertEqual failed: \("\[1: 2\]"\) is not equal to \("\[3: 4\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualDictionaries' failed \(\d+\.\d+ seconds\)
     func testAssertEqualDictionaries() {
         XCTAssertEqual([1:2], [3:4], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\)
     func testAssertEqualWithAccuracy() {
         XCTAssertEqualWithAccuracy(1, 2, accuracy: 0.1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertFalse : XCTAssertFalse failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' failed \(\d+\.\d+ seconds\)
     func testAssertFalse() {
         XCTAssertFalse(true, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertGreaterThan : XCTAssertGreaterThan failed: \("0"\) is not greater than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThan' failed \(\d+\.\d+ seconds\)
     func testAssertGreaterThan() {
         XCTAssertGreaterThan(0, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertGreaterThanOrEqual : XCTAssertGreaterThanOrEqual failed: \("-1"\) is less than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertGreaterThanOrEqual' failed \(\d+\.\d+ seconds\)
     func testAssertGreaterThanOrEqual() {
         XCTAssertGreaterThanOrEqual(-1, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertLessThan : XCTAssertLessThan failed: \("0"\) is not less than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThan' failed \(\d+\.\d+ seconds\)
     func testAssertLessThan() {
         XCTAssertLessThan(0, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertLessThanOrEqual : XCTAssertLessThanOrEqual failed: \("1"\) is greater than \("0"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertLessThanOrEqual' failed \(\d+\.\d+ seconds\)
     func testAssertLessThanOrEqual() {
         XCTAssertLessThanOrEqual(1, 0, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNil : XCTAssertNil failed: "helloworld" - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNil' failed \(\d+\.\d+ seconds\)
     func testAssertNil() {
         XCTAssertNil("helloworld", "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualValues' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualValues : XCTAssertNotEqual failed: \("1"\) is equal to \("1"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualValues' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualValues' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualValues() {
         XCTAssertNotEqual(1, 1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualOptionals : XCTAssertNotEqual failed: \("Optional\(1\)"\) is equal to \("Optional\(1\)"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualOptionals' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualOptionals() {
         XCTAssertNotEqual(Optional(1), Optional(1), "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArraySlices : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArraySlices' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualArraySlices() {
         XCTAssertNotEqual([1][0..<1], [1][0..<1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualContiguousArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualContiguousArrays' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualContiguousArrays() {
         XCTAssertNotEqual(ContiguousArray(arrayLiteral: 1), ContiguousArray(arrayLiteral: 1), "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualArrays : XCTAssertNotEqual failed: \("\[1\]"\) is equal to \("\[1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualArrays' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualArrays() {
         XCTAssertNotEqual([1], [1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualDictionaries : XCTAssertNotEqual failed: \("\[1: 1\]"\) is equal to \("\[1: 1\]"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualDictionaries' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualDictionaries() {
         XCTAssertNotEqual([1:1], [1:1], "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualWithAccuracy() {
         XCTAssertNotEqualWithAccuracy(1, 1, 0.1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotNil : XCTAssertNotNil failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' failed \(\d+\.\d+ seconds\)
     func testAssertNotNil() {
         XCTAssertNotNil(nil, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertTrue : XCTAssertTrue failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testAssertTrue' failed \(\d+\.\d+ seconds\)
     func testAssertTrue() {
         XCTAssertTrue(false, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testFail' started at \d+:\d+:\d+\.\d+
 // CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testFail : failed - message
-// CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'FailureMessagesTestCase.testFail' failed \(\d+\.\d+ seconds\)
     func testFail() {
         XCTFail("message", file: "test.swift")
     }

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -25,27 +25,27 @@ class NegativeAccuracyTestCase: XCTestCase {
     }()
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\)
     func test_equalWithAccuracy_passes() {
         XCTAssertEqualWithAccuracy(0, 0.1, accuracy: -0.1)
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\)
     func test_equalWithAccuracy_fails() {
         XCTAssertEqualWithAccuracy(0, 0.2, accuracy: -0.1)
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\)
     func test_notEqualWithAccuracy_passes() {
         XCTAssertNotEqualWithAccuracy(1, 2, -0.5)
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
-// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\)
     func test_notEqualWithAccuracy_fails() {
         XCTAssertNotEqualWithAccuracy(1, 2, -1)
     }

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -66,7 +66,7 @@ class Observation: XCTestCase {
 
 // CHECK: Test Case 'Observation.test_one' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/Observation/All/main.swift:[[@LINE+12]]: error: Observation.test_one : failed - fail!
-// CHECK: Test Case 'Observation.test_one' failed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'Observation.test_one' failed \(\d+\.\d+ seconds\)
     func test_one() {
         XCTAssertEqual(observer.startedBundlePaths.count, 1)
         XCTAssertEqual(
@@ -82,7 +82,7 @@ class Observation: XCTestCase {
     }
 
 // CHECK: Test Case 'Observation.test_two' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'Observation.test_two' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'Observation.test_two' passed \(\d+\.\d+ seconds\)
     func test_two() {
         XCTAssertEqual(observer.startedBundlePaths.count, 1)
         XCTAssertEqual(
@@ -96,7 +96,7 @@ class Observation: XCTestCase {
     }
 
 // CHECK: Test Case 'Observation.test_three' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'Observation.test_three' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'Observation.test_three' passed \(\d+\.\d+ seconds\)
     func test_three() {
         XCTAssertEqual(observer.startedBundlePaths.count, 1)
         XCTAssertEqual(observer.startedTestCaseNames, ["Observation.test_one", "Observation.test_two"])

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -58,7 +58,7 @@ class ExecutedTestCase: XCTestCase {
     }()
 
 // CHECK: Test Case 'ExecutedTestCase.test_executed' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExecutedTestCase.test_executed' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'ExecutedTestCase.test_executed' passed \(\d+\.\d+ seconds\)
     func test_executed() {
         let suiteNames = observer.startedTestSuites.map { $0.name }
         XCTAssertEqual(suiteNames, ["Selected tests", "ExecutedTestCase"])

--- a/Tests/Functional/Performance/Misuse/main.swift
+++ b/Tests/Functional/Performance/Misuse/main.swift
@@ -23,14 +23,14 @@ class PerformanceMisuseTestCase: XCTestCase {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails : API violation - Can only record one set of metrics per test method.
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {}
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails' started at \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndNotStartingOrEnding_fails() {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails : API violation - startMeasuring\(\) must be called during the block.
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {}
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails' started at \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndStoppingWithoutStarting_fails() {
@@ -39,7 +39,7 @@ class PerformanceMisuseTestCase: XCTestCase {
             self.stopMeasuring()
         }
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStartingTwice_fails' started at \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndStartingTwice_fails() {
@@ -49,7 +49,7 @@ class PerformanceMisuseTestCase: XCTestCase {
             self.startMeasuring()
         }
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStartingTwice_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStartingTwice_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingTwice_fails' started at \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndStoppingTwice_fails() {
@@ -60,21 +60,21 @@ class PerformanceMisuseTestCase: XCTestCase {
             self.stopMeasuring()
         }
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingTwice_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingTwice_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_startMeasuringOutsideOfBlock_fails() {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails : API violation - Cannot start measuring. startMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         startMeasuring()
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringOutsideOfBlock_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_stopMeasuringOutsideOfBlock_fails() {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails : API violation - Cannot stop measuring. stopMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         stopMeasuring()
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringOutsideOfBlock_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_startMeasuringAfterBlock_fails() {
@@ -83,7 +83,7 @@ class PerformanceMisuseTestCase: XCTestCase {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails : API violation - Cannot start measuring. startMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         startMeasuring()
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_startMeasuringAfterBlock_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails' started at \d+:\d+:\d+\.\d+
     func test_stopMeasuringAfterBlock_fails() {
@@ -92,21 +92,21 @@ class PerformanceMisuseTestCase: XCTestCase {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails : API violation - Cannot stop measuring. stopMeasuring\(\) is only supported from a block passed to measureMetrics\(...\).
         stopMeasuring()
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_stopMeasuringAfterBlock_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringNoMetrics_fails' started at \d+:\d+:\d+\.\d+
     func test_measuringNoMetrics_fails() {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_measuringNoMetrics_fails : API violation - At least one metric must be provided to measure.
         measureMetrics([], automaticallyStartMeasuring: true) {}
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringNoMetrics_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringNoMetrics_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' started at \d+:\d+:\d+\.\d+
     func test_measuringUnknownMetric_fails() {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_measuringUnknownMetric_fails : API violation - Unknown metric: UnladenAirspeedVelocity
         measureMetrics(["UnladenAirspeedVelocity"], automaticallyStartMeasuring: true) {}
     }
-    // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' failed \(\d+\.\d+ seconds\)
 
     static var allTests = {
         return [

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -18,7 +18,7 @@ class PerformanceTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Performance/main.swift:[[@LINE+4]]: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' measured \[Time, seconds\] .*
-    // CHECK: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_measureBlockIteratesTenTimes' passed \(\d+\.\d+ seconds\)
     func test_measureBlockIteratesTenTimes() {
         var iterationCount = 0
         measure(block: {
@@ -29,7 +29,7 @@ class PerformanceTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Performance/main.swift:[[@LINE+4]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' measured \[Time, seconds\] .*
-    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' passed \(\d+\.\d+ seconds\)
     func test_measuresMetricsWithAutomaticStartAndStop() {
         var iterationCount = 0
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true, for: {
@@ -40,7 +40,7 @@ class PerformanceTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' measured \[Time, seconds\] .*
-    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' passed \(\d+\.\d+ seconds\)
     func test_measuresMetricsWithManualStartAndStop() {
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
@@ -50,7 +50,7 @@ class PerformanceTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' measured \[Time, seconds\] .*
-    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' passed \(\d+\.\d+ seconds\)
     func test_measuresMetricsWithoutExplicitStop() {
         measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
@@ -58,14 +58,14 @@ class PerformanceTestCase: XCTestCase {
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_hasWallClockAsDefaultPerformanceMetric' started at \d+:\d+:\d+\.\d+
-    // CHECK: Test Case 'PerformanceTestCase.test_hasWallClockAsDefaultPerformanceMetric' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_hasWallClockAsDefaultPerformanceMetric' passed \(\d+\.\d+ seconds\)
     func test_hasWallClockAsDefaultPerformanceMetric() {
         XCTAssertEqual(PerformanceTestCase.defaultPerformanceMetrics(), [XCTPerformanceMetric_WallClockTime])
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[\d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
-    // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' passed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' passed \(\d+\.\d+ seconds\)
     func test_printsValuesAfterMeasuring() {
         measure {}
     }
@@ -80,7 +80,7 @@ class PerformanceTestCase: XCTestCase {
         }
         XCTAssertEqual(iterationCount, 3)
     }
-    // CHECK: Test Case 'PerformanceTestCase.test_abortsMeasurementsAfterTestFailure' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_abortsMeasurementsAfterTestFailure' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' started at \d+:\d+:\d+\.\d+
     func test_measuresWallClockTimeInBlock() {
@@ -94,7 +94,7 @@ class PerformanceTestCase: XCTestCase {
             }
         }
     }
-    // CHECK: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'PerformanceTestCase.test_measuresWallClockTimeInBlock' failed \(\d+\.\d+ seconds\)
 
     static var allTests = {
         return [

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -27,19 +27,19 @@ class ExecutedTestCase: XCTestCase {
 
 // CHECK-METHOD:   Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
 // CHECK-METHOD:   Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
-// CHECK-METHOD:   Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
+// CHECK-METHOD:   Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\)
 // CHECK-CLASS: Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
 // CHECK-CLASS: Test Case 'ExecutedTestCase.test_bar' started at \d+:\d+:\d+\.\d+
-// CHECK-CLASS: Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\).
+// CHECK-CLASS: Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\)
 // CHECK-ALL:      Test Suite 'ExecutedTestCase' started at \d+:\d+:\d+\.\d+
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' started at \d+:\d+:\d+\.\d+
-// CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\).
+// CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\)
     func test_bar() {}
 
 // CHECK-CLASS: Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
-// CHECK-CLASS: Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
+// CHECK-CLASS: Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\)
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' started at \d+:\d+:\d+\.\d+
-// CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\).
+// CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\)
     func test_foo() {}
 }
 // CHECK-METHOD:   Test Suite 'ExecutedTestCase' passed at \d+:\d+:\d+\.\d+
@@ -57,7 +57,7 @@ class SkippedTestCase: XCTestCase {
     }()
 
 // CHECK-ALL: Test Case 'SkippedTestCase.test_baz' started at \d+:\d+:\d+\.\d+
-// CHECK-ALL: Test Case 'SkippedTestCase.test_baz' passed \(\d+\.\d+ seconds\).
+// CHECK-ALL: Test Case 'SkippedTestCase.test_baz' passed \(\d+\.\d+ seconds\)
     func test_baz() {}
 }
 // CHECK-ALL: Test Suite 'SkippedTestCase' passed at \d+:\d+:\d+\.\d+

--- a/Tests/Functional/SingleFailingTestCase/main.swift
+++ b/Tests/Functional/SingleFailingTestCase/main.swift
@@ -21,7 +21,7 @@ class SingleFailingTestCase: XCTestCase {
 
     // CHECK: Test Case 'SingleFailingTestCase.test_fails' started at \d+:\d+:\d+\.\d+
     // CHECK: .*/SingleFailingTestCase/main.swift:[[@LINE+3]]: error: SingleFailingTestCase.test_fails : XCTAssertTrue failed -
-    // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\).
+    // CHECK: Test Case 'SingleFailingTestCase.test_fails' failed \(\d+\.\d+ seconds\)
     func test_fails() {
         XCTAssert(false)
     }

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -42,7 +42,7 @@ class SetUpTearDownTestCase: XCTestCase {
 // CHECK: In setUp\(\)
 // CHECK: In test_hasValueFromSetUp\(\)
 // CHECK: In tearDown\(\)
-// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'SetUpTearDownTestCase.test_hasValueFromSetUp' passed \(\d+\.\d+ seconds\)
     func test_hasValueFromSetUp() {
         print("In \(#function)")
         XCTAssertEqual(value, 42)
@@ -70,14 +70,14 @@ class NewInstanceForEachTestTestCase: XCTestCase {
     var value = 1
 
 // CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValue' passed \(\d+\.\d+ seconds\)
     func test_hasInitializedValue() {
         XCTAssertEqual(value, 1)
         value += 1
     }
 
 // CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' passed \(\d+\.\d+ seconds\).
+// CHECK: Test Case 'NewInstanceForEachTestTestCase.test_hasInitializedValueInAnotherTest' passed \(\d+\.\d+ seconds\)
     func test_hasInitializedValueInAnotherTest() {
         XCTAssertEqual(value, 1)
     }


### PR DESCRIPTION
- remove trailing period in PrintObserver to match Apple XCTest as stated
in the FIXME comment
- update functional test suite accordingly