### PR TITLE
build: stage the swiftmodule for build compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,20 @@ add_swift_library(XCTest
                     -I${XCTEST_PATH_TO_FOUNDATION_BUILD}/Foundation
                     -I${XCTEST_PATH_TO_FOUNDATION_BUILD}/Foundation/usr/lib/swift)
 
+# Temporary staging; the various swift projects that depend on XCTest all expect
+# the swiftdoc and swiftmodule to be in the top level.
+# So for now, make a copy so we don't have to do a coordinated commit across
+# all the swift projects to change this assumption.
+add_custom_target(TARGET
+                    XCTest
+                  POST_BUILD
+                  COMMAND
+                    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/swift/XCTest.swiftdoc ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMAND
+                    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/swift/XCTest.swiftmodule ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMENT
+                    "Copying swiftmodule/swiftdoc to build directory")
+
 if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py)
   set(LIT_COMMAND "${PYTHON_EXECUTABLE};${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py"
       CACHE STRING "command used to spawn llvm-lit")


### PR DESCRIPTION
Copy the swiftmodule and swiftdoc to the root of the build to permit
building swiftpm in the swift build against the CMake build.