### PR TITLE
Improve error reporting in edge cases.

### DIFF
--- a/Sources/XCTest/Public/XCTestRun.swift
+++ b/Sources/XCTest/Public/XCTestRun.swift
@@ -119,13 +119,21 @@ open class XCTestRun {
     ///   result of a failed assertion, `false` if it was the result of an
     ///   uncaught exception.
     func recordFailure(withDescription description: String, inFile filePath: String?, atLine lineNumber: Int, expected: Bool) {
+        func failureLocation() -> String {
+            if let filePath = filePath {
+                return "\(test.name) (\(filePath):\(lineNumber))"
+            } else {
+                return "\(test.name)"
+            }
+        }
+
         guard isStarted else {
             fatalError("Invalid attempt to record a failure for a test run " +
-                       "that has not yet been started: \(self)")
+                       "that has not yet been started: \(failureLocation())")
         }
         guard !isStopped else {
             fatalError("Invalid attempt to record a failure for a test run " +
-                       "that has already been stopped: \(self)")
+                       "that has already been stopped: \(failureLocation())")
         }
 
         if expected {


### PR DESCRIPTION
When a failure happens after the test suite has stopped (or started),
the failure message included the description of the class XCTestRun or
XCTestCaseRun, which is the default description.

Since those errors are difficult to trace back, instead of logging an
unhelpful source/line location pointing to the inside of XCTest, log the
additional information passed in into the method, to help the user to
locate their error.

I have tried to provide a test that shows the message itself, but I have been unable to create one. I'm pretty sure I have seen this error when a completion callback is invoked after the test has finished, but I cannot reproduce it in the test suite.