### PR TITLE
build: add support for new build layout for libdispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ add_swift_library(XCTest
 
                     -I${XCTEST_PATH_TO_LIBDISPATCH_SOURCE}
                     -I${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
+                    -I${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift/swift
                     -Xcc -fblocks
 
                     -I${XCTEST_PATH_TO_FOUNDATION_BUILD}/swift

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -94,6 +94,7 @@ else:
                 '-Xcc', '-fblocks',
                 '-I', libdispatch_src_dir,
                 '-I', libdispatch_overlay_dir,
+                '-I', os.path.join(libdispatch_overlay_dir, 'swift'),
                 '-L', libdispatch_build_dir,
                 '-L', os.path.join(libdispatch_build_dir, 'src'),
             ])


### PR DESCRIPTION
Stage the changes needed in the include path for libdispatch with the
new CMake support.