### PR TITLE
build: clean up `DEPLOYMENT_TARGET_*`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,7 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
   set(swift_optimization_flags -O)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL Android OR CMAKE_SYSTEM_NAME STREQUAL Linux)
-  set(deployment_target -DDEPLOYMENT_TARGET_LINUX)
-elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  set(deployment_target -DDEPLOYMENT_TARGET_MACOSX)
-elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-  set(deployment_target -DDEPLOYMENT_TARGET_FREEBSD)
-elseif(CMAKE_SYSTEM_NAME STREQUAL Windows)
-  set(deployment_target -DDEPLOYMENT_TARGET_WINDOWS)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set(WORKAROUND_SR9138 -Xlinker;-ignore:4217)
   set(WORKAROUND_SR9995 -Xlinker;-nodefaultlib:libcmt)
 endif()
@@ -100,8 +93,6 @@ add_swift_library(XCTest
                     Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
                     Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
                     Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
-                  CFLAGS
-                    ${deployment_target}
                   SWIFT_FLAGS
                     ${swift_optimization_flags}
 

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -47,13 +47,6 @@ swift_exec.extend([
     '-I', os.path.join(built_products_dir, 'swift'),
 ])
 
-if platform.system() == 'Linux':
-    swift_exec.extend(['-Xcc', '-DDEPLOYMENT_TARGET_LINUX'])
-elif platform.system() == 'Darwin':
-    swift_exec.extend(['-Xcc', '-DDEPLOYMENT_TARGET_MACOSX'])
-elif platform.system() == 'Windows':
-    swift_exec.extend(['-Xcc', '-DDEPLOYMENT_TARGET_WINDOWS'])
-
 if platform.system() == 'Darwin':
     # On Darwin, we need to make sure swiftc references the
     # proper SDK, has a deployment target set, and more...


### PR DESCRIPTION
These flags were used by CoreFoundation whcih was exposed through Foundation.
Now that that is no longer exposed, remove the unnecessary CFLAGS.