### PR TITLE
[SR-5247] Add the new spellings for the *WithAccuracy assertion functions

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -30,13 +30,13 @@ private enum _XCTAssertion {
     var name: String? {
         switch(self) {
         case .equal: return "XCTAssertEqual"
-        case .equalWithAccuracy: return "XCTAssertEqualWithAccuracy"
+        case .equalWithAccuracy: return "XCTAssertEqual"
         case .greaterThan: return "XCTAssertGreaterThan"
         case .greaterThanOrEqual: return "XCTAssertGreaterThanOrEqual"
         case .lessThan: return "XCTAssertLessThan"
         case .lessThanOrEqual: return "XCTAssertLessThanOrEqual"
         case .notEqual: return "XCTAssertNotEqual"
-        case .notEqualWithAccuracy: return "XCTAssertNotEqualWithAccuracy"
+        case .notEqualWithAccuracy: return "XCTAssertNotEqual"
         case .`nil`: return "XCTAssertNil"
         case .notNil: return "XCTAssertNotNil"
         case .`true`: return "XCTAssertTrue"
@@ -224,7 +224,7 @@ public func XCTAssertEqual<T, U: Equatable>(_ expression1: @autoclosure () throw
     }
 }
 
-public func XCTAssertEqualWithAccuracy<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertEqual<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.equalWithAccuracy, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if abs(value1.distance(to: value2)) <= abs(accuracy.distance(to: T(0))) {
@@ -233,6 +233,11 @@ public func XCTAssertEqualWithAccuracy<T: FloatingPoint>(_ expression1: @autoclo
             return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\") +/- (\"\(accuracy)\")")
         }
     }
+}
+
+@available(*, deprecated, renamed: "XCTAssertEqual(_:_:accuracy:file:line:)")
+public func XCTAssertEqualWithAccuracy<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(expression1, expression2, accuracy: accuracy, message, file: file, line: line)
 }
 
 public func XCTAssertFalse(_ expression: @autoclosure () throws -> Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
@@ -367,7 +372,7 @@ public func XCTAssertNotEqual<T, U: Equatable>(_ expression1: @autoclosure () th
     }
 }
 
-public func XCTAssertNotEqualWithAccuracy<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertNotEqual<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.notEqualWithAccuracy, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if abs(value1.distance(to: value2)) > abs(accuracy.distance(to: T(0))) {
@@ -376,6 +381,11 @@ public func XCTAssertNotEqualWithAccuracy<T: FloatingPoint>(_ expression1: @auto
             return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\") +/- (\"\(accuracy)\")")
         }
     }
+}
+
+@available(*, deprecated, renamed: "XCTAssertNotEqual(_:_:accuracy:file:line:)")
+public func XCTAssertNotEqualWithAccuracy<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+    XCTAssertNotEqual(expression1, expression2, accuracy: accuracy, message, file: file, line: line)
 }
 
 public func XCTAssertNotNil(_ expression: @autoclosure () throws -> Any?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {

--- a/Tests/Functional/FailureMessagesTestCase/main.swift
+++ b/Tests/Functional/FailureMessagesTestCase/main.swift
@@ -94,10 +94,10 @@ class FailureMessagesTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqualWithAccuracy failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertEqualWithAccuracy : XCTAssertEqual failed: \("1\.0"\) is not equal to \("2\.0"\) \+/- \("0\.1"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertEqualWithAccuracy' failed \(\d+\.\d+ seconds\)
     func testAssertEqualWithAccuracy() {
-        XCTAssertEqualWithAccuracy(1, 2, accuracy: 0.1, "message", file: "test.swift")
+        XCTAssertEqual(1, 2, accuracy: 0.1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertFalse' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
@@ -185,10 +185,10 @@ class FailureMessagesTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
+// CHECK: test.swift:[[@LINE+3]]: error: FailureMessagesTestCase.testAssertNotEqualWithAccuracy : XCTAssertNotEqual failed: \("1\.0"\) is equal to \("1\.0"\) \+/- \("0\.1"\) - message
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotEqualWithAccuracy' failed \(\d+\.\d+ seconds\)
     func testAssertNotEqualWithAccuracy() {
-        XCTAssertNotEqualWithAccuracy(1, 1, 0.1, "message", file: "test.swift")
+        XCTAssertNotEqual(1, 1, accuracy: 0.1, "message", file: "test.swift")
     }
 
 // CHECK: Test Case 'FailureMessagesTestCase.testAssertNotNil' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+

--- a/Tests/Functional/NegativeAccuracyTestCase/main.swift
+++ b/Tests/Functional/NegativeAccuracyTestCase/main.swift
@@ -27,27 +27,27 @@ class NegativeAccuracyTestCase: XCTestCase {
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_passes' passed \(\d+\.\d+ seconds\)
     func test_equalWithAccuracy_passes() {
-        XCTAssertEqualWithAccuracy(0, 0.1, accuracy: -0.1)
+        XCTAssertEqual(0, 0.1, accuracy: -0.1)
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqualWithAccuracy failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
+// CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqual failed: \(\"0\.0\"\) is not equal to \(\"0\.2\"\) \+\/- \(\"-0\.1\"\) - $
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\)
     func test_equalWithAccuracy_fails() {
-        XCTAssertEqualWithAccuracy(0, 0.2, accuracy: -0.1)
+        XCTAssertEqual(0, 0.2, accuracy: -0.1)
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\)
     func test_notEqualWithAccuracy_passes() {
-        XCTAssertNotEqualWithAccuracy(1, 2, -0.5)
+        XCTAssertNotEqual(1, 2, accuracy: -0.5)
     }
 
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqualWithAccuracy failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
+// CHECK: .*/NegativeAccuracyTestCase/main.swift:[[@LINE+3]]: error: NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqual failed: \("1\.0"\) is equal to \("2\.0"\) \+/- \("-1\.0"\) - $
 // CHECK: Test Case 'NegativeAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\)
     func test_notEqualWithAccuracy_fails() {
-        XCTAssertNotEqualWithAccuracy(1, 2, -1)
+        XCTAssertNotEqual(1, 2, accuracy: -1)
     }
 }
 // CHECK: Test Suite 'NegativeAccuracyTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+

--- a/build_script.py
+++ b/build_script.py
@@ -91,6 +91,7 @@ class DarwinStrategy:
             "-configuration {style_options} "
             "SWIFT_EXEC=\"{swiftc}\" "
             "SWIFT_LINK_OBJC_RUNTIME=YES "
+            "INDEX_ENABLE_DATA_STORE=NO "
             "SYMROOT=\"{build_dir}\" OBJROOT=\"{build_dir}\"".format(
                 swiftc=swiftc,
                 build_dir=build_dir,
@@ -122,6 +123,7 @@ class DarwinStrategy:
             "-configuration {style_options} "
             "SWIFT_EXEC=\"{swiftc}\" "
             "SWIFT_LINK_OBJC_RUNTIME=YES "
+            "INDEX_ENABLE_DATA_STORE=NO "
             "SYMROOT=\"{build_dir}\" OBJROOT=\"{build_dir}\" ".format(
                 swiftc=swiftc,
                 build_dir=build_dir,


### PR DESCRIPTION
This is to bring Corelibs XCTest in line with changes made in the main XCTest Swift overlay for Xcode 9 (see [here](https://github.com/apple/swift/commit/c5ff1f2cac8da6a14330f4b033b94c7c926d2126#diff-b1b9777d77a07ee6e082cce7a2c52608)).

`XCTAssertEqualWithAccuracy` and `XCTAssertNotEqualWithAccuracy` are now deprecated in favor of `XCTAssertEqual(_:_:accuracy:file:line:)` and `XCTAssertNotEqual(_:_:accuracy:file:line:)`.

This fixes an inconsistency where `XCTAssertEqualWithAccuracy` had `accuracy:` as a named parameter, but `XCTAssertNotEqualWithAccuracy` had it unnamed.