### PR TITLE
[SR-5643] Adopt Swift 4 API adjustments from Apple XCTest

### DIFF
--- a/Sources/XCTest/Private/PerformanceMeter.swift
+++ b/Sources/XCTest/Private/PerformanceMeter.swift
@@ -40,7 +40,7 @@ internal protocol PerformanceMeterDelegate {
     ///   as average, and standard deviation
     /// - Parameter file: The source file name where the measurement was invoked
     /// - Parameter line: The source line number where the measurement was invoked
-    func recordMeasurements(results: String, file: StaticString, line: UInt)
+    func recordMeasurements(results: String, file: StaticString, line: Int)
 
     /// Reports a test failure from the analysis of performance measurements.
     /// This can currently be caused by an unexpectedly large standard deviation
@@ -48,14 +48,14 @@ internal protocol PerformanceMeterDelegate {
     /// - Parameter description: An explanation of the failure
     /// - Parameter file: The source file name where the measurement was invoked
     /// - Parameter line: The source line number where the measurement was invoked
-    func recordFailure(description: String, file: StaticString, line: UInt)
+    func recordFailure(description: String, file: StaticString, line: Int)
 
     /// Reports a misuse of the `PerformanceMeter` API, such as calling `
     /// startMeasuring` multiple times.
     /// - Parameter description: An explanation of the misuse
     /// - Parameter file: The source file name where the misuse occurred
     /// - Parameter line: The source line number where the misuse occurred
-    func recordAPIViolation(description: String, file: StaticString, line: UInt)
+    func recordAPIViolation(description: String, file: StaticString, line: Int)
 }
 
 /// - Bug: This class is intended to be `internal` but is public to work around
@@ -97,16 +97,16 @@ public final class PerformanceMeter {
     private let metrics: [PerformanceMetric]
     private let delegate: PerformanceMeterDelegate
     private let invocationFile: StaticString
-    private let invocationLine: UInt
+    private let invocationLine: Int
 
-    private init(metrics: [PerformanceMetric], delegate: PerformanceMeterDelegate, file: StaticString, line: UInt) {
+    private init(metrics: [PerformanceMetric], delegate: PerformanceMeterDelegate, file: StaticString, line: Int) {
         self.metrics = metrics
         self.delegate = delegate
         self.invocationFile = file
         self.invocationLine = line
     }
 
-    static func measureMetrics(_ metricNames: [String], delegate: PerformanceMeterDelegate, file: StaticString = #file, line: UInt = #line, for block: (PerformanceMeter) -> Void) {
+    static func measureMetrics(_ metricNames: [String], delegate: PerformanceMeterDelegate, file: StaticString = #file, line: Int = #line, for block: (PerformanceMeter) -> Void) {
         do {
             let metrics = try self.metrics(forNames: metricNames)
             let meter = PerformanceMeter(metrics: metrics, delegate: delegate, file: file, line: line)
@@ -116,7 +116,7 @@ public final class PerformanceMeter {
         }
     }
 
-    func startMeasuring(file: StaticString = #file, line: UInt = #line) {
+    func startMeasuring(file: StaticString = #file, line: Int = #line) {
         guard state == .iterationUnstarted else {
             return recordAPIViolation(.startMeasuringAlreadyCalled, file: file, line: line)
         }
@@ -124,7 +124,7 @@ public final class PerformanceMeter {
         metrics.forEach { $0.startMeasuring() }
     }
 
-    func stopMeasuring(file: StaticString = #file, line: UInt = #line) {
+    func stopMeasuring(file: StaticString = #file, line: Int = #line) {
         guard state != .iterationUnstarted else {
             return recordAPIViolation(.stopBeforeStarting, file: file, line: line)
         }
@@ -195,7 +195,7 @@ public final class PerformanceMeter {
         }
     }
 
-    private func recordAPIViolation(_ error: Error, file: StaticString, line: UInt) {
+    private func recordAPIViolation(_ error: Error, file: StaticString, line: Int) {
         state = .measurementAborted
         delegate.recordAPIViolation(description: String(describing: error), file: file, line: line)
     }

--- a/Sources/XCTest/Private/PrintObserver.swift
+++ b/Sources/XCTest/Private/PrintObserver.swift
@@ -24,7 +24,7 @@ internal class PrintObserver: XCTestObservation {
         printAndFlush("Test Case '\(testCase.name)' started at \(dateFormatter.string(from: testCase.testRun!.startDate!))")
     }
 
-    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {
+    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
         let file = filePath ?? "<unknown>"
         printAndFlush("\(file):\(lineNumber): error: \(testCase.name) : \(description)")
     }
@@ -68,7 +68,7 @@ internal class PrintObserver: XCTestObservation {
 }
 
 extension PrintObserver: XCTestInternalObservation {
-    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: UInt) {
+    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: Int) {
         printAndFlush("\(file):\(line): Test Case '\(testCase.name)' measured \(results)")
     }
 }

--- a/Sources/XCTest/Private/XCPredicateExpectation.swift
+++ b/Sources/XCTest/Private/XCPredicateExpectation.swift
@@ -18,7 +18,7 @@ internal class XCPredicateExpectation: XCTestExpectation {
     internal let handler: XCPredicateExpectationHandler?
     private let evaluationInterval = 0.01
     
-    internal init(predicate: NSPredicate, object: AnyObject, description: String, file: StaticString, line: UInt, testCase: XCTestCase, handler: XCPredicateExpectationHandler? = nil) {
+    internal init(predicate: NSPredicate, object: AnyObject, description: String, file: StaticString, line: Int, testCase: XCTestCase, handler: XCPredicateExpectationHandler? = nil) {
         self.predicate = predicate
         self.object = object
         self.handler = handler

--- a/Sources/XCTest/Private/XCTestInternalObservation.swift
+++ b/Sources/XCTest/Private/XCTestInternalObservation.swift
@@ -23,10 +23,10 @@ internal protocol XCTestInternalObservation: XCTestObservation {
     ///   reported, if available.
     /// - Parameter line: The line number in the source file where the failure
     ///   was reported.
-    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: UInt)
+    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: Int)
 }
 
 // All `XCInternalTestObservation` methods are optional, so empty default implementations are provided
 internal extension XCTestInternalObservation {
-    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: UInt) {}
+    func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: Int) {}
 }

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -139,7 +139,7 @@ public extension XCTestCase {
                 // If the test failed, send an error object.
                 error = NSError(
                     domain: XCTestErrorDomain,
-                    code: XCTestErrorCode.timeoutWhileWaiting.rawValue,
+                    code: XCTestError.Code.timeoutWhileWaiting.rawValue,
                     userInfo: [:])
             }
             completionHandler(error)

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -33,7 +33,7 @@ public extension XCTestCase {
     ///   between these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    @discardableResult func expectation(description: String, file: StaticString = #file, line: UInt = #line) -> XCTestExpectation {
+    @discardableResult func expectation(description: String, file: StaticString = #file, line: Int = #line) -> XCTestExpectation {
         let expectation = XCTestExpectation(
             description: description,
             file: file,
@@ -68,7 +68,7 @@ public extension XCTestCase {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    func waitForExpectations(timeout: TimeInterval, file: StaticString = #file, line: UInt = #line, handler: XCWaitCompletionHandler? = nil) {
+    func waitForExpectations(timeout: TimeInterval, file: StaticString = #file, line: Int = #line, handler: XCWaitCompletionHandler? = nil) {
         // Mirror Objective-C XCTest behavior; display an unexpected test
         // failure when users wait without having first set expectations.
         // FIXME: Objective-C XCTest raises an exception for most "API

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+PredicateExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+PredicateExpectation.swift
@@ -33,7 +33,7 @@ public extension XCTestCase {
     ///   first successful evaluation will fulfill the expectation. If provided,
     ///   the handler can override that behavior which leaves the caller
     ///   responsible for fulfilling the expectation.
-    @discardableResult func expectation(for predicate: NSPredicate, evaluatedWith object: AnyObject, file: StaticString = #file, line: UInt = #line, handler: XCPredicateExpectationHandler? = nil) -> XCTestExpectation {
+    @discardableResult func expectation(for predicate: NSPredicate, evaluatedWith object: AnyObject, file: StaticString = #file, line: Int = #line, handler: XCPredicateExpectationHandler? = nil) -> XCTestExpectation {
         let expectation = XCPredicateExpectation(
             predicate: predicate,
             object: object,

--- a/Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
@@ -15,12 +15,12 @@
 public class XCTestExpectation {
     internal let description: String
     internal let file: StaticString
-    internal let line: UInt
+    internal let line: Int
 
     internal var isFulfilled = false
     internal weak var testCase: XCTestCase?
 
-    internal init(description: String, file: StaticString, line: UInt, testCase: XCTestCase) {
+    internal init(description: String, file: StaticString, line: Int, testCase: XCTestCase) {
         self.description = description
         self.file = file
         self.line = line
@@ -47,7 +47,7 @@ public class XCTestExpectation {
     ///   between these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    public func fulfill(_ file: StaticString = #file, line: UInt = #line) {
+    public func fulfill(_ file: StaticString = #file, line: Int = #line) {
         // FIXME: Objective-C XCTest emits failures when expectations are
         //        fulfilled after the test cases that generated those
         //        expectations have completed. Similarly, this should cause an

--- a/Sources/XCTest/Public/XCAbstractTest.swift
+++ b/Sources/XCTest/Public/XCAbstractTest.swift
@@ -22,7 +22,7 @@ open class XCTest {
     }
 
     /// Number of test cases. Must be overridden by subclasses.
-    open var testCaseCount: UInt {
+    open var testCaseCount: Int {
         fatalError("Must be overridden by subclasses.")
     }
 

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -93,7 +93,7 @@ private func _XCTEvaluateAssertion(_ assertion: _XCTAssertion, message: @autoclo
             currentTestCase.recordFailure(
                 withDescription: "\(result.failureDescription(assertion)) - \(message())",
                 inFile: String(describing: file),
-                atLine: line,
+                atLine: Int(line),
                 expected: result.isExpected)
         }
     }

--- a/Sources/XCTest/Public/XCTestCase+Performance.swift
+++ b/Sources/XCTest/Public/XCTestCase+Performance.swift
@@ -49,7 +49,7 @@ public extension XCTestCase {
     ///   these methods are not exactly identical between these environments. To 
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
-    func measure(file: StaticString = #file, line: UInt = #line, block: () -> Void) {
+    func measure(file: StaticString = #file, line: Int = #line, block: () -> Void) {
         measureMetrics(type(of: self).defaultPerformanceMetrics(),
                        automaticallyStartMeasuring: true,
                        file: file,
@@ -103,7 +103,7 @@ public extension XCTestCase {
     ///   these methods are not exactly identical between these environments. To
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
-    func measureMetrics(_ metrics: [String], automaticallyStartMeasuring: Bool, file: StaticString = #file, line: UInt = #line, for block: () -> Void) {
+    func measureMetrics(_ metrics: [String], automaticallyStartMeasuring: Bool, file: StaticString = #file, line: Int = #line, for block: () -> Void) {
         guard _performanceMeter == nil else {
             return recordAPIViolation(description: "Can only record one set of metrics per test method.", file: file, line: line)
         }
@@ -125,7 +125,7 @@ public extension XCTestCase {
     ///   these methods are not exactly identical between these environments. To
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
-    func startMeasuring(file: StaticString = #file, line: UInt = #line) {
+    func startMeasuring(file: StaticString = #file, line: Int = #line) {
         guard let performanceMeter = _performanceMeter, !performanceMeter.didFinishMeasuring else {
             return recordAPIViolation(description: "Cannot start measuring. startMeasuring() is only supported from a block passed to measureMetrics(...).", file: file, line: line)
         }
@@ -140,7 +140,7 @@ public extension XCTestCase {
     ///   these methods are not exactly identical between these environments. To
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
-    func stopMeasuring(file: StaticString = #file, line: UInt = #line) {
+    func stopMeasuring(file: StaticString = #file, line: Int = #line) {
         guard let performanceMeter = _performanceMeter, !performanceMeter.didFinishMeasuring else {
             return recordAPIViolation(description: "Cannot stop measuring. stopMeasuring() is only supported from a block passed to measureMetrics(...).", file: file, line: line)
         }
@@ -149,18 +149,18 @@ public extension XCTestCase {
 }
 
 extension XCTestCase: PerformanceMeterDelegate {
-    internal func recordAPIViolation(description: String, file: StaticString, line: UInt) {
+    internal func recordAPIViolation(description: String, file: StaticString, line: Int) {
         recordFailure(withDescription: "API violation - \(description)",
                       inFile: String(describing: file),
                       atLine: line,
                       expected: false)
     }
 
-    internal func recordMeasurements(results: String, file: StaticString, line: UInt) {
+    internal func recordMeasurements(results: String, file: StaticString, line: Int) {
         XCTestObservationCenter.shared().testCase(self, didMeasurePerformanceResults: results, file: file, line: line)
     }
 
-    internal func recordFailure(description: String, file: StaticString, line: UInt) {
+    internal func recordFailure(description: String, file: StaticString, line: Int) {
         recordFailure(withDescription: "failed: " + description, inFile: String(describing: file), atLine: line, expected: true)
     }
 }

--- a/Sources/XCTest/Public/XCTestCase+Performance.swift
+++ b/Sources/XCTest/Public/XCTestCase+Performance.swift
@@ -157,7 +157,7 @@ extension XCTestCase: PerformanceMeterDelegate {
     }
 
     internal func recordMeasurements(results: String, file: StaticString, line: Int) {
-        XCTestObservationCenter.shared().testCase(self, didMeasurePerformanceResults: results, file: file, line: line)
+        XCTestObservationCenter.shared.testCase(self, didMeasurePerformanceResults: results, file: file, line: line)
     }
 
     internal func recordFailure(description: String, file: StaticString, line: Int) {

--- a/Sources/XCTest/Public/XCTestCase+Performance.swift
+++ b/Sources/XCTest/Public/XCTestCase+Performance.swift
@@ -11,8 +11,30 @@
 //  Methods on XCTestCase for testing the performance of code blocks.
 //
 
-/// Records wall clock time in seconds between `startMeasuring`/`stopMeasuring`.
-public let XCTPerformanceMetric_WallClockTime = WallClockTimeMetric.name
+public struct XCTPerformanceMetric : RawRepresentable, Equatable, Hashable {
+    public private(set) var rawValue: String
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var hashValue: Int {
+        return rawValue.hashValue
+    }
+
+    public static func ==(_ lhs: XCTPerformanceMetric, _ rhs: XCTPerformanceMetric) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+}
+
+public extension XCTPerformanceMetric {
+    /// Records wall clock time in seconds between `startMeasuring`/`stopMeasuring`.
+    public static let wallClockTime = XCTPerformanceMetric(rawValue: WallClockTimeMetric.name)
+}
 
 /// The following methods are called from within a test method to carry out 
 /// performance testing on blocks of code.
@@ -21,11 +43,11 @@ public extension XCTestCase {
     /// The names of the performance metrics to measure when invoking `measure(block:)`. 
     /// Returns `XCTPerformanceMetric_WallClockTime` by default. Subclasses can
     /// override this to change the behavior of `measure(block:)`
-    class func defaultPerformanceMetrics() -> [String] {
-        return [XCTPerformanceMetric_WallClockTime]
+    class var defaultPerformanceMetrics: [XCTPerformanceMetric] {
+        return [.wallClockTime]
     }
 
-    /// Call from a test method to measure resources (`defaultPerformanceMetrics()`)
+    /// Call from a test method to measure resources (`defaultPerformanceMetrics`)
     /// used by the block in the current process.
     ///
     ///     func testPerformanceOfMyFunction() {
@@ -50,7 +72,7 @@ public extension XCTestCase {
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
     func measure(file: StaticString = #file, line: Int = #line, block: () -> Void) {
-        measureMetrics(type(of: self).defaultPerformanceMetrics(),
+        measureMetrics(type(of: self).defaultPerformanceMetrics,
                        automaticallyStartMeasuring: true,
                        file: file,
                        line: line,
@@ -66,7 +88,7 @@ public extension XCTestCase {
     /// may interfere the API will measure them separately.
     ///
     ///     func testMyFunction2_WallClockTime() {
-    ///         measureMetrics(type(of: self).defaultPerformanceMetrics(), automaticallyStartMeasuring: false) {
+    ///         measureMetrics(type(of: self).defaultPerformanceMetrics, automaticallyStartMeasuring: false) {
     ///
     ///             // Do setup work that needs to be done for every iteration but
     ///             // you don't want to measure before the call to `startMeasuring()`
@@ -103,12 +125,12 @@ public extension XCTestCase {
     ///   these methods are not exactly identical between these environments. To
     ///   ensure compatibility of tests between swift-corelibs-xctest and Apple
     ///   XCTest, it is not recommended to pass explicit values for `file` and `line`.
-    func measureMetrics(_ metrics: [String], automaticallyStartMeasuring: Bool, file: StaticString = #file, line: Int = #line, for block: () -> Void) {
+    func measureMetrics(_ metrics: [XCTPerformanceMetric], automaticallyStartMeasuring: Bool, file: StaticString = #file, line: Int = #line, for block: () -> Void) {
         guard _performanceMeter == nil else {
             return recordAPIViolation(description: "Can only record one set of metrics per test method.", file: file, line: line)
         }
 
-        PerformanceMeter.measureMetrics(metrics, delegate: self, file: file, line: line) { meter in
+        PerformanceMeter.measureMetrics(metrics.map({ $0.rawValue }), delegate: self, file: file, line: line) { meter in
             self._performanceMeter = meter
             if automaticallyStartMeasuring {
                 meter.startMeasuring(file: file, line: line)

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -37,7 +37,7 @@ open class XCTestCase: XCTest {
     /// A private setter for the name of this test case.
     private var _name: String
 
-    open override var testCaseCount: UInt {
+    open override var testCaseCount: Int {
         return 1
     }
 
@@ -99,7 +99,7 @@ open class XCTestCase: XCTest {
     /// - Parameter expected: `true` if the failure being reported was the
     ///   result of a failed assertion, `false` if it was the result of an
     ///   uncaught exception.
-    open func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: UInt, expected: Bool) {
+    open func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
         testRun?.recordFailure(
             withDescription: description,
             inFile: filePath,

--- a/Sources/XCTest/Public/XCTestCaseRun.swift
+++ b/Sources/XCTest/Public/XCTestCaseRun.swift
@@ -23,7 +23,7 @@ open class XCTestCaseRun: XCTestRun {
         XCTestObservationCenter.shared().testCaseDidFinish(testCase)
     }
 
-    open override func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: UInt, expected: Bool) {
+    open override func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: Int, expected: Bool) {
         super.recordFailure(
             withDescription: "\(test.name) : \(description)",
             inFile: filePath,

--- a/Sources/XCTest/Public/XCTestCaseRun.swift
+++ b/Sources/XCTest/Public/XCTestCaseRun.swift
@@ -15,12 +15,12 @@
 open class XCTestCaseRun: XCTestRun {
     open override func start() {
         super.start()
-        XCTestObservationCenter.shared().testCaseWillStart(testCase)
+        XCTestObservationCenter.shared.testCaseWillStart(testCase)
     }
 
     open override func stop() {
         super.stop()
-        XCTestObservationCenter.shared().testCaseDidFinish(testCase)
+        XCTestObservationCenter.shared.testCaseDidFinish(testCase)
     }
 
     open override func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: Int, expected: Bool) {
@@ -29,7 +29,7 @@ open class XCTestCaseRun: XCTestRun {
             inFile: filePath,
             atLine: lineNumber,
             expected: expected)
-        XCTestObservationCenter.shared().testCase(
+        XCTestObservationCenter.shared.testCase(
             testCase,
             didFailWithDescription: description,
             inFile: filePath,

--- a/Sources/XCTest/Public/XCTestErrors.swift
+++ b/Sources/XCTest/Public/XCTestErrors.swift
@@ -14,14 +14,32 @@
 /// The domain used by errors produced by the XCTest library.
 public let XCTestErrorDomain = "org.swift.XCTestErrorDomain"
 
-/// Error codes for errors in the XCTestErrorDomain.
-public enum XCTestErrorCode : Int {
+/// Describes an error in the XCTestErrorDomain.
+public struct XCTestError : _BridgedStoredNSError {
+    public let _nsError: NSError
+
+    public init(_nsError error: NSError) {
+        precondition(error.domain == XCTestErrorDomain)
+        self._nsError = error
+    }
+
+    public static var _nsErrorDomain: String { return XCTestErrorDomain }
+
+    public enum Code : Int, _ErrorCodeProtocol {
+        public typealias _ErrorType = XCTestError
+
+        case timeoutWhileWaiting
+        case failureWhileWaiting
+    }
+}
+
+public extension XCTestError {
     /// Indicates that one or more expectations failed to be fulfilled in time
     /// during a call to `waitForExpectations(timeout:handler:)`
-    case timeoutWhileWaiting
+    public static var timeoutWhileWaiting: XCTestError.Code { return .timeoutWhileWaiting }
 
     /// Indicates that a test assertion failed while waiting for expectations
     /// during a call to `waitForExpectations(timeout:handler:)`
     /// FIXME: swift-corelibs-xctest does not currently produce this error code.
-    case failureWhileWaiting
+    public static var failureWhileWaiting: XCTestError.Code { return .failureWhileWaiting }
 }

--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -89,7 +89,7 @@ public func XCTMain(_ testCases: [XCTestCaseEntry]) -> Never {
         exit(0)
     case .run(selectedTestName: _):
         // Add a test observer that prints test progress to stdout.
-        let observationCenter = XCTestObservationCenter.shared()
+        let observationCenter = XCTestObservationCenter.shared
         observationCenter.addTestObserver(PrintObserver())
 
         observationCenter.testBundleWillStart(testBundle)

--- a/Sources/XCTest/Public/XCTestObservation.swift
+++ b/Sources/XCTest/Public/XCTestObservation.swift
@@ -39,7 +39,7 @@ public protocol XCTestObservation: class {
     ///   was reported, if available.
     /// - Parameter lineNumber: The line number in the source file where the
     ///   failure was reported.
-    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt)
+    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int)
 
     /// Called just after a test finishes executing.
     /// - Parameter testCase: The test case that finished. Its `name` property 
@@ -66,7 +66,7 @@ public extension XCTestObservation {
     func testBundleWillStart(_ testBundle: Bundle) {}
     func testSuiteWillStart(_ testSuite: XCTestSuite) {}
     func testCaseWillStart(_ testCase: XCTestCase) {}
-    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {}
+    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {}
     func testCaseDidFinish(_ testCase: XCTestCase) {}
     func testSuiteDidFinish(_ testSuite: XCTestSuite) {}
     func testBundleDidFinish(_ testBundle: Bundle) {}

--- a/Sources/XCTest/Public/XCTestObservationCenter.swift
+++ b/Sources/XCTest/Public/XCTestObservationCenter.swift
@@ -11,18 +11,19 @@
 //  Notification center for test run progress events.
 //
 
+private let _sharedCenter: XCTestObservationCenter = XCTestObservationCenter()
+
 /// Provides a registry for objects wishing to be informed about progress
 /// during the course of a test run. Observers must implement the
 /// `XCTestObservation` protocol
 /// - seealso: `XCTestObservation`
 public class XCTestObservationCenter {
 
-    private static var center = XCTestObservationCenter()
     private var observers = Set<ObjectWrapper<XCTestObservation>>()
 
     /// Registration should be performed on this shared instance
-    public class func shared() -> XCTestObservationCenter {
-        return center
+    public class var shared: XCTestObservationCenter {
+        return _sharedCenter
     }
 
     /// Register an observer to receive future events during a test run. The order

--- a/Sources/XCTest/Public/XCTestObservationCenter.swift
+++ b/Sources/XCTest/Public/XCTestObservationCenter.swift
@@ -49,7 +49,7 @@ public class XCTestObservationCenter {
         forEachObserver { $0.testCaseWillStart(testCase) }
     }
 
-    internal func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {
+    internal func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
         forEachObserver { $0.testCase(testCase, didFailWithDescription: description, inFile: filePath, atLine: lineNumber) }
     }
 
@@ -65,7 +65,7 @@ public class XCTestObservationCenter {
         forEachObserver { $0.testBundleDidFinish(testBundle) }
     }
 
-    internal func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: UInt) {
+    internal func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: Int) {
         forEachInternalObserver { $0.testCase(testCase, didMeasurePerformanceResults: results, file: file, line: line) }
     }
 

--- a/Sources/XCTest/Public/XCTestRun.swift
+++ b/Sources/XCTest/Public/XCTestRun.swift
@@ -42,22 +42,22 @@ open class XCTestRun {
     }
 
     /// The number of tests in the run.
-    open var testCaseCount: UInt {
+    open var testCaseCount: Int {
         return test.testCaseCount
     }
 
     /// The number of test executions recorded during the run.
-    open private(set) var executionCount: UInt = 0
+    open private(set) var executionCount: Int = 0
 
     /// The number of test failures recorded during the run.
-    open private(set) var failureCount: UInt = 0
+    open private(set) var failureCount: Int = 0
 
     /// The number of uncaught exceptions recorded during the run.
-    open private(set) var unexpectedExceptionCount: UInt = 0
+    open private(set) var unexpectedExceptionCount: Int = 0
 
     /// The total number of test failures and uncaught exceptions recorded
     /// during the run.
-    open var totalFailureCount: UInt {
+    open var totalFailureCount: Int {
         return failureCount + unexpectedExceptionCount
     }
 
@@ -118,7 +118,7 @@ open class XCTestRun {
     /// - Parameter expected: `true` if the failure being reported was the
     ///   result of a failed assertion, `false` if it was the result of an
     ///   uncaught exception.
-    func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: UInt, expected: Bool) {
+    func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: Int, expected: Bool) {
         guard isStarted else {
             fatalError("Invalid attempt to record a failure for a test run " +
                        "that has not yet been started: \(self)")

--- a/Sources/XCTest/Public/XCTestSuite.swift
+++ b/Sources/XCTest/Public/XCTestSuite.swift
@@ -30,7 +30,7 @@ open class XCTestSuite: XCTest {
     private let _name: String
 
     /// The number of test cases in this suite.
-    open override var testCaseCount: UInt {
+    open override var testCaseCount: Int {
         return tests.reduce(0) { $0 + $1.testCaseCount }
     }
 

--- a/Sources/XCTest/Public/XCTestSuiteRun.swift
+++ b/Sources/XCTest/Public/XCTestSuiteRun.swift
@@ -36,12 +36,12 @@ open class XCTestSuiteRun: XCTestRun {
 
     open override func start() {
         super.start()
-        XCTestObservationCenter.shared().testSuiteWillStart(testSuite)
+        XCTestObservationCenter.shared.testSuiteWillStart(testSuite)
     }
 
     open override func stop() {
         super.stop()
-        XCTestObservationCenter.shared().testSuiteDidFinish(testSuite)
+        XCTestObservationCenter.shared.testSuiteDidFinish(testSuite)
     }
 
     /// The test run for each of the tests in this suite.

--- a/Sources/XCTest/Public/XCTestSuiteRun.swift
+++ b/Sources/XCTest/Public/XCTestSuiteRun.swift
@@ -19,18 +19,18 @@ open class XCTestSuiteRun: XCTestRun {
     }
 
     /// The combined execution count of each test case run in the suite.
-    open override var executionCount: UInt {
+    open override var executionCount: Int {
         return testRuns.reduce(0) { $0 + $1.executionCount }
     }
 
     /// The combined failure count of each test case run in the suite.
-    open override var failureCount: UInt {
+    open override var failureCount: Int {
         return testRuns.reduce(0) { $0 + $1.failureCount }
     }
 
     /// The combined unexpected failure count of each test case run in the
     /// suite.
-    open override var unexpectedExceptionCount: UInt {
+    open override var unexpectedExceptionCount: Int {
         return testRuns.reduce(0) { $0 + $1.unexpectedExceptionCount }
     }
 

--- a/Tests/Functional/Asynchronous/Handler/main.swift
+++ b/Tests/Functional/Asynchronous/Handler/main.swift
@@ -23,7 +23,7 @@ class HandlerTestCase: XCTestCase {
         self.waitForExpectations(timeout: 0.2) { error in
             XCTAssertNotNil(error, "Expectation handlers for unfulfilled expectations should not be nil.")
             XCTAssertEqual(error?.domain, XCTestErrorDomain, "The error domain should be XCTest's own error domain")
-            XCTAssertEqual(error?.code, XCTestErrorCode.timeoutWhileWaiting.rawValue, "The error code should indicate that a timeout occurred")
+            XCTAssertEqual(error?.code, XCTestError.Code.timeoutWhileWaiting.rawValue, "The error code should indicate that a timeout occurred")
             handlerWasCalled = true
         }
         XCTAssertTrue(handlerWasCalled)

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -32,7 +32,7 @@ class Observer: XCTestObservation {
         startedTestCaseNames.append(testCase.name)
     }
 
-    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {
+    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
         failureDescriptions.append(description)
     }
 

--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -50,7 +50,7 @@ class Observer: XCTestObservation {
 }
 
 let observer = Observer()
-XCTestObservationCenter.shared().addTestObserver(observer)
+XCTestObservationCenter.shared.addTestObserver(observer)
 
 // CHECK: Test Suite 'Observation' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 class Observation: XCTestCase {
@@ -90,7 +90,7 @@ class Observation: XCTestCase {
         XCTAssertEqual(observer.finishedTestCaseNames,["Observation.test_one"])
         XCTAssertEqual(observer.finishedBundlePaths.count, 0)
 
-        XCTestObservationCenter.shared().removeTestObserver(observer)
+        XCTestObservationCenter.shared.removeTestObserver(observer)
     }
 
 // CHECK: Test Case 'Observation.test_three' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
@@ -101,7 +101,7 @@ class Observation: XCTestCase {
         XCTAssertEqual(observer.finishedTestCaseNames,["Observation.test_one"])
         XCTAssertEqual(observer.finishedBundlePaths.count, 0)
 
-        XCTestObservationCenter.shared().addTestObserver(observer)
+        XCTestObservationCenter.shared.addTestObserver(observer)
     }
 }
 

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -21,7 +21,7 @@ class Observer: XCTestObservation {
     }
 
     func testCaseWillStart(_ testCase: XCTestCase) {}
-    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: UInt) {}
+    func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {}
     func testCaseDidFinish(_ testCase: XCTestCase) {}
 
     func testSuiteDidFinish(_ testSuite: XCTestSuite) {

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -32,7 +32,7 @@ class Observer: XCTestObservation {
 }
 
 let observer = Observer()
-XCTestObservationCenter.shared().addTestObserver(observer)
+XCTestObservationCenter.shared.addTestObserver(observer)
 
 class SkippedTestCase: XCTestCase {
     static var allTests = {

--- a/Tests/Functional/Performance/Misuse/main.swift
+++ b/Tests/Functional/Performance/Misuse/main.swift
@@ -21,20 +21,20 @@ class PerformanceMisuseTestCase: XCTestCase {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails : API violation - Can only record one set of metrics per test method.
         measure {}
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails : API violation - Can only record one set of metrics per test method.
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true) {}
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {}
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMultipleInOneTest_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndNotStartingOrEnding_fails() {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails : API violation - startMeasuring\(\) must be called during the block.
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {}
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {}
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndNotStartingOrEnding_fails' failed \(\d+\.\d+ seconds\)
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndStoppingWithoutStarting_fails() {
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingWithoutStarting_fails : API violation - Cannot stop measuring before starting measuring.
             self.stopMeasuring()
         }
@@ -43,7 +43,7 @@ class PerformanceMisuseTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStartingTwice_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndStartingTwice_fails() {
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
             // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStartingTwice_fails : API violation - Already called startMeasuring\(\) once this iteration.
             self.startMeasuring()
@@ -53,7 +53,7 @@ class PerformanceMisuseTestCase: XCTestCase {
 
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingTwice_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     func test_whenMeasuringMetricsAndStoppingTwice_fails() {
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
             self.stopMeasuring()
             // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_whenMeasuringMetricsAndStoppingTwice_fails : API violation - Already called stopMeasuring\(\) once this iteration.
@@ -104,7 +104,7 @@ class PerformanceMisuseTestCase: XCTestCase {
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     func test_measuringUnknownMetric_fails() {
         // CHECK: .*/Misuse/main.swift:[[@LINE+1]]: error: PerformanceMisuseTestCase.test_measuringUnknownMetric_fails : API violation - Unknown metric: UnladenAirspeedVelocity
-        measureMetrics(["UnladenAirspeedVelocity"], automaticallyStartMeasuring: true) {}
+        measureMetrics([XCTPerformanceMetric("UnladenAirspeedVelocity")], automaticallyStartMeasuring: true) {}
     }
     // CHECK: Test Case 'PerformanceMisuseTestCase.test_measuringUnknownMetric_fails' failed \(\d+\.\d+ seconds\)
 

--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -30,7 +30,7 @@ class PerformanceTestCase: XCTestCase {
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithAutomaticStartAndStop' passed \(\d+\.\d+ seconds\)
     func test_measuresMetricsWithAutomaticStartAndStop() {
         var iterationCount = 0
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true, for: {
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: true, for: {
             iterationCount += 1
         })
         XCTAssertEqual(iterationCount, 10)
@@ -40,7 +40,7 @@ class PerformanceTestCase: XCTestCase {
     // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' measured \[Time, seconds\] .*
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithManualStartAndStop' passed \(\d+\.\d+ seconds\)
     func test_measuresMetricsWithManualStartAndStop() {
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
             self.stopMeasuring()
         }
@@ -50,7 +50,7 @@ class PerformanceTestCase: XCTestCase {
     // CHECK: .*/Performance/main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' measured \[Time, seconds\] .*
     // CHECK: Test Case 'PerformanceTestCase.test_measuresMetricsWithoutExplicitStop' passed \(\d+\.\d+ seconds\)
     func test_measuresMetricsWithoutExplicitStop() {
-        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false) {
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()
         }
     }
@@ -58,7 +58,7 @@ class PerformanceTestCase: XCTestCase {
     // CHECK: Test Case 'PerformanceTestCase.test_hasWallClockAsDefaultPerformanceMetric' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     // CHECK: Test Case 'PerformanceTestCase.test_hasWallClockAsDefaultPerformanceMetric' passed \(\d+\.\d+ seconds\)
     func test_hasWallClockAsDefaultPerformanceMetric() {
-        XCTAssertEqual(PerformanceTestCase.defaultPerformanceMetrics(), [XCTPerformanceMetric_WallClockTime])
+        XCTAssertEqual(PerformanceTestCase.defaultPerformanceMetrics, [.wallClockTime])
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+


### PR DESCRIPTION
In Xcode 9, XCTest underwent a bit of a "Swiftification" effort to adopt more modern Swift idioms and improve how its APIs get presented in Swift 4. This PR adopts those changes here as well. They include:

* Migrate from `UInt` -> `Int`. Prior to Swift 4, several XCTest APIs were brought into Swift using the
`UInt` type, in contrast to other Apple system frameworks which consistently used `Int`. In Swift 4, XCTest began being treated as a system framework and now uses `Int` as well.
* Make `XCTestObservationCenter.shared` a class property instead of class function.
* Add an `XCTestError` struct. This is to match the struct generated by the Objective-C importer for
Apple XCTest due to its `XCTestErrorCode` having been marked with the `NSErrorDomain` API note.
* Add `XCTPerformanceMetric` string enum. In Xcode 9, the `XCTPerformanceMetric_WallClockTime` string constant was turned into a string enumeration to improve the ability to use strong typing
at call sites using it. At the same time, the `defaultPerformanceMetrics` class function on `XCTestCase` was changed to be a class property.