### PR TITLE
Re-export Foundation from XCTest

### DIFF
--- a/Sources/XCTest/Private/PerformanceMeter.swift
+++ b/Sources/XCTest/Private/PerformanceMeter.swift
@@ -11,12 +11,6 @@
 //  Measures the performance of a block of code and reports the results.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// Describes a type that is capable of measuring some aspect of code performance
 /// over time.
 internal protocol PerformanceMetric {

--- a/Sources/XCTest/Private/PrintObserver.swift
+++ b/Sources/XCTest/Private/PrintObserver.swift
@@ -11,12 +11,6 @@
 //  Prints test progress to stdout.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// Prints textual representations of each XCTestObservation event to stdout.
 /// Mirrors the Apple XCTest output exactly.
 internal class PrintObserver: XCTestObservation {

--- a/Sources/XCTest/Private/TestListing.swift
+++ b/Sources/XCTest/Private/TestListing.swift
@@ -11,12 +11,6 @@
 //  Implementation of the mode for printing the list of tests.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 internal struct TestListing {
     private let testSuite: XCTestSuite
 

--- a/Sources/XCTest/Private/WallClockTimeMetric.swift
+++ b/Sources/XCTest/Private/WallClockTimeMetric.swift
@@ -11,12 +11,6 @@
 //  Performance metric measuring how long it takes code to execute
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// This metric uses the system uptime to keep track of how much time passes
 /// between starting and stopping measuring.
 internal final class WallClockTimeMetric: PerformanceMetric {

--- a/Sources/XCTest/Private/XCPredicateExpectation.swift
+++ b/Sources/XCTest/Private/XCPredicateExpectation.swift
@@ -11,12 +11,6 @@
 //  Expectations with a specified predicate and object to evaluate.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 internal class XCPredicateExpectation: XCTestExpectation {
     internal let predicate: NSPredicate
     internal let object: AnyObject

--- a/Sources/XCTest/Private/XCTestCaseSuite.swift
+++ b/Sources/XCTest/Private/XCTestCaseSuite.swift
@@ -11,12 +11,6 @@
 //  A test suite associated with a particular test case class.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// A test suite which is associated with a particular test case class. It will
 /// call `setUp` and `tearDown` on the class itself before and after invoking
 /// all of the test cases making up the class.

--- a/Sources/XCTest/Public/Asynchronous/XCNotificationExpectationHandler.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCNotificationExpectationHandler.swift
@@ -12,12 +12,6 @@
 //  observed.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// A block to be invoked when a notification specified by the expectation is
 /// observed.
 ///

--- a/Sources/XCTest/Public/Asynchronous/XCPredicateExpectationHandler.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCPredicateExpectationHandler.swift
@@ -12,12 +12,6 @@
 //  evaluated with a given object.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// A block to be invoked when evaluating the predicate against the object 
 /// returns true. If the block is not provided the first successful evaluation 
 /// will fulfill the expectation. If provided, the handler can override that 

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -11,12 +11,6 @@
 //  Methods on XCTestCase for testing asynchronous operations
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 public extension XCTestCase {
 
     /// Creates and returns an expectation associated with the test case.

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+NotificationExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+NotificationExpectation.swift
@@ -10,12 +10,6 @@
 //  XCTestCase+NotificationExpectation.swift
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 public extension XCTestCase {
     /// Creates and returns an expectation for a notification.
     ///

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+PredicateExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+PredicateExpectation.swift
@@ -10,12 +10,6 @@
 //  XCTestCase+PredicateExpectation.swift
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 public extension XCTestCase {
     /// Creates and returns an expectation that is fulfilled if the predicate
     /// returns true when evaluated with the given object. The expectation

--- a/Sources/XCTest/Public/Asynchronous/XCWaitCompletionHandler.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCWaitCompletionHandler.swift
@@ -12,12 +12,6 @@
 //  fulfilled times out.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// A block to be invoked when a call to wait times out or has had all
 /// associated expectations fulfilled.
 ///

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -11,12 +11,6 @@
 //  Base class for test cases
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// This is a compound type used by `XCTMain` to represent tests to run. It combines an
 /// `XCTestCase` subclass type with the list of test case methods to invoke on the class.
 /// This type is intended to be produced by the `testCase` helper function.

--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -12,10 +12,12 @@
 //  for running tests and some infrastructure for running them.
 //
 
+// Note that we are re-exporting Foundation so tests importing XCTest don't need
+// to import it themselves. This is consistent with the behavior of Apple XCTest
 #if os(macOS)
-    import SwiftFoundation
+    @_exported import SwiftFoundation
 #else
-    import Foundation
+    @_exported import Foundation
 #endif
 
 #if os(macOS)

--- a/Sources/XCTest/Public/XCTestObservation.swift
+++ b/Sources/XCTest/Public/XCTestObservation.swift
@@ -11,12 +11,6 @@
 //  Hooks for being notified about progress during a test run.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// `XCTestObservation` provides hooks for being notified about progress during a
 /// test run.
 /// - seealso: `XCTestObservationCenter`

--- a/Sources/XCTest/Public/XCTestObservationCenter.swift
+++ b/Sources/XCTest/Public/XCTestObservationCenter.swift
@@ -11,12 +11,6 @@
 //  Notification center for test run progress events.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// Provides a registry for objects wishing to be informed about progress
 /// during the course of a test run. Observers must implement the
 /// `XCTestObservation` protocol

--- a/Sources/XCTest/Public/XCTestRun.swift
+++ b/Sources/XCTest/Public/XCTestRun.swift
@@ -11,12 +11,6 @@
 //  A test run collects information about the execution of a test.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// A test run collects information about the execution of a test. Failures in
 /// explicit test assertions are classified as "expected", while failures from
 /// unrelated or uncaught exceptions are classified as "unexpected".

--- a/Sources/XCTest/Public/XCTestSuiteRun.swift
+++ b/Sources/XCTest/Public/XCTestSuiteRun.swift
@@ -11,12 +11,6 @@
 //  A test run for an `XCTestSuite`.
 //
 
-#if os(macOS)
-    import SwiftFoundation
-#else
-    import Foundation
-#endif
-
 /// A test run for an `XCTestSuite`.
 open class XCTestSuiteRun: XCTestRun {
     /// The combined `testDuration` of each test case run in the suite.

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Expectations/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Notifications/Handler/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Expectations/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Predicates/Handler/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/ListTests/main.swift
+++ b/Tests/Functional/ListTests/main.swift
@@ -6,10 +6,8 @@
 // RUN: %{xctest_checker} %t_verify verify_json.expected
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -3,10 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
-    import SwiftFoundation
     import SwiftXCTest
 #else
-    import Foundation
     import XCTest
 #endif
 


### PR DESCRIPTION
**Resolves: [SR-3615](https://bugs.swift.org/browse/SR-3615)**

This brings Corelibs XCTest into closer parity with Apple XCTest in that importing XCTest from a test source file is sufficient to allow using Foundation symbols without needing to explicitly import Foundation in the test.

This is not a source-breaking change, as existing code that already imports Foundation can continue to do so with no ill effects.

This change has a particular benefit to the Corelibs XCTest codebase itself because it significantly reduces the number of platform-conditional imports that we need.