### PR TITLE
XCTestAssertNoThrow for 3.1

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -42,7 +42,7 @@ private enum _XCTAssertion {
         case .`true`: return "XCTAssertTrue"
         case .`false`: return "XCTAssertFalse"
         case .throwsError: return "XCTAssertThrowsError"
-        case .noThrow return "XCTAssertNoThrow"
+        case .noThrow: return "XCTAssertNoThrow"
         case .fail: return nil
         }
     }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -429,7 +429,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
         do {
              _ = try expression()
             return .success
-        } catch let error {
+        } catch _ {
             return .expectedFailure("threw error")
         }
     }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -430,7 +430,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
              _ = try expression()
             return .success
         } catch _ {
-            return .expectedFailure("threw error")
+            return .expectedFailure("\(filename):\(line): XCTAssertNoThrow failed: threw error \"\(error)\". : \(message)")
         }
     }
 }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -25,6 +25,7 @@ private enum _XCTAssertion {
     case `false`
     case fail
     case throwsError
+    case noThrow
 
     var name: String? {
         switch(self) {
@@ -41,6 +42,7 @@ private enum _XCTAssertion {
         case .`true`: return "XCTAssertTrue"
         case .`false`: return "XCTAssertFalse"
         case .throwsError: return "XCTAssertThrowsError"
+        case .noThrow return "XCTAssertNoThrow"
         case .fail: return nil
         }
     }
@@ -418,6 +420,17 @@ public func XCTAssertThrowsError<T>(_ expression: @autoclosure () throws -> T, _
             return .success
         } else {
             return .expectedFailure("did not throw error")
+        }
+    }
+}
+
+public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    _XCTEvaluateAssertion(.noThrow, message: message, file: file, line: line) {
+        do {
+             _ = try expression()
+            return .success
+        } catch let error {
+            return .expectedFailure("threw error")
         }
     }
 }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -429,7 +429,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
         do {
              _ = try expression()
             return .success
-        } catch _ {
+        } catch let error {
             return .expectedFailure("threw error \"\(error)\"")
         }
     }

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -430,7 +430,7 @@ public func XCTAssertNoThrow<T>(_ expression: @autoclosure () throws -> T, _ mes
              _ = try expression()
             return .success
         } catch _ {
-            return .expectedFailure("\(filename):\(line): XCTAssertNoThrow failed: threw error \"\(error)\". : \(message)")
+            return .expectedFailure("threw error \"\(error)\"")
         }
     }
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,7 @@ func test_shouldNotThrowErrorDefiningSuccess() {
 }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error -
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
 func test_shouldThrowErrorDefiningFailure() {
     XCTAssertNoThrow(try functionThatDoesThrowError())

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,8 @@ func test_shouldNotThrowErrorDefiningSuccess() {
 }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' passed \(\d+\.\d+ seconds\)
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error -
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
 func test_shouldThrowErrorDefiningFailure() {
     XCTAssertNoThrow(try functionThatDoesThrowError())
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -124,7 +124,7 @@ class ErrorHandling: XCTestCase {
 }
 
 // CHECK: Test Suite 'ErrorHandling' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ErrorHandling.allTests)])
 

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -118,7 +118,7 @@ class ErrorHandling: XCTestCase {
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : threw error "anError\("an error message"\)"
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
-    func test_shouldThrowErrorDefiningFailure() throws {
+    func test_shouldThrowErrorDefiningFailure() {
         XCTAssertNoThrow(try functionThatDoesThrowError())
     }
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -29,7 +29,7 @@ class ErrorHandling: XCTestCase {
 
             // Tests for XCTAssertNoThrow
             ("test_shouldNotThrowErrorDefiningSuccess", test_shouldNotThrowErrorDefiningSuccess),
-            ("test_shouldThrowErrorDefiningError", test_shouldThrowErrorDefiningError)
+            ("test_shouldThrowErrorDefiningFailure", test_shouldThrowErrorDefiningFailure),
         ]
     }()
     
@@ -117,7 +117,7 @@ func test_shouldNotThrowErrorDefiningSuccess() {
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' passed \(\d+\.\d+ seconds\)
-func test_shouldThrowErrorDefiningError() {
+func test_shouldThrowErrorDefiningFailure() {
     XCTAssertNoThrow(try functionThatDoesThrowError())
 }
 

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -129,6 +129,6 @@ class ErrorHandling: XCTestCase {
 XCTMain([testCase(ErrorHandling.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -107,19 +107,20 @@ class ErrorHandling: XCTestCase {
     func test_assertionExpressionCanThrow() {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)
     }
-}
+
 
 // CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' started at \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' passed \(\d+\.\d+ seconds\)
-func test_shouldNotThrowErrorDefiningSuccess() {
-    XCTAssertNoThrow(try functionThatDoesNotThrowError())
-}
+    func test_shouldNotThrowErrorDefiningSuccess() {
+        XCTAssertNoThrow(try functionThatDoesNotThrowError())
+    }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
-func test_shouldThrowErrorDefiningFailure() {
-    XCTAssertNoThrow(try functionThatDoesThrowError())
+    func test_shouldThrowErrorDefiningFailure() {
+        XCTAssertNoThrow(try functionThatDoesThrowError())
+    }
 }
 
 // CHECK: Test Suite 'ErrorHandling' failed at \d+:\d+:\d+\.\d+

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -115,7 +115,7 @@ class ErrorHandling: XCTestCase {
         XCTAssertNoThrow(try functionThatDoesNotThrowError())
     }
 
-// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
 // CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
     func test_shouldThrowErrorDefiningFailure() {

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,9 +116,9 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow threw error
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : threw error "anError\("an error message"\)"
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
-    func test_shouldThrowErrorDefiningFailure() {
+    func test_shouldThrowErrorDefiningFailure() throws {
         XCTAssertNoThrow(try functionThatDoesThrowError())
     }
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,7 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error "anError\("an error message"\)"
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error "anError\("an error message"\)" -
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
     func test_shouldThrowErrorDefiningFailure() {
         XCTAssertNoThrow(try functionThatDoesThrowError())

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -116,7 +116,7 @@ class ErrorHandling: XCTestCase {
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' started at \d+:\d+:\d+\.\d+
-// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : threw error "anError\("an error message"\)"
+// CHECK: .*/ErrorHandling/main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldThrowErrorDefiningFailure : XCTAssertNoThrow failed: threw error "anError\("an error message"\)"
 // CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningFailure' failed \(\d+\.\d+ seconds\)
     func test_shouldThrowErrorDefiningFailure() {
         XCTAssertNoThrow(try functionThatDoesThrowError())

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -26,6 +26,10 @@ class ErrorHandling: XCTestCase {
             
             // Tests for throwing assertion expressions
             ("test_assertionExpressionCanThrow", test_assertionExpressionCanThrow),
+
+            // Tests for XCTAssertNoThrow
+            ("test_shouldNotThrowErrorDefiningSuccess", test_shouldNotThrowErrorDefiningSuccess),
+            ("test_shouldThrowErrorDefiningError", test_shouldThrowErrorDefiningError)
         ]
     }()
     
@@ -104,6 +108,19 @@ class ErrorHandling: XCTestCase {
         XCTAssertEqual(try functionThatShouldReturnButThrows(), 1)
     }
 }
+
+// CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' started at \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ErrorHandling.test_shouldNotThrowErrorDefiningSuccess' passed \(\d+\.\d+ seconds\)
+func test_shouldNotThrowErrorDefiningSuccess() {
+    XCTAssertNoThrow(try functionThatDoesNotThrowError())
+}
+
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' started at \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ErrorHandling.test_shouldThrowErrorDefiningError' passed \(\d+\.\d+ seconds\)
+func test_shouldThrowErrorDefiningError() {
+    XCTAssertNoThrow(try functionThatDoesThrowError())
+}
+
 // CHECK: Test Suite 'ErrorHandling' failed at \d+:\d+:\d+\.\d+
 // CHECK: \t Executed 6 tests, with 4 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 


### PR DESCRIPTION
- Adds XCTestAssertNoThrow function
- Adds two test for testing XCTestAssertNoThrow

This has already been merged to master in #184, but I was asked by @briancroom to open a PR against the `swift-3.1-branch`.