### PR TITLE
Force use of -swift-version 3 to build XCTest sources.

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -180,10 +180,12 @@ class GenericUnixStrategy:
         else:
             libdispatch_args = ""
 
+        # NOTE: Force -swift-version 3 to build XCTest sources.
         run("{swiftc} -Xcc -fblocks -c {style_options} -emit-object -emit-module "
             "-module-name XCTest -module-link-name XCTest -parse-as-library "
             "-emit-module-path {build_dir}/XCTest.swiftmodule "
             "-force-single-frontend-invocation "
+            "-swift-version 3"
             "-I {foundation_build_dir} -I {core_foundation_build_dir} "
             "{libdispatch_args} "
             "{source_paths} -o {build_dir}/XCTest.o".format(

--- a/build_script.py
+++ b/build_script.py
@@ -185,7 +185,7 @@ class GenericUnixStrategy:
             "-module-name XCTest -module-link-name XCTest -parse-as-library "
             "-emit-module-path {build_dir}/XCTest.swiftmodule "
             "-force-single-frontend-invocation "
-            "-swift-version 3"
+            "-swift-version 3 "
             "-I {foundation_build_dir} -I {core_foundation_build_dir} "
             "{libdispatch_args} "
             "{source_paths} -o {build_dir}/XCTest.o".format(


### PR DESCRIPTION
Prerequisite for https://github.com/apple/swift/pull/8861