### PR TITLE
[SR-906] Allow continueAfterFailure to be set

### DIFF
--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -115,12 +115,12 @@ open class XCTestCase: XCTest {
 
         // FIXME: Apple XCTest does not throw a fatal error and crash the test
         //        process, it merely prevents the remainder of a testClosure
-        //        from expecting after it's been determined that it has already
+        //        from executing after it's been determined that it has already
         //        failed. The following behavior is incorrect.
-        // FIXME: No regression tests exist for this feature. We may break it
-        //        without ever realizing.
         if !continueAfterFailure {
-            fatalError("Terminating execution due to test failure")
+            tearDown()
+            print("Terminating execution due to test failure")
+            abort()
         }
     }
 
@@ -132,17 +132,7 @@ open class XCTestCase: XCTest {
     /// class.
     open class func tearDown() {}
 
-    open var continueAfterFailure: Bool {
-        get {
-            return true
-        }
-        set {
-            // TODO: When using the Objective-C runtime, XCTest is able to throw an exception from an assert and then catch it at the frame above the test method.
-            //      This enables the framework to effectively stop all execution in the current test.
-            //      There is no such facility in Swift. Until we figure out how to get a compatible behavior,
-            //      we have decided to hard-code the value of 'true' for continue after failure.
-        }
-    }
+    open var continueAfterFailure = true
 }
 
 /// Wrapper function allowing an array of static test case methods to fit

--- a/Tests/Functional/ContinueAfterFailureTestCase/main.swift
+++ b/Tests/Functional/ContinueAfterFailureTestCase/main.swift
@@ -1,0 +1,62 @@
+// RUN: %{swiftc} %s -o %T/ContinueAfterFailureTestCase
+// RUN: %T/ContinueAfterFailureTestCase > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+// CHECK: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'ContinueAfterFailureTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class ContinueAfterFailureTestCase: XCTestCase {
+    static var allTests = {
+        return [
+            ("testDoesNotContinueAfterFailure", testDoesNotContinueAfterFailure),
+            ("testContinueAfterFailure", testContinueAfterFailure)
+        ]
+    }()
+
+    override func tearDown() {
+        super.tearDown()
+        print("In \(#function)")
+    }
+
+    // CHECK: Test Case 'ContinueAfterFailureTestCase.testDoesNotContinueAfterFailure' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: First Log in DoesNotContinueAfterFailure test
+    // CHECK: .*/ContinueAfterFailureTestCase/main.swift:[[@LINE+8]]: error: ContinueAfterFailureTestCase.testDoesNotContinueAfterFailure : XCTAssertTrue failed -
+    // CHECK: In tearDown\(\)
+    // CHECK: Terminating execution due to test failure
+    // CHECK-NOT: Second Log in DoesNotContinueAfterFailure test
+    // CHECK-NOT: Test Case 'ContinueAfterFailureTestCase.testDoesNotContinueAfterFailure' failed \(\d+\.\d+ seconds\)
+    func testDoesNotContinueAfterFailure() {
+        continueAfterFailure = false
+        print("First Log in DoesNotContinueAfterFailure test")
+        XCTAssert(false)
+        print("Second Log in DoesNotContinueAfterFailure test")
+    }
+    
+    // CHECK-NOT: Test Case 'ContinueAfterFailureTestCase.testContinueAfterFailure' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK-NOT: First Log in ContinueAfterFailure test
+    // CHECK-NOT: .*/ContinueAfterFailureTestCase/main.swift:[[@LINE+6]]: error: ContinueAfterFailureTestCase.testContinueAfterFailure : XCTAssertTrue failed -
+    // CHECK-NOT: Second Log in ContinueAfterFailure test
+    // CHECK-NOT: Test Case 'ContinueAfterFailureTestCase.testContinueAfterFailure' failed \(\d+\.\d+ seconds\)
+    func testContinueAfterFailure() {
+        continueAfterFailure = true
+        print("First Log in ContinueAfterFailure test")
+        XCTAssert(false)
+        print("Second Log in ContinueAfterFailure test")
+    }
+}
+// CHECK-NOT: Test Suite 'ContinueAfterFailureTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-NOT: \t Executed 2 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+XCTMain([testCase(ContinueAfterFailureTestCase.allTests)])
+
+// CHECK-NOT: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-NOT: \t Executed 2 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK-NOT: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-NOT: \t Executed 2 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds


### PR DESCRIPTION
[After this exchange of ideas](https://bugs.swift.org/browse/SR-906), my opinion is that for the moment we can add the feature for setting continueAfterFailure, and after that write a new task that addresses the fact that all tests stop if a failure occurs and continueAfterFailure is false.

I was thinking in something like:
[SR-XXX] Allow remaining tests to continue after a failure instead of stopping the test process
"Apple XCTest does not throw a fatal error and crash the test process, it merely prevents the remainder of a testClosure from expecting after it's been determined that it has already failed. The following behavior is incorrect."

And migrating all the conclusions we got to this new task.

What do you think?