### PR TITLE
build: match hardcoded extensions in the compiler

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -66,8 +66,8 @@ function(add_swift_target target)
     get_filename_component(name ${source} NAME)
 
     set(obj ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}${CMAKE_C_OUTPUT_EXTENSION})
-    set(mod ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}.swiftmodule~partial)
-    set(doc ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}.swiftdoc~partial)
+    set(mod ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}.swiftmodule)
+    set(doc ${CMAKE_CURRENT_BINARY_DIR}/${target}.dir/${name}.swiftdoc)
 
     set(all_sources ${sources})
     list(INSERT all_sources ${i} -primary-file)


### PR DESCRIPTION
The swiftdoc partials must have the extension .swiftdoc.  Adjust the
output names to match this assumption.  This is needed to repair the
CMake build with the newer compiler.