### PR TITLE
XCTestAssertNoThrow

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -42,7 +42,7 @@ private enum _XCTAssertion {
         case .`true`: return "XCTAssertTrue"
         case .`false`: return "XCTAssertFalse"
         case .throwsError: return "XCTAssertThrowsError"
-        case .noThrow return "XCTAssertNoThrow"
+        case .noThrow: return "XCTAssertNoThrow"
         case .fail: return nil
         }
     }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -429,7 +429,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
         do {
              _ = try expression()
             return .success
-        } catch let error {
+        } catch _ {
             return .expectedFailure("threw error")
         }
     }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -430,7 +430,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
              _ = try expression()
             return .success
         } catch _ {
-            return .expectedFailure("threw error")
+            return .expectedFailure("\(filename):\(line): XCTAssertNoThrow failed: threw error \"\(error)\". : \(message)")
         }
     }
 }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -25,6 +25,7 @@ private enum _XCTAssertion {
     case `false`
     case fail
     case throwsError
+    case noThrow
 
     var name: String? {
         switch(self) {
@@ -41,6 +42,7 @@ private enum _XCTAssertion {
         case .`true`: return "XCTAssertTrue"
         case .`false`: return "XCTAssertFalse"
         case .throwsError: return "XCTAssertThrowsError"
+        case .noThrow return "XCTAssertNoThrow"
         case .fail: return nil
         }
     }
@@ -418,6 +420,17 @@ public func XCTAssertThrowsError<T>(_ expression: @autoclosure () throws -> T, _
             return .success
         } else {
             return .expectedFailure("did not throw error")
+        }
+    }
+}
+
+public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    _XCTEvaluateAssertion(.noThrow, message: message, file: file, line: line) {
+        do {
+             _ = try expression()
+            return .success
+        } catch let error {
+            return .expectedFailure("threw error")
         }
     }
 }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -429,7 +429,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
         do {
              _ = try expression()
             return .success
-        } catch _ {
+        } catch let error {
             return .expectedFailure("threw error \"\(error)\"")
         }
     }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -430,7 +430,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
              _ = try expression()
             return .success
         } catch _ {
-            return .expectedFailure("\(filename):\(line): XCTAssertNoThrow failed: threw error \"\(error)\". : \(message)")
+            return .expectedFailure("threw error \"\(error)\"")
         }
     }
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,7 @@ func test_shouldNotThrowErrorDefiningSuccess() {
 }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error -
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
 func test_shouldThrowErrorDefiningFailure() {
     XCTAssertNoThrow(try functionThatDoesThrowError())

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,8 @@ func test_shouldNotThrowErrorDefiningSuccess() {
 }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' passed \(\d+\.\d+ seconds\)
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error -
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
 func test_shouldThrowErrorDefiningFailure() {
     XCTAssertNoThrow(try functionThatDoesThrowError())
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -124,7 +124,7 @@ class ErrorHandling: XCTestCase {
 }
 
 // CHECK: Test Suite 'ErrorHandling' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ErrorHandling.allTests)])
 

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -118,7 +118,7 @@ class ErrorHandling: XCTestCase {
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : threw error "anError\("an error message"\)"
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
-    func test_shouldThrowErrorDefiningFailure() throws {
+    func test_shouldThrowErrorDefiningFailure() {
         XCTAssertNoThrow(try functionThatDoesThrowError())
     }
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -29,7 +29,7 @@ class ErrorHandling: XCTestCase {
 
             // Tests for XCTAssertNoThrow
             ("test_shouldNotThrowErrorDefiningSuccess", test_shouldNotThrowErrorDefiningSuccess),
-            ("test_shouldThrowErrorDefiningError", test_shouldThrowErrorDefiningError)
+            ("test_shouldThrowErrorDefiningFailure", test_shouldThrowErrorDefiningFailure),
         ]
     }()
     
@@ -117,7 +117,7 @@ func test_shouldNotThrowErrorDefiningSuccess() {
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' passed \(\d+\.\d+ seconds\)
-func test_shouldThrowErrorDefiningError() {
+func test_shouldThrowErrorDefiningFailure() {
     XCTAssertNoThrow(try functionThatDoesThrowError())
 }
 

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -129,6 +129,6 @@ class ErrorHandling: XCTestCase {
 XCTMain([testCase(ErrorHandling.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -107,19 +107,20 @@ class ErrorHandling: XCTestCase {
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)
     }
-}
+
 
 // CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' passed \(\d+\.\d+ seconds\)
-func test_shouldNotThrowErrorDefiningSuccess() {
-    XCTAssertNoThrow(try functionThatDoesNotThrowError())
-}
+    func test_shouldNotThrowErrorDefiningSuccess() {
+        XCTAssertNoThrow(try functionThatDoesNotThrowError())
+    }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
-func test_shouldThrowErrorDefiningFailure() {
-    XCTAssertNoThrow(try functionThatDoesThrowError())
+    func test_shouldThrowErrorDefiningFailure() {
+        XCTAssertNoThrow(try functionThatDoesThrowError())
+    }
 }
 
 // CHECK: Test Suite 'ErrorHandling' failed at \d+:\d+:\d+\.\d+

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -115,7 +115,7 @@ class ErrorHandling: XCTestCase {
         XCTAssertNoThrow(try functionThatDoesNotThrowError())
     }
 
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
     func test_shouldThrowErrorDefiningFailure() {

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,9 +116,9 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : threw error "anError\("an error message"\)"
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
-    func test_shouldThrowErrorDefiningFailure() {
+    func test_shouldThrowErrorDefiningFailure() throws {
         XCTAssertNoThrow(try functionThatDoesThrowError())
     }
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,7 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error "anError\("an error message"\)"
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error "anError\("an error message"\)" -
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
     func test_shouldThrowErrorDefiningFailure() {
         XCTAssertNoThrow(try functionThatDoesThrowError())

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,7 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : threw error "anError\("an error message"\)"
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error "anError\("an error message"\)"
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
     func test_shouldThrowErrorDefiningFailure() {
         XCTAssertNoThrow(try functionThatDoesThrowError())

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -26,6 +26,10 @@ class ErrorHandling: XCTestCase {
             
             // Tests for throwing assertion expressions
             ("test_assertionExpressionCanThrow", test_assertionExpressionCanThrow),
+
+            // Tests for XCTAssertNoThrow
+            ("test_shouldNotThrowErrorDefiningSuccess", test_shouldNotThrowErrorDefiningSuccess),
+            ("test_shouldThrowErrorDefiningError", test_shouldThrowErrorDefiningError)
         ]
     }()
     
@@ -104,6 +108,19 @@ class ErrorHandling: XCTestCase {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)
     }
 }
+
+// CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' started at \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' passed \(\d+\.\d+ seconds\)
+func test_shouldNotThrowErrorDefiningSuccess() {
+    XCTAssertNoThrow(try functionThatDoesNotThrowError())
+}
+
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' passed \(\d+\.\d+ seconds\)
+func test_shouldThrowErrorDefiningError() {
+    XCTAssertNoThrow(try functionThatDoesThrowError())
+}
+
 // CHECK: Test Suite 'ErrorHandling' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 


### PR DESCRIPTION
- Adds XCTestAssertNoThrow function
- Adds two test for testing XCTestAssertNoThrow


I get the following errors when attempting to test my branch. I might be doing something wrong.

```bash
Arthur@ ~/Documents/oss/swift-oss/swift-corelibs-xctest 
(feature/XCTestAssertNoThrow)$ ../swift/utils/build-script --preset corelibs-xctest
../swift/utils/build-script: note: using preset 'corelibs-xctest', which expands to 

../swift/utils/build-script --release --assertions --xctest --test -- --skip-test-cmark --skip-test-swift --skip-test-foundation --skip-build-benchmarks

+ mkdir -p /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert
+ env HOST_VARIABLE_macosx_x86_64__SWIFT_BENCHMARK_TARGETS=swift-benchmark-macosx-x86_64 HOST_VARIABLE_macosx_x86_64__SWIFT_RUN_BENCHMARK_TARGETS=check-swift-benchmark-macosx-x86_64 'HOST_VARIABLE_macosx_x86_64__SWIFT_SDKS=IOS IOS_SIMULATOR OSX TVOS TVOS_SIMULATOR WATCHOS WATCHOS_SIMULATOR' HOST_VARIABLE_macosx_x86_64__SWIFT_STDLIB_TARGETS=swift-test-stdlib-macosx-x86_64 HOST_VARIABLE_macosx_x86_64__SWIFT_TEST_TARGETS=check-swift-macosx-x86_64 caffeinate /Users/Arthur/Documents/oss/swift-oss/swift/utils/build-script-impl --workspace /Users/Arthur/Documents/oss/swift-oss --build-dir /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert --install-prefix /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr --host-target macosx-x86_64 --stdlib-deployment-targets 'macosx-x86_64 iphonesimulator-i386 iphonesimulator-x86_64 appletvsimulator-x86_64 watchsimulator-i386 iphoneos-armv7 iphoneos-armv7s iphoneos-arm64 appletvos-arm64 watchos-armv7k' --host-cc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang --host-cxx /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ --darwin-xcrun-toolchain default --darwin-deployment-version-osx=10.9 --darwin-deployment-version-ios=7.0 --darwin-deployment-version-tvos=9.0 --darwin-deployment-version-watchos=2.0 --cmake /usr/local/bin/cmake --cmark-build-type Release --llvm-build-type Release --swift-build-type Release --swift-stdlib-build-type Release --lldb-build-type Release --foundation-build-type Release --libdispatch-build-type Release --libicu-build-type Release --xctest-build-type Release --swiftpm-build-type Release --swift-enable-assertions true --swift-stdlib-enable-assertions true --swift-analyze-code-coverage false --cmake-generator Ninja --build-jobs 4 '--common-cmake-options=-G Ninja -DCMAKE_C_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DCMAKE_MAKE_PROGRAM=/usr/local/bin/ninja' --build-args=-j4 --cmark-cmake-options= '--llvm-cmake-options=-DLLVM_ENABLE_ASSERTIONS=TRUE -DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;PowerPC;SystemZ' '--swift-cmake-options=-DSWIFT_STDLIB_ENABLE_SIL_OWNERSHIP=FALSE -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE' --xctest-cmake-options= --build-stdlib-deployment-targets all --ninja-bin=/usr/local/bin/ninja --skip-build-benchmarks --skip-build-foundation --skip-build-lldb --skip-build-llbuild --skip-build-libdispatch --skip-build-libicu --skip-build-swiftpm --skip-build-playgroundlogger --skip-build-playgroundsupport --build-swift-dynamic-stdlib --build-swift-dynamic-sdk-overlay --skip-build-ios-device --skip-build-ios-simulator --skip-build-tvos-device --skip-build-tvos-simulator --skip-build-watchos-device --skip-build-watchos-simulator --skip-build-android --skip-test-ios-host --skip-test-ios-simulator --skip-test-tvos-host --skip-test-tvos-simulator --skip-test-watchos-host --skip-test-watchos-simulator --skip-test-android-host --skip-test-benchmarks --skip-test-optimized --android-deploy-device-path /data/local/tmp --toolchain-prefix /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --skip-test-cmark --skip-test-swift --skip-test-foundation --llvm-lit-args=-sv
Building the standard library for: swift-test-stdlib-macosx-x86_64
cmark: using standard linker
+ /usr/local/bin/cmake --build /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/cmark-macosx-x86_64 -- -j4 all
ninja: no work to do.
llvm: using standard linker
symlinking the system headers (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../../usr/include/c++) into the local clang build directory (/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64/include).
+ ln -s -f /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../../usr/include/c++ /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64/include
+ /usr/local/bin/cmake --build /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64 -- -j4 all
ninja: no work to do.
swift: using standard linker
+ /usr/local/bin/cmake --build /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64 -- -j4 all swift-test-stdlib-macosx-x86_64
[1/1] Building HTML documentation
Running Sphinx v1.3.3
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
no targets are out of date.
build succeeded.
xctest: using standard linker
+ /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-xctest/build_script.py --swiftc=/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc --build-dir=/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64 --foundation-build-dir=/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/foundation-macosx-x86_64/Foundation --release
xctest-build: xcodebuild -workspace /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-xctest/XCTest.xcworkspace -scheme SwiftXCTest -configuration Release SWIFT_EXEC="/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc" SWIFT_LINK_OBJC_RUNTIME=YES SYMROOT="/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64" OBJROOT="/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64"
Build settings from command line:
    OBJROOT = /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64
    SWIFT_EXEC = /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc
    SWIFT_LINK_OBJC_RUNTIME = YES
    SYMROOT = /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64

=== BUILD TARGET CoreFoundation OF PROJECT Foundation WITH CONFIGURATION Release ===

Check dependencies

=== BUILD TARGET SwiftFoundation OF PROJECT Foundation WITH CONFIGURATION Release ===

Check dependencies

CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
    cd /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation
    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
    export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
    export TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault
    /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc -incremental -module-name SwiftFoundation -O -whole-module-optimization -DDEPLOYMENT_ENABLE_LIBDISPATCH -DDEPLOYMENT_RUNTIME_SWIFT -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -target x86_64-apple-macosx10.11 -g -module-cache-path /Users/Arthur/Library/Developer/Xcode/DerivedData/ModuleCache -Xfrontend -serialize-debugging-options -I /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release -F /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release -c -num-threads 4 /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSArray.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSEnergyFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLError.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPersonNameComponentsFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCompoundPredicate.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/FoundationErrors.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/URL.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLDTDNode.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSNull.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLProtectionSpace.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSEnumerator.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/CharacterSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSTimer.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLParser.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCFSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/MultiHandle.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/TaskRegistry.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSComparisonPredicate.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/NSURLSessionDelegate.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCache.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/HTTPMessage.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSOperation.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Unit.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCFCharacterSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSExpression.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPort.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSTextCheckingResult.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/ProgressFraction.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSTimeZone.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDateComponentsFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLCredential.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLElement.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSJSONSerialization.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSString.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSRange.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSAttributedString.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSSwiftRuntime.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Date.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSFileHandle.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPredicate.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSUUID.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLNode.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSLocale.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSError.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSSortDescriptor.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Boxing.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSBundle.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/ReferenceConvertible.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSSpecialValue.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/EasyHandle.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPortMessage.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Bridging.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLAuthenticationChallenge.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSIndexSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDate.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSValue.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSFileManager.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCharacterSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Calendar.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Notification.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Locale.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSStream.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURL.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Set.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Array.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSThread.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSConcreteValue.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/TransferState.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSData.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/IndexPath.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSScanner.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSIndexPath.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPathUtilities.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLRequest.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSGeometry.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDateFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSMeasurementFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSProcessInfo.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSRegularExpression.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSLengthFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCFArray.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/HTTPBodySource.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Progress.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDateIntervalFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/Configuration.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCalendar.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Process.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSObjCRuntime.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Dictionary.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSStringAPI.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/DateComponents.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDictionary.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSNumberFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSStringEncodings.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Measurement.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSHost.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSAffineTransform.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLDocument.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCFDictionary.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/NSURLSession.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSNotificationQueue.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiverHelpers.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimalNumber.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Data.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/String.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCoder.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedCoderOldStyleArray.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/IndexSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSNotification.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSObject.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSByteCountFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPlatform.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/NSURLSessionTask.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLProtocol.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSLog.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSRunLoop.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLDTD.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/PersonNameComponents.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSMassFormatter.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSMeasurement.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSNumber.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/TimeZone.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLCache.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/ExtraStringAPIs.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/DateInterval.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSUserDefaults.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSLock.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/libcurlHelpers.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSHTTPCookie.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/URLComponents.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSCFString.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSOrderedSet.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLResponse.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimal.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSHTTPCookieStorage.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/CGFloat.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLCredentialStorage.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/URLRequest.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPropertyList.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSURLSession/NSURLSessionConfiguration.swift /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSPersonNameComponents.swift -output-file-map /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/SwiftFoundation-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/SwiftFoundation.swiftmodule -Xcc -iquote -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-generated-files.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-own-target-headers.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-project-headers.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release/include -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release/usr/local/include -Xcc -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/libxml2 -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/DerivedSources/x86_64 -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/DerivedSources -import-underlying-module -Xcc -working-directory/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation

CompileSwift normal x86_64
    cd /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation
    /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swift -frontend -c -filelist /var/folders/1_/dt39frhj0jsf9lb0df3pscf00000gn/T/sources-41d4dd -target x86_64-apple-macosx10.11 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release -F /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release -g -import-underlying-module -module-cache-path /Users/Arthur/Library/Developer/Xcode/DerivedData/ModuleCache -D DEPLOYMENT_ENABLE_LIBDISPATCH -D DEPLOYMENT_RUNTIME_SWIFT -serialize-debugging-options -Xcc -iquote -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-generated-files.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-own-target-headers.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-project-headers.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release/include -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release/usr/local/include -Xcc -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/libxml2 -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/DerivedSources/x86_64 -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/DerivedSources -Xcc -working-directory/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation -emit-module-doc-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/SwiftFoundation.swiftdoc -O -module-name SwiftFoundation -emit-module-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/SwiftFoundation.swiftmodule -serialize-diagnostics-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/NSArray.dia -emit-dependencies-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/NSArray.d -num-threads 4 -output-filelist /var/folders/1_/dt39frhj0jsf9lb0df3pscf00000gn/T/outputs-548004
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/CGFloat.swift:12:37: warning: unknown architecture for build configuration 'arch'
#if arch(i386) || arch(arm) || arch(powerpc)
                                    ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/CGFloat.swift:12:37: note: did you mean 'powerpc64'?
#if arch(i386) || arch(arm) || arch(powerpc)
                                    ^~~~~~~
                                    powerpc64
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/CGFloat.swift:173:37: warning: unknown architecture for build configuration 'arch'
#if arch(i386) || arch(arm) || arch(powerpc)
                                    ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/CGFloat.swift:173:37: note: did you mean 'powerpc64'?
#if arch(i386) || arch(arm) || arch(powerpc)
                                    ^~~~~~~
                                    powerpc64
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSArray.swift:373:34: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<Int32>' to 'UnsafeMutablePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<Int32>' to rebind the type of memory
        return Data(bytesNoCopy: unsafeBitCast(buffer, to: UnsafeMutablePointer<UInt8>.self), count: count * MemoryLayout<Int>.size, deallocator: .custom({ _ in
                                 ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSArray.swift:133:16: warning: 'initialize(from:)' is deprecated: it will be removed in Swift 4.0.  Please use 'UnsafeMutableBufferPointer.initialize(from:)' instead
        buffer.initialize(from: optionalArray)
               ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/CharacterSet.swift:489:16: warning: 'unsafeBitCast' from '_SwiftNSCharacterSet' to 'NSCharacterSet' is unnecessary and can be removed
        return unsafeBitCast(_wrapped, to: NSCharacterSet.self)
               ^~~~~~~~~~~~~~        ~~~~~~~~~~~~~~~~~~~~~~~~~~
                                     
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLParser.swift:50:22: warning: 'unsafeBitCast' from 'UnsafePointer<UInt8>' to 'UnsafePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafePointer<UInt8>' to rebind the type of memory
    let len = strlen(unsafeBitCast(bytes, to: UnsafePointer<Int8>.self))
                     ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLParser.swift:260:114: warning: 'unsafeBitCast' from 'UnsafePointer<UInt8>' to 'UnsafePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafePointer<UInt8>' to rebind the type of memory
                asAttrNamespaceNameString = _colonSeparatedStringFromPrefixAndSuffix("xmlns", 5, ns, UInt(strlen(unsafeBitCast(ns, to: UnsafePointer<Int8>.self))))
                                                                                                                 ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLParser.swift:292:56: warning: 'unsafeBitCast' from 'UnsafePointer<UInt8>' to 'UnsafePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafePointer<UInt8>' to rebind the type of memory
        let attrPrefixLen = attrPrefix != nil ? strlen(unsafeBitCast(attrPrefix!, to: UnsafePointer<Int8>.self)) : 0
                                                       ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLParser.swift:294:133: warning: 'unsafeBitCast' from 'UnsafePointer<UInt8>' to 'UnsafePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafePointer<UInt8>' to rebind the type of memory
            attributeQName = _colonSeparatedStringFromPrefixAndSuffix(attrPrefix!, UInt(attrPrefixLen), attrLocalName, UInt(strlen((unsafeBitCast(attrLocalName, to: UnsafePointer<Int8>.self)))))
                                                                                                                                    ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLParser.swift:310:29: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<UInt8>' to 'UnsafeMutablePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<UInt8>' to rebind the type of memory
                    strncpy(unsafeBitCast(buffer.baseAddress!, to: UnsafeMutablePointer<Int8>.self),
                            ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSXMLParser.swift:311:25: warning: 'unsafeBitCast' from 'UnsafePointer<UInt8>' to 'UnsafePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafePointer<UInt8>' to rebind the type of memory
                        unsafeBitCast(attributes[idx + 3]!, to: UnsafePointer<Int8>.self),
                        ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSString.swift:289:24: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<UInt16>' to 'UnsafePointer<UInt16>' can be replaced with 'UnsafePointer' initializer
                return unsafeBitCast(_storage._core.startUTF16, to: UnsafePointer<UniChar>.self)
                       ^~~~~~~~~~~~~~                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       UnsafePointer(                         )
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSString.swift:280:24: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<UInt8>' to 'UnsafePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<UInt8>' to rebind the type of memory
                return unsafeBitCast(_storage._core.startASCII, to: UnsafePointer<Int8>.self)
                       ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSString.swift:843:41: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<UInt8>' to 'UnsafeMutablePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<UInt8>' to rebind the type of memory
                buffer.moveAssign(from: unsafeBitCast(_storage._core.startASCII, to: UnsafeMutablePointer<Int8>.self)
                                        ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift:299:54: warning: expression implicitly coerced from 'Any?' to Any
            return self._objRefMap[_SwiftValue.store(objv)] != nil
                                                     ^~~~
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift:299:54: note: provide a default value to avoid this warning
            return self._objRefMap[_SwiftValue.store(objv)] != nil
                                                     ^~~~
                                                          ?? <#default value#>
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift:299:54: note: force-unwrap the value to avoid this warning
            return self._objRefMap[_SwiftValue.store(objv)] != nil
                                                     ^~~~
                                                         !
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift:299:54: note: explicitly cast to Any with 'as Any' to silence this warning
            return self._objRefMap[_SwiftValue.store(objv)] != nil
                                                     ^~~~
                                                          as Any
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift:535:41: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
                    fatalError("Object \(object) does not conform to NSCoding")
                                        ^~~~~~~~
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift:535:42: note: use 'String(describing:)' to silence this warning
                    fatalError("Object \(object) does not conform to NSCoding")
                                        ~^~~~~~~
                                         String(describing:  )
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedArchiver.swift:535:42: note: provide a default value to avoid this warning
                    fatalError("Object \(object) does not conform to NSCoding")
                                        ~^~~~~~~
                                                ?? <#default value#>
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:62:34: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to 'UnsafePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to rebind the type of memory
                _cf_uuid_unparse(unsafeBitCast(val, to: UnsafePointer<UInt8>.self), unsafeBitCast(str, to: UnsafeMutablePointer<Int8>.self))
                                 ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:62:85: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)>' to 'UnsafeMutablePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)>' to rebind the type of memory
                _cf_uuid_unparse(unsafeBitCast(val, to: UnsafePointer<UInt8>.self), unsafeBitCast(str, to: UnsafeMutablePointer<Int8>.self))
                                                                                    ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:63:40: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)>' to 'UnsafePointer<Int8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)>' to rebind the type of memory
                return String(cString: unsafeBitCast(str, to: UnsafePointer<CChar>.self), encoding: .utf8)!
                                       ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:71:48: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to 'UnsafeMutablePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to rebind the type of memory
            return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(MemoryLayout<uuid_t>.size)))
                                               ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:88:38: warning: 'unsafeBitCast' from 'UnsafePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to 'UnsafePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to rebind the type of memory
            return NSUUID(uuidBytes: unsafeBitCast($0, to: UnsafePointer<UInt8>.self))
                                     ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:27:38: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to 'UnsafeMutablePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to rebind the type of memory
            _cf_uuid_generate_random(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
                                     ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:34:32: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to 'UnsafeMutablePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to rebind the type of memory
            reference.getBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
                               ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/UUID.swift:44:43: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to 'UnsafeMutablePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)>' to rebind the type of memory
            return _cf_uuid_parse(string, unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self))
                                          ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Process.swift:210:20: warning: 'initialize(from:)' is deprecated: it will be removed in Swift 4.0.  Please use 'UnsafeMutableBufferPointer.initialize(from:)' instead
            buffer.initialize(from: array.map { $0.withCString(strdup) })
                   ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Process.swift:210:20: warning: 'initialize(from:)' is deprecated: it will be removed in Swift 4.0.  Please use 'UnsafeMutableBufferPointer.initialize(from:)' instead
            buffer.initialize(from: array.map { $0.withCString(strdup) })
                   ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Process.swift:228:18: warning: 'initialize(from:)' is deprecated: it will be removed in Swift 4.0.  Please use 'UnsafeMutableBufferPointer.initialize(from:)' instead
            envp.initialize(from: env.map { strdup("\($0)=\($1)") })
                 ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDictionary.swift:127:19: warning: 'initialize(from:)' is deprecated: it will be removed in Swift 4.0.  Please use 'UnsafeMutableBufferPointer.initialize(from:)' instead
        keyBuffer.initialize(from: keys)
                  ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDictionary.swift:130:21: warning: 'initialize(from:)' is deprecated: it will be removed in Swift 4.0.  Please use 'UnsafeMutableBufferPointer.initialize(from:)' instead
        valueBuffer.initialize(from: objects.map { _SwiftValue.store($0) })
                    ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift:393:57: warning: expression implicitly coerced from 'Any?' to Any
        object = self._replacementMap[_SwiftValue.store(decodedObject)]
                                                        ^~~~~~~~~~~~~
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift:393:57: note: provide a default value to avoid this warning
        object = self._replacementMap[_SwiftValue.store(decodedObject)]
                                                        ^~~~~~~~~~~~~
                                                                      ?? <#default value#>
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift:393:57: note: force-unwrap the value to avoid this warning
        object = self._replacementMap[_SwiftValue.store(decodedObject)]
                                                        ^~~~~~~~~~~~~
                                                                     !
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift:393:57: note: explicitly cast to Any with 'as Any' to silence this warning
        object = self._replacementMap[_SwiftValue.store(decodedObject)]
                                                        ^~~~~~~~~~~~~
                                                                      as Any
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift:460:85: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
                                         withDescription: "Invalid class reference \(innerDecodingContext.dict["$class"]). The data may be corrupt.")
                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift:460:111: note: use 'String(describing:)' to silence this warning
                                         withDescription: "Invalid class reference \(innerDecodingContext.dict["$class"]). The data may be corrupt.")
                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
                                                                                     String(describing:                 )
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSKeyedUnarchiver.swift:460:111: note: provide a default value to avoid this warning
                                         withDescription: "Invalid class reference \(innerDecodingContext.dict["$class"]). The data may be corrupt.")
                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
                                                                                                                         ?? <#default value#>
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSAffineTransform.swift:120:34: warning: 'M_PI' is deprecated: Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.
        let α = Double(angle) * M_PI / 180.0
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSAffineTransform.swift:148:34: warning: 'M_PI' is deprecated: Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.
        let α = Double(angle) * M_PI / 180.0
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/Data.swift:86:90: warning: 'unsafeBitCast' from 'UnsafeMutableRawPointer' to 'Int' can be replaced with 'bitPattern:' initializer on 'Int'
        if _DataStorage.vmOpsThreshold <= num && ((unsafeBitCast(source, to: Int.self) | unsafeBitCast(dest, to: Int.self)) & (NSPageSize() - 1)) == 0 {
                                                                                         ^~~~~~~~~~~~~~    ~~~~~~~~~~~~~~~
                                                                                         Int(bitPattern:   )
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/DateInterval.swift:159:48: warning: 'unsafeBitCast' from 'UnsafeMutablePointer<(UInt, UInt)>' to 'UnsafeMutablePointer<UInt8>' changes pointee type and may lead to undefined behavior; use the 'withMemoryRebound' method on 'UnsafeMutablePointer<(UInt, UInt)>' to rebind the type of memory
            return Int(bitPattern: CFHashBytes(unsafeBitCast($0, to: UnsafeMutablePointer<UInt8>.self), CFIndex(MemoryLayout<UInt>.size * 2)))
                                               ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimal.swift:1038:66: warning: '-' is deprecated: Mixed-type subtraction is deprecated. Please use explicit type conversion.
    _ = integerMultiplyByPowerOf10(&result, bb.pointee, maxpow10 - diffexp)
                                                                 ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimal.swift:1041:26: warning: '-=' is deprecated: Mixed-type subtraction is deprecated. Please use explicit type conversion.
    bb.pointee._exponent -= maxpow10 - diffexp;
                         ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimal.swift:1041:38: warning: '-' is deprecated: Mixed-type subtraction is deprecated. Please use explicit type conversion.
    bb.pointee._exponent -= maxpow10 - diffexp;
                                     ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimal.swift:1339:27: warning: '-' is deprecated: Mixed-type subtraction is deprecated. Please use explicit type conversion.
    if (19 <= a._exponent - b._exponent) {
                          ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimal.swift:1618:23: warning: '+' is deprecated: Mixed-type addition is deprecated. Please use explicit type conversion.
        var s = scale + _exponent
                      ^
/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation/Foundation/NSDecimal.swift:2028:42: warning: '+' is deprecated: Mixed-type addition is deprecated. Please use explicit type conversion.
                exponent = 10 * exponent + numeral
                                         ^
Assertion failed: (FuncChild->getKind() != Node::Kind::Suffix || FuncChild->getText() == "merged"), function finalize, file /Users/Arthur/Documents/oss/swift-oss/swift/lib/SILOptimizer/Utils/SpecializationMangler.cpp, line 47.
0  swift                    0x000000010bef14d8 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 40
1  swift                    0x000000010bef1bd6 SignalHandler(int) + 454
2  libsystem_platform.dylib 0x00007fff8f731bba _sigtramp + 26
3  libsystem_platform.dylib 0x00007fff56ea32a0 _sigtramp + 3346470656
4  libsystem_c.dylib        0x00007fff8f5b8420 abort + 129
5  libsystem_c.dylib        0x00007fff8f57f893 basename_r + 0
6  swift                    0x00000001090eca1a swift::NewMangling::SpecializationMangler::finalize() + 1290
7  swift                    0x00000001090ede0c swift::NewMangling::FunctionSignatureSpecializationMangler::mangle(int) + 476
8  swift                    0x000000010919e5be FunctionSignatureTransform::createOptimizedSILFunctionName() + 462
9  swift                    0x000000010919f0e4 FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() + 52
10 swift                    0x00000001091a4568 FunctionSignatureTransform::run(bool) + 648
11 swift                    0x00000001091a3ac5 (anonymous namespace)::FunctionSignatureOpts::run() + 2069
12 swift                    0x00000001090eef19 swift::SILPassManager::runPassOnFunction(swift::SILFunctionTransform*, swift::SILFunction*) + 2473
13 swift                    0x00000001090efe07 swift::SILPassManager::runFunctionPasses(llvm::ArrayRef<swift::SILFunctionTransform*>) + 1127
14 swift                    0x00000001090f1114 swift::SILPassManager::runOneIteration() + 948
15 swift                    0x0000000108ef83db swift::SILPassManager::executePassPipelinePlan(swift::SILPassPipelinePlan const&) + 187
16 swift                    0x00000001090fa463 swift::runSILOptimizationPasses(swift::SILModule&) + 243
17 swift                    0x0000000108da43c5 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 13653
18 swift                    0x0000000108d5bcf1 main + 3025
19 libdyld.dylib            0x00007fff8f524255 start + 1
Stack dump:
0.	Program arguments: /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swift -frontend -c -filelist /var/folders/1_/dt39frhj0jsf9lb0df3pscf00000gn/T/sources-41d4dd -target x86_64-apple-macosx10.11 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release -F /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release -g -import-underlying-module -module-cache-path /Users/Arthur/Library/Developer/Xcode/DerivedData/ModuleCache -D DEPLOYMENT_ENABLE_LIBDISPATCH -D DEPLOYMENT_RUNTIME_SWIFT -serialize-debugging-options -Xcc -iquote -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-generated-files.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-own-target-headers.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/SwiftFoundation-project-headers.hmap -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release/include -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Release/usr/local/include -Xcc -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/libxml2 -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/DerivedSources/x86_64 -Xcc -I/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/DerivedSources -Xcc -working-directory/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-foundation -emit-module-doc-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/SwiftFoundation.swiftdoc -O -module-name SwiftFoundation -emit-module-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/SwiftFoundation.swiftmodule -serialize-diagnostics-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/NSArray.dia -emit-dependencies-path /Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64/Foundation.build/Release/SwiftFoundation.build/Objects-normal/x86_64/NSArray.d -num-threads 4 -output-filelist /var/folders/1_/dt39frhj0jsf9lb0df3pscf00000gn/T/outputs-548004 
1.	While running pass #2833414 SILFunctionTransform "Function Signature Optimization" on SILFunction "@_TTSfq4n_d___TFSSCfVSS13CharacterViewSS_unique_suffix".

<unknown>:0: error: unable to execute command: Abort trap: 6
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
** BUILD FAILED **


The following build commands failed:
	CompileSwift normal x86_64
	CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
(2 failures)
Traceback (most recent call last):
  File "/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-xctest/build_script.py", line 524, in <module>
    main()
  File "/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-xctest/build_script.py", line 520, in main
    parsed_args.func(parsed_args)
  File "/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-xctest/build_script.py", line 98, in build
    source_dir=SOURCE_DIR))
  File "/Users/Arthur/Documents/oss/swift-oss/swift-corelibs-xctest/build_script.py", line 31, in run
    subprocess.check_call(command, shell=True)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'xcodebuild -workspace /Users/Arthur/Documents/oss/swift-oss/swift-corelibs-xctest/XCTest.xcworkspace -scheme SwiftXCTest -configuration Release SWIFT_EXEC="/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc" SWIFT_LINK_OBJC_RUNTIME=YES SYMROOT="/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64" OBJROOT="/Users/Arthur/Documents/oss/swift-oss/build/Ninja-ReleaseAssert/xctest-macosx-x86_64"' returned non-zero exit status 65
../swift/utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
../swift/utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting
```