### PR TITLE
Force corelibs-xctest to build with -swift-version 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_swift_library(XCTest
                     Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
                   SWIFT_FLAGS
                     ${swift_optimization_flags}
+                    -swift-version 4
 
                     -I${XCTEST_PATH_TO_LIBDISPATCH_SOURCE}
                     -I${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift


### PR DESCRIPTION
There may be a regression in the compiler's handling of `@autoclosure`, which prevents
xctest building in `-swift-version 5`.  Temporarily hold it to `-swift-version 4`.