### PR TITLE
build: Fix building TestFoundation in Xcode

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -473,7 +473,10 @@
 			buildSettings = {
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = $BUILT_PRODUCTS_DIR;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
+					$BUILT_PRODUCTS_DIR,
+					"../swift-corelibs-foundation/build/Debug",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks @loader_path/Frameworks";
@@ -482,6 +485,7 @@
 					"-framework",
 					SwiftFoundation,
 				);
+				OTHER_SWIFT_FLAGS = "-swift-version 3";
 				PRODUCT_BUNDLE_PACKAGE_TYPE = FMWK;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
@@ -506,6 +510,7 @@
 					"-framework",
 					SwiftFoundation,
 				);
+				OTHER_SWIFT_FLAGS = "-swift-version 3";
 				PRODUCT_BUNDLE_PACKAGE_TYPE = FMWK;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";

--- a/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTest.xcscheme
+++ b/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestFunctionalTests.xcscheme
+++ b/XCTest.xcodeproj/xcshareddata/xcschemes/SwiftXCTestFunctionalTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"


### PR DESCRIPTION
- TestFoundation needs SwiftXCTest and SwiftXCTest needs
  SwiftFoundation, so this allows xctest to find the framework.

Needs the following PR to work:
https://github.com/apple/swift-corelibs-foundation/pull/1038

This should allow the OSX test to work on swift-ci. I tested it by running the same command swift-ci runs and saw no issues. For testing it will need to be tested at the same time with the PR listed above.