### PR TITLE
Allow running XCTest bundle with multiple comma-separated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ The `XCTMain` function does not return, and will cause your test executable to e
 * A particular test or test case can be selected to execute. For example:
 
 ```
-$ ./FooTests Tests.FooTestCase/testFoo  # Run a single test case
-$ ./FooTests Tests.FooTestCase          # Run all the tests in FooTestCase
+$ ./FooTests Tests.FooTestCase/testFoo                            # Run a single test method
+$ ./FooTests Tests.FooTestCase                                    # Run all the tests in FooTestCase
+$ ./FooTests Tests.FooTestCase/testFoo,Tests.FooTestCase/testBar  # Run multiple test methods
 ```
 * Tests can be listed, instead of executed.
 

--- a/Sources/XCTest/Private/ArgumentParser.swift
+++ b/Sources/XCTest/Private/ArgumentParser.swift
@@ -17,10 +17,10 @@ internal struct ArgumentParser {
 
     /// The basic operations that can be performed by an XCTest runner executable
     enum ExecutionMode {
-        /// Run a test or test suite, printing results to stdout and exiting with
-        /// a non-0 return code if any tests failed. The name of a test or class
-        /// may be provided to only run a subset of test cases.
-        case run(selectedTestName: String?)
+        /// Run tests or test cases, printing results to stdout and exiting with
+        /// a non-0 return code if any tests failed. The names of tests or test cases
+        /// may be provided to only run a subset of them.
+        case run(selectedTestNames: [String]?)
 
         /// The different ways that the tests can be represented when they are listed
         enum ListType {
@@ -39,9 +39,9 @@ internal struct ArgumentParser {
         /// Print Help
         case help(invalidOption: String?)
 
-        var selectedTestName: String? {
-            if case .run(let name) = self {
-                return name
+        var selectedTestNames: [String]? {
+            if case .run(let names) = self {
+                return names
             } else {
                 return nil
             }
@@ -56,7 +56,7 @@ internal struct ArgumentParser {
 
     var executionMode: ExecutionMode {
         if arguments.count <= 1 {
-            return .run(selectedTestName: nil)
+            return .run(selectedTestNames: nil)
         } else if arguments[1] == "--list-tests" || arguments[1] == "-l" {
             return .list(type: .humanReadable)
         } else if arguments[1] == "--dump-tests-json" {
@@ -66,7 +66,7 @@ internal struct ArgumentParser {
         } else if let fst = arguments[1].first, fst == "-" {
             return .help(invalidOption: arguments[1])
         } else {
-            return .run(selectedTestName: arguments[1])
+            return .run(selectedTestNames: arguments[1].split(separator: ",").map(String.init))
         }
     }
 }

--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -66,7 +66,7 @@ public func XCTMain(_ testCases: [XCTestCaseEntry]) -> Never {
     // - An `XCTestSuite` representing the .xctest test bundle is not included.
     let rootTestSuite: XCTestSuite
     let currentTestSuite: XCTestSuite
-    if executionMode.selectedTestName == nil {
+    if executionMode.selectedTestNames == nil {
         rootTestSuite = XCTestSuite(name: "All tests")
         currentTestSuite = XCTestSuite(name: "\(testBundle.bundleURL.lastPathComponent).xctest")
         rootTestSuite.addTest(currentTestSuite)
@@ -75,7 +75,7 @@ public func XCTMain(_ testCases: [XCTestCaseEntry]) -> Never {
         currentTestSuite = rootTestSuite
     }
 
-    let filter = TestFiltering(selectedTestName: executionMode.selectedTestName)
+    let filter = TestFiltering(selectedTestNames: executionMode.selectedTestNames)
     TestFiltering.filterTests(testCases, filter: filter.selectedTestFilter)
         .map(XCTestCaseSuite.init)
         .forEach(currentTestSuite.addTest)
@@ -118,7 +118,7 @@ public func XCTMain(_ testCases: [XCTestCaseEntry]) -> Never {
                      > \(exeName) \(sampleTests)
               """)
         exit(invalidOption == nil ? EXIT_SUCCESS : EXIT_FAILURE)
-    case .run(selectedTestName: _):
+    case .run(selectedTestNames: _):
         // Add a test observer that prints test progress to stdout.
         let observationCenter = XCTestObservationCenter.shared
         observationCenter.addTestObserver(PrintObserver())

--- a/Tests/Functional/SelectedTest/main.swift
+++ b/Tests/Functional/SelectedTest/main.swift
@@ -1,9 +1,11 @@
 // RUN: %{swiftc} %s -o %T/SelectedTest
 // RUN: %T/SelectedTest SelectedTest.ExecutedTestCase/test_foo > %T/one_test_case || true
 // RUN: %T/SelectedTest SelectedTest.ExecutedTestCase > %T/one_test_case_class || true
+// RUN: %T/SelectedTest SelectedTest.ExecutedTestCase/test_foo,SelectedTest.ExecutedTestCase/test_bar > %T/two_test_cases || true
 // RUN: %T/SelectedTest > %T/all || true
 // RUN: %{xctest_checker} -p "// CHECK-METHOD:" %T/one_test_case %s
 // RUN: %{xctest_checker} -p "// CHECK-CLASS:" %T/one_test_case_class %s
+// RUN: %{xctest_checker} -p "// CHECK-TWO-METHODS:" %T/two_test_cases %s
 // RUN: %{xctest_checker} -p "// CHECK-ALL:" %T/all %s
 
 #if os(macOS)
@@ -14,6 +16,7 @@
 
 // CHECK-METHOD: Test Suite 'Selected tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-CLASS: Test Suite 'Selected tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-TWO-METHODS: Test Suite 'Selected tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-ALL: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-ALL: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 
@@ -31,6 +34,9 @@ class ExecutedTestCase: XCTestCase {
 // CHECK-CLASS: Test Suite 'ExecutedTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-CLASS: Test Case 'ExecutedTestCase.test_bar' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-CLASS: Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\)
+// CHECK-TWO-METHODS:   Test Suite 'ExecutedTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-TWO-METHODS:   Test Case 'ExecutedTestCase.test_bar' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-TWO-METHODS:   Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\)
 // CHECK-ALL:      Test Suite 'ExecutedTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_bar' passed \(\d+\.\d+ seconds\)
@@ -38,6 +44,8 @@ class ExecutedTestCase: XCTestCase {
 
 // CHECK-CLASS: Test Case 'ExecutedTestCase.test_foo' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-CLASS: Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\)
+// CHECK-TWO-METHODS:   Test Case 'ExecutedTestCase.test_foo' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-TWO-METHODS:   Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\)
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-ALL:      Test Case 'ExecutedTestCase.test_foo' passed \(\d+\.\d+ seconds\)
     func test_foo() {}
@@ -46,6 +54,8 @@ class ExecutedTestCase: XCTestCase {
 // CHECK-METHOD:   \t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-CLASS: Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-CLASS: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK-TWO-METHODS: Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-TWO-METHODS: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-ALL:      Test Suite 'ExecutedTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-ALL:      \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
@@ -72,6 +82,8 @@ XCTMain([
 // CHECK-METHOD:   \t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-CLASS: Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-CLASS: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK-TWO-METHODS: Test Suite 'Selected tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK-TWO-METHODS: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-ALL:      Test Suite '.*\.xctest' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK-ALL:      \t Executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK-ALL:      Test Suite 'All tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+


### PR DESCRIPTION
This improves consistency with macOS version of XCTest which supports such behavior.

Right now any tool which runs a subset of tests is required to invoke the XCTest bundle N times, which forces the tool to spawn a lot of processes, and part of the work will be performed over and over again. This is especially painful if any expensive initialization is required (such as starting a web server), since `class func setUp()` will be called every time a new test method is called instead of once per test case.

From user's point of view statistics in this scenario will be shown in a more human-friendly format as `Executed 100 tests, with 0 failures` instead of `Executed 1 tests, with 0 failures` printed 100 times.