### PR TITLE
Update minimum macOS deployment target to 10.12

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -491,7 +491,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
 					SwiftFoundation,
@@ -518,7 +518,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
 					SwiftFoundation,


### PR DESCRIPTION
Currently, building the `corelibs-foundation` test suite on High Sierra fails with

> Error: Module file's minimum deployment target is OS X v10.12

Update the Xcode project file to fix this.