### PR TITLE
[5.0] Revert "Revert "Convert RunLoopMode to RunLoop.Mode as with Darwin Foundation""

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
@@ -95,7 +95,7 @@ open class XCTNSPredicateExpectation: XCTestExpectation {
             }
         }
 
-        runLoop.add(timer, forMode: .defaultRunLoopMode)
+        runLoop.add(timer, forMode: .default)
         queue.async {
             self.timer = timer
         }

--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -362,7 +362,7 @@ private extension XCTWaiter {
         let timeIntervalToRun = min(0.1, timeout)
 
         // RunLoop.run(mode:before:) should have @discardableResult <rdar://problem/45371901>
-        _ = runLoop.run(mode: .defaultRunLoopMode, before: Date(timeIntervalSinceNow: timeIntervalToRun))
+        _ = runLoop.run(mode: .default, before: Date(timeIntervalSinceNow: timeIntervalToRun))
     }
 
     func cancelPrimitiveWait() {

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -47,7 +47,7 @@ class ExpectationsTestCase: XCTestCase {
         let timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
             expectation.fulfill()
         }
-        RunLoop.current.add(timer, forMode: .defaultRunLoopMode)
+        RunLoop.current.add(timer, forMode: .default)
         waitForExpectations(timeout: 1.0)
     }
 
@@ -59,7 +59,7 @@ class ExpectationsTestCase: XCTestCase {
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { _ in
             expectation.fulfill()
         }
-        RunLoop.current.add(timer, forMode: .defaultRunLoopMode)
+        RunLoop.current.add(timer, forMode: .default)
         waitForExpectations(timeout: 0.1)
     }
 


### PR DESCRIPTION
Reverts apple/swift-corelibs-xctest#243

Foundation PR is here: https://github.com/apple/swift-corelibs-foundation/pull/1854