### PR TITLE
Run tests with a private module cache

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -45,6 +45,8 @@ swift_exec.extend([
     '-L', built_products_dir,
     '-I', built_products_dir,
     '-I', os.path.join(built_products_dir, 'swift'),
+    # A module cache in the built products directory is less likely to break in CI.
+    '-module-cache-path', os.path.join(built_products_dir, 'XCTest.dir', 'ModuleCache'),
 ])
 
 if platform.system() == 'Linux':


### PR DESCRIPTION
We currently believe that the reason Linux CI is so prone to module-loading failures is that different jobs with slightly different compilers may end up using the same system-wide module cache directories. If so, using `-module-cache-path` to point to a directory specific to the working copy should improve CI reliability.

This PR modifies Corelibs XCTest's `lit` configuration to run `swift` with a `-module-cache-path $BUILT_PRODUCTS_DIR/XCTest.dir/ModuleCache` argument, contributing to this solution.

Fixes https://bugs.swift.org/browse/SR-10665.