### PR TITLE
[SR-1047] Run xctest_checker tests in tests

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -11,7 +11,7 @@
 import os
 import platform
 import tempfile
-
+import sys
 import lit
 
 # Set up lit config.
@@ -105,3 +105,6 @@ xctest_checker = os.path.join(
     'xctest_checker',
     'xctest_checker.py')
 config.substitutions.append(('%{xctest_checker}', xctest_checker))
+
+# Add Python to run xctest_checker.py tests as part of XCTest tests
+config.substitutions.append( ('%{python}', sys.executable) )

--- a/Tests/Functional/xctest_checker/main.swift
+++ b/Tests/Functional/xctest_checker/main.swift
@@ -1,0 +1,1 @@
+// RUN: %{python} -m unittest discover


### PR DESCRIPTION
swift-corelibs-xctest uses a Python program called xctest_checker to run its functional test suite. That program itself has unit tests, written in Python.
These unit tests should be run as part of the greater XCTest test suite. This is probably possible by modifying the lit.cfg in the swift-corelibs-xctest project such that it picks up on a file with a RUN: directive that triggers the Python tests. See https://github.com/apple/swift/pull/778 for an example.
See llvm.org/docs/CommandGuide/lit.html for additional details on lit--it's the test runner for Swift, LLVM, and other projects, so it's nice to know about it.