### PR TITLE
Tests: adjust lit.cfg for Windows support

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -38,15 +38,21 @@ def _getenv(name):
 
 built_products_dir = _getenv('BUILT_PRODUCTS_DIR')
 # Force tests to build with -swift-version 4 for now.
-swift_exec = [
-    _getenv('SWIFT_EXEC'),
-    '-swift-version', '4',
-    '-Xlinker', '-rpath',
-    '-Xlinker', built_products_dir,
+swift_exec = [ _getenv('SWIFT_EXEC'), '-swift-version', '4', ]
+if not platform.system() == 'Windows':
+    swift_exec.extend(['-Xlinker', '-rpath', '-Xlinker', built_products_dir,])
+swift_exec.extend([
     '-L', built_products_dir,
     '-I', built_products_dir,
     '-I', os.path.join(built_products_dir, 'swift'),
-]
+])
+
+if platform.system() == 'Linux':
+    swift_exec.extend(['-Xcc', '-DDEPLOYMENT_TARGET_LINUX'])
+elif platform.system() == 'Darwin':
+    swift_exec.extend(['-Xcc', '-DDEPLOYMENT_TARGET_MACOSX'])
+elif platform.system() == 'Windows':
+    swift_exec.extend(['-Xcc', '-DDEPLOYMENT_TARGET_WINDOWS'])
 
 if platform.system() == 'Darwin':
     # On Darwin, we need to make sure swiftc references the
@@ -68,13 +74,14 @@ if platform.system() == 'Darwin':
         '-I', os.path.join(built_products_dir, 'usr', 'local', 'include'),
     ])
 else:
-    # On Linux, we need to jump through extra hoops to link
-    # swift-corelibs-foundation.
+    # We need to jump through extra hoops to link swift-corelibs-foundation.
     foundation_dir = _getenv('FOUNDATION_BUILT_PRODUCTS_DIR')
     core_foundation_dir = _getenv('CORE_FOUNDATION_BUILT_PRODUCTS_DIR')
+    if platform.system() == 'Windows':
+        swift_exec.extend(['-Xlinker', '-nodefaultlib:libcmt'])
+    else:
+        swift_exec.extend(['-Xlinker', '-rpath', '-Xlinker', foundation_dir,])
     swift_exec.extend([
-        '-Xlinker', '-rpath',
-        '-Xlinker', foundation_dir,
         '-L', foundation_dir,
         '-I', foundation_dir,
         '-I', os.path.join(foundation_dir, 'swift'),
@@ -110,7 +117,7 @@ xctest_checker = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
     'xctest_checker',
     'xctest_checker.py')
-config.substitutions.append(('%{xctest_checker}', xctest_checker))
+config.substitutions.append(('%{xctest_checker}', '%%{python} %s' % xctest_checker))
 
 # Add Python to run xctest_checker.py tests as part of XCTest tests
 config.substitutions.append( ('%{python}', sys.executable) )


### PR DESCRIPTION
This enables us to start running tests on Windows.