### PR TITLE
Remove XCTAssert(Not)Equal overloads made obsolete by conditional conformances.

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -169,61 +169,6 @@ public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -
     }
 }
 
-public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 == value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(String(describing: value1))\") is not equal to (\"\(String(describing: value2))\")")
-        }
-    }
-}
-
-public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -> ArraySlice<T>, _ expression2: @autoclosure () throws -> ArraySlice<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 == value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
-        }
-    }
-}
-
-public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -> ContiguousArray<T>, _ expression2: @autoclosure () throws -> ContiguousArray<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 == value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
-        }
-    }
-}
-
-public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -> [T], _ expression2: @autoclosure () throws -> [T], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 == value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
-        }
-    }
-}
-
-public func XCTAssertEqual<T, U: Equatable>(_ expression1: @autoclosure () throws -> [T: U], _ expression2: @autoclosure () throws -> [T: U], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 == value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
-        }
-    }
-}
-
 public func XCTAssertEqual<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.equalWithAccuracy, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
@@ -307,61 +252,6 @@ public func XCTAssertNil(_ expression: @autoclosure () throws -> Any?, _ message
 }
 
 public func XCTAssertNotEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 != value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
-        }
-    }
-}
-
-public func XCTAssertNotEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 != value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(String(describing: value1))\") is equal to (\"\(String(describing: value2))\")")
-        }
-    }
-}
-
-public func XCTAssertNotEqual<T: Equatable>(_ expression1: @autoclosure () throws -> ContiguousArray<T>, _ expression2: @autoclosure () throws -> ContiguousArray<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 != value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
-        }
-    }
-}
-
-public func XCTAssertNotEqual<T: Equatable>(_ expression1: @autoclosure () throws -> ArraySlice<T>, _ expression2: @autoclosure () throws -> ArraySlice<T>, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 != value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
-        }
-    }
-}
-
-public func XCTAssertNotEqual<T: Equatable>(_ expression1: @autoclosure () throws -> [T], _ expression2: @autoclosure () throws -> [T], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-    _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
-        let (value1, value2) = (try expression1(), try expression2())
-        if value1 != value2 {
-            return .success
-        } else {
-            return .expectedFailure("(\"\(value1)\") is equal to (\"\(value2)\")")
-        }
-    }
-}
-
-public func XCTAssertNotEqual<T, U: Equatable>(_ expression1: @autoclosure () throws -> [T: U], _ expression2: @autoclosure () throws -> [T: U], _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.notEqual, message: message, file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
         if value1 != value2 {


### PR DESCRIPTION
The various array types, Optional, and Dictionary are now Equatable when
their element types are Equatable, so we can remove the overloads meant to
support those use cases. Fixes rdar://problem/17924430.