### PR TITLE
build: default to shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(XCTest
         LANGUAGES
           C)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 option(XCTEST_PATH_TO_LIBDISPATCH_SOURCE "Path to libdispatch source" "")
 option(XCTEST_PATH_TO_LIBDISPATCH_BUILD "Path to libdispatch build" "")
 


### PR DESCRIPTION
Build XCTest shared by default.  The user can pass
`-DBUILD_SHARED_LIBS=NO` to build static.