### PR TITLE
Fix ld warning

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -487,10 +487,7 @@
 			buildSettings = {
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = (
-					$BUILT_PRODUCTS_DIR,
-					"../swift-corelibs-foundation/build/Debug",
-				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks @loader_path/Frameworks";
@@ -517,7 +514,7 @@
 			buildSettings = {
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = $BUILT_PRODUCTS_DIR;
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
When building the `SwiftXCTest` target in Xcode 9 beta 4, `ld` reports the following warning:

```
Ld /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug/SwiftXCTest.framework/Versions/A/SwiftXCTest normal x86_64
    cd /Users/ipartrid/swift-corelibs-xctest
    export MACOSX_DEPLOYMENT_TARGET=10.11
    /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -L/Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug -F/Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug -F../swift-corelibs-foundation/build/Debug -filelist /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/XCTest.build/Debug/SwiftXCTest.build/Objects-normal/x86_64/SwiftXCTest.LinkFileList -install_name @rpath/SwiftXCTest.framework/Versions/A/SwiftXCTest -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mmacosx-version-min=10.11 -Xlinker -object_path_lto -Xlinker /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/XCTest.build/Debug/SwiftXCTest.build/Objects-normal/x86_64/SwiftXCTest_lto.o -Xlinker -export_dynamic -Xlinker -no_deduplicate -fobjc-link-runtime -L/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -Xlinker -add_ast_path -Xlinker /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/XCTest.build/Debug/SwiftXCTest.build/Objects-normal/x86_64/SwiftXCTest.swiftmodule -framework SwiftFoundation -single_module -Xlinker -dependency_info -Xlinker /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Intermediates.noindex/XCTest.build/Debug/SwiftXCTest.build/Objects-normal/x86_64/SwiftXCTest_dependency_info.dat -o /Users/ipartrid/Library/Developer/Xcode/DerivedData/Foundation-dlbuoxyagtlausbjtyopapynebeb/Build/Products/Debug/SwiftXCTest.framework/Versions/A/SwiftXCTest

ld: warning: directory not found for option '-F../swift-corelibs-foundation/build/Debug'
```

As far as I can tell, this directory is just not used by the build system and I'm not sure why it's been added to the Framework Search Paths for that target.

This PR removes the references, and hence the warning.