### PR TITLE
Tests: adjust test for Windows release build

### DIFF
--- a/Tests/Functional/Performance/main.swift
+++ b/Tests/Functional/Performance/main.swift
@@ -65,7 +65,9 @@ class PerformanceTestCase: XCTestCase {
     // CHECK: .*[/\\]Performance[/\\]main.swift:[[@LINE+3]]: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' measured \[Time, seconds\] average: \d+.\d{3}, relative standard deviation: \d+.\d{3}%, values: \[\d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}, \d+.\d{6}\], performanceMetricID:org.swift.XCTPerformanceMetric_WallClockTime, maxPercentRelativeStandardDeviation: \d+.\d{3}%, maxStandardDeviation: \d.\d{3}
     // CHECK: Test Case 'PerformanceTestCase.test_printsValuesAfterMeasuring' passed \(\d+\.\d+ seconds\)
     func test_printsValuesAfterMeasuring() {
-        measure {}
+        measure {
+          Thread.sleep(forTimeInterval: 1)
+        }
     }
 
     // CHECK: Test Case 'PerformanceTestCase.test_abortsMeasurementsAfterTestFailure' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+


### PR DESCRIPTION
Running the test in release mode on Windows, the block would completely
get optimized out and the resulting time slice was 0 per measurement.
This would result in the relative standard deviation being undefined,
which would render as `nan(ind)%` failing the expectation.  Add a sleep
to ensure that the block has something to execute.