### PR TITLE
Temporarily disable `test_multithreadedXCTestCaseConveniences`

### DIFF
--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -461,32 +461,6 @@ class ExpectationsTestCase: XCTestCase {
         RunLoop.main.run(until: Date() + 1)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_multithreadedXCTestCaseConveniences' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_multithreadedXCTestCaseConveniences' passed \(\d+\.\d+ seconds\)
-    func test_multithreadedXCTestCaseConveniences() {
-        let iterationCount = 10 // Increase for more thorough stress test
-
-        for _ in 0..<iterationCount {
-            let aStarted = XCTestExpectation(description: "Thread A started")
-            let bStarted = XCTestExpectation(description: "Thread B started")
-            let aFinished = XCTestExpectation(description: "Thread A finished")
-            let bFinished = XCTestExpectation(description: "Thread B finished")
-
-            Thread.detachNewThread {
-                aStarted.fulfill()
-                self.wait(for: [bStarted], timeout: 1)
-                aFinished.fulfill()
-            }
-            Thread.detachNewThread {
-                bStarted.fulfill()
-                self.wait(for: [aStarted], timeout: 1)
-                bFinished.fulfill()
-            }
-
-            wait(for: [aFinished, bFinished], timeout: 2)
-        }
-    }
-
     static var allTests = {
         return [
             ("test_waitingForAnUnfulfilledExpectation_fails", test_waitingForAnUnfulfilledExpectation_fails),
@@ -532,16 +506,15 @@ class ExpectationsTestCase: XCTestCase {
             // Regressions
             ("test_fulfillmentOnSecondaryThread", test_fulfillmentOnSecondaryThread),
             ("test_runLoopInsideDispatch", test_runLoopInsideDispatch),
-            ("test_multithreadedXCTestCaseConveniences", test_multithreadedXCTestCaseConveniences),
         ]
     }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 32 tests, with 17 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 31 tests, with 17 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ExpectationsTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 32 tests, with 17 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 31 tests, with 17 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 32 tests, with 17 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 31 tests, with 17 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds


### PR DESCRIPTION
This method is failing often (but not always) in Jenkins PR runs. We are investigating
a potential data race causing it (rdar://problem/45700041) but implementing that fix will
take some time so this temporarily removes this test from the suite to un-block CI.

Example failing Jenkins run:
https://ci.swift.org/job/swift-PR-Linux/8743/consoleFull#13585896343122a513-f36a-4c87-8ed7-cbc36a1ec144

rdar://problem/45859473