### PR TITLE
XCTest: use Foundation SPI on Windows

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -367,7 +367,11 @@ private extension XCTWaiter {
 
     func cancelPrimitiveWait() {
         guard let runLoop = runLoop else { return }
+#if os(Windows)
+        runLoop._stop()
+#else
         CFRunLoopStop(runLoop.getCFRunLoop())
+#endif
     }
 }
 


### PR DESCRIPTION
Foundation on Windows does not re-expose the CoreFoundation symbols.  In
order to permit XCTest to continue working with minimum changes, it
exposes a SPI.  Switch to that SPI for Windows.  This allows us to build
XCTest on Windows.