### PR TITLE
Revert "Convert RunLoopMode to RunLoop.Mode as with Darwin Foundation"

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
@@ -95,7 +95,7 @@ open class XCTNSPredicateExpectation: XCTestExpectation {
             }
         }
 
-        runLoop.add(timer, forMode: .default)
+        runLoop.add(timer, forMode: .defaultRunLoopMode)
         queue.async {
             self.timer = timer
         }

--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -362,7 +362,7 @@ private extension XCTWaiter {
         let timeIntervalToRun = min(0.1, timeout)
 
         // RunLoop.run(mode:before:) should have @discardableResult <rdar://problem/45371901>
-        _ = runLoop.run(mode: .default, before: Date(timeIntervalSinceNow: timeIntervalToRun))
+        _ = runLoop.run(mode: .defaultRunLoopMode, before: Date(timeIntervalSinceNow: timeIntervalToRun))
     }
 
     func cancelPrimitiveWait() {

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -47,7 +47,7 @@ class ExpectationsTestCase: XCTestCase {
         let timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
             expectation.fulfill()
         }
-        RunLoop.current.add(timer, forMode: .default)
+        RunLoop.current.add(timer, forMode: .defaultRunLoopMode)
         waitForExpectations(timeout: 1.0)
     }
 
@@ -59,7 +59,7 @@ class ExpectationsTestCase: XCTestCase {
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { _ in
             expectation.fulfill()
         }
-        RunLoop.current.add(timer, forMode: .default)
+        RunLoop.current.add(timer, forMode: .defaultRunLoopMode)
         waitForExpectations(timeout: 0.1)
     }
 


### PR DESCRIPTION
The corresponding change to Foundation is not in swift-5.0-branch.  Revert this to fix the [failing build](https://ci.swift.org/job/oss-swift-5.0-package-linux-ubuntu-16_04//244/).