### PR TITLE
build: add additional library search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,9 @@ add_swift_library(XCTest
                     ${CMAKE_CURRENT_BINARY_DIR}/swift/XCTest.swiftmodule
                   LINK_FLAGS
                     -L${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
+                    -L${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/bin
                     -L${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src -ldispatch
+                    -L${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/BlocksRuntime
                     -L${XCTEST_PATH_TO_FOUNDATION_BUILD} -lFoundation
 
                     # compatibility with Foundation build_script.py


### PR DESCRIPTION
Alter the search path for libdispatch components when linking
foundation. This is needed to ensure that BlocksRuntime is found on
Windows.