### PR TITLE
Fix redundant access-level modifiers.

### DIFF
--- a/Sources/XCTest/Public/XCTestCase+Performance.swift
+++ b/Sources/XCTest/Public/XCTestCase+Performance.swift
@@ -33,7 +33,7 @@ public struct XCTPerformanceMetric : RawRepresentable, Equatable, Hashable {
 
 public extension XCTPerformanceMetric {
     /// Records wall clock time in seconds between `startMeasuring`/`stopMeasuring`.
-    public static let wallClockTime = XCTPerformanceMetric(rawValue: WallClockTimeMetric.name)
+    static let wallClockTime = XCTPerformanceMetric(rawValue: WallClockTimeMetric.name)
 }
 
 /// The following methods are called from within a test method to carry out 

--- a/Sources/XCTest/Public/XCTestErrors.swift
+++ b/Sources/XCTest/Public/XCTestErrors.swift
@@ -36,10 +36,10 @@ public struct XCTestError : _BridgedStoredNSError {
 public extension XCTestError {
     /// Indicates that one or more expectations failed to be fulfilled in time
     /// during a call to `waitForExpectations(timeout:handler:)`
-    public static var timeoutWhileWaiting: XCTestError.Code { return .timeoutWhileWaiting }
+    static var timeoutWhileWaiting: XCTestError.Code { return .timeoutWhileWaiting }
 
     /// Indicates that a test assertion failed while waiting for expectations
     /// during a call to `waitForExpectations(timeout:handler:)`
     /// FIXME: swift-corelibs-xctest does not currently produce this error code.
-    public static var failureWhileWaiting: XCTestError.Code { return .failureWhileWaiting }
+    static var failureWhileWaiting: XCTestError.Code { return .failureWhileWaiting }
 }


### PR DESCRIPTION
This patch aims to make `corelibs-xctest` adapted to [this PR]( https://github.com/apple/swift/pull/18623), which produces warnings for redundant access-level modifiers.

For the code pattern shown in the example below, there are two feasible ways to fix the redundancy issue:
```
public extension {            // (1) remove `public` modifier for extension;
   public func foo() {}       // or (2) remove `public` modifier for member.
}
```
This patch goes with (2), keeping consistency with the rest of the project.