### PR TITLE
In test output, unconditionalize parens and unnamed parameter.

### DIFF
--- a/Tests/Functional/Observation/All/main.swift
+++ b/Tests/Functional/Observation/All/main.swift
@@ -108,18 +108,18 @@ class Observation: XCTestCase {
 // There's no guarantee as to the order in which these two observers will be
 // called, so we match any order here.
 
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? Observation)|(Test Suite 'Observation' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? Observation)|(Test Suite 'Observation' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? Observation)|(Test Suite 'Observation' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): Observation)|(Test Suite 'Observation' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): Observation)|(Test Suite 'Observation' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): Observation)|(Test Suite 'Observation' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
 
 XCTMain([testCase(Observation.allTests)])
 
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? .*\.xctest)|(Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? .*\.xctest)|(Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? .*\.xctest)|(Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): .*\.xctest)|(Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): .*\.xctest)|(Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): .*\.xctest)|(Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
 
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? All tests)|(Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? All tests)|(Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? All tests)|(Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): All tests)|(Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): All tests)|(Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): All tests)|(Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 3 tests, with 1 failure \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
 
-// CHECK: In testBundleDidFinish\(?_?:?\)?
+// CHECK: In testBundleDidFinish\(_:\)

--- a/Tests/Functional/Observation/Selected/main.swift
+++ b/Tests/Functional/Observation/Selected/main.swift
@@ -70,15 +70,15 @@ class ExecutedTestCase: XCTestCase {
 // There's no guarantee as to the order in which these two observers will be
 // called, so we match any order here.
 
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? ExecutedTestCase)|(Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+|\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? ExecutedTestCase)|(Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+|\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? ExecutedTestCase)|(Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+|\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): ExecutedTestCase)|(Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+|\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): ExecutedTestCase)|(Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+|\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): ExecutedTestCase)|(Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+|\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
 
 XCTMain([
     testCase(SkippedTestCase.allTests),
     testCase(ExecutedTestCase.allTests),
 ])
 
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? Selected tests|Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? Selected tests|Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
-// CHECK: (In testSuiteDidFinish\(?_?:\)?:? Selected tests|Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): Selected tests|Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): Selected tests|Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)
+// CHECK: (In testSuiteDidFinish\(_:\): Selected tests|Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+)|(\t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds)


### PR DESCRIPTION
Now that https://github.com/apple/swift/pull/19062 has landed (which
makes the output generated for #function more consistent), remove the
conditional matching that was done in
https://github.com/apple/swift-corelibs-xctest/pull/221.