### PR TITLE
build: add DT_SONAME for ELF libraries

### DIFF
--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -133,7 +133,11 @@ function(add_swift_target target)
   endif()
 
   if(AST_LIBRARY)
-    set(emit_library -emit-library)
+    if(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL Darwin)
+      set(emit_library -emit-library)
+    else()
+      set(emit_library -emit-library -Xlinker -soname -Xlinker ${AST_OUTPUT})
+    endif()
   endif()
   if(NOT AST_LIBRARY OR library_kind STREQUAL SHARED)
     add_custom_command(OUTPUT


### PR DESCRIPTION
ELF libraries should have DT_SONAME set so that they can be loaded
properly. This is needed currently since we do not use proper CMake
support for Swift and that requires that we pass along the -soname
flag to the linker ourselves. Account for that.