### PR TITLE
Facilitate implicit import of Dispatch in Foundation

### DIFF
--- a/Sources/XCTest/Private/PrintObserver.swift
+++ b/Sources/XCTest/Private/PrintObserver.swift
@@ -59,7 +59,9 @@ internal class PrintObserver: XCTestObservation {
 
     fileprivate func printAndFlush(_ message: String) {
         print(message)
+        #if !os(Android)
         fflush(stdout)
+        #endif
     }
 
     private func formatTimeInterval(_ timeInterval: TimeInterval) -> String {

--- a/build_script.py
+++ b/build_script.py
@@ -200,13 +200,14 @@ class GenericUnixStrategy:
                 libdispatch_args=libdispatch_args,
                 source_paths=" ".join(sourcePaths)))
         run("{swiftc} -emit-library {build_dir}/XCTest.o "
-            "-L {foundation_build_dir} -lswiftGlibc -lswiftCore -lFoundation -lm "
+            "-L {dispatch_build_dir} -L {foundation_build_dir} -lswiftGlibc -lswiftCore -lFoundation -lm "
             # We embed an rpath of `$ORIGIN` to ensure other referenced
             # libraries (like `Foundation`) can be found solely via XCTest.
             "-Xlinker -rpath=\\$ORIGIN "
             "-o {build_dir}/libXCTest.so".format(
                 swiftc=swiftc,
                 build_dir=build_dir,
+                dispatch_build_dir=os.path.join(args.libdispatch_build_dir, 'src', '.libs'),
                 foundation_build_dir=foundation_build_dir))
 
         # Build the static library.


### PR DESCRIPTION
Hi Apple,

Would you consder this minor change that achieves two things: It allows XCTest to build for Android by removing a reference to stdout and it paves the way for Foundation to implicitly import Dispatch for compatibility with Darwin. As this would create a implicit link against libdispatch.so, this requires this small change so building XCTest.so knows where to find the library when building on all Linuxies.

This PR is essentially the previous PR but not modifiying Package.swift and adding the path to the lib dispatch.so library during a toolchain build to resolve: https://ci.swift.org/job/swift-corelibs-foundation-PR-Linux/119/console when we tried to have Foundation implicitly import dispatch: https://github.com/apple/swift-corelibs-foundation/pull/1206#issuecomment-328864090

Thanks,

John