### PR TITLE
build: adjust for new build layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ add_swift_library(XCTest
                     -Xcc -fblocks
 
                     -I${XCTEST_PATH_TO_FOUNDATION_BUILD}/swift
+                    -Fsystem ${XCTEST_PATH_TO_FOUNDATION_BUILD}
                     -Fsystem ${XCTEST_PATH_TO_COREFOUNDATION_BUILD}/System/Library/Frameworks
 
                     # compatibility with Foundation build_script.py

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -85,6 +85,8 @@ else:
         '-L', foundation_dir,
         '-I', foundation_dir,
         '-I', os.path.join(foundation_dir, 'swift'),
+        '-Xcc', '-F', '-Xcc', foundation_dir,
+
         '-I', core_foundation_dir,
         '-Xcc', '-F', '-Xcc', os.path.join(core_foundation_dir, 'System', 'Library', 'Frameworks'),
     ])


### PR DESCRIPTION
Moving CoreFoundation into the root is needed to actually get the proper
dependency tracking for Foundation builds.  This adjusts the use of it
in XCTest.