### PR TITLE
Add Help Printing to XCTest executables

### DIFF
--- a/Sources/XCTest/Private/ArgumentParser.swift
+++ b/Sources/XCTest/Private/ArgumentParser.swift
@@ -36,6 +36,9 @@ internal struct ArgumentParser {
         /// Print a list of all the tests in the suite.
         case list(type: ListType)
 
+        /// Print Help
+        case help(invalidOption: String?)
+
         var selectedTestName: String? {
             if case .run(let name) = self {
                 return name
@@ -58,6 +61,10 @@ internal struct ArgumentParser {
             return .list(type: .humanReadable)
         } else if arguments[1] == "--dump-tests-json" {
             return .list(type: .json)
+        } else if arguments[1] == "--help" || arguments[1] == "-h" {
+            return .help(invalidOption: nil)
+        } else if let fst = arguments[1].first, fst == "-" {
+            return .help(invalidOption: arguments[1])
         } else {
             return .run(selectedTestName: arguments[1])
         }


### PR DESCRIPTION
- Provides usage and examples on --help, -h, or and invalid option
- Examples are customized based on the tests contained in the executable
  and the executable name

For example, for Foundation's TestFoundation:

```
> TestFoundation --invalid

Error: Invalid option "--invalid"

Usage: TestFoundation.exe [OPTION]
       TestFoundation.exe [TESTCASE]
Run and report results of test cases.

With no OPTION or TESTCASE, runs all test cases.

  -h, --help                   Print this help message
  -l, --list-test              List tests line by line to standard output
      --dump-tests-json        List tests in JSON to standard output

Examples:
  Run a single test

       > TestFoundation.exe TestFoundation.TestAffineTransform/test_BasicConstruction

  Run all the tests in TestFoundation.TestAffineTransform

       > TestFoundation.exe TestFoundation.TestAffineTransform
```