### PR TITLE
tests: pass `verify_json.expected` as absolute path

### DIFF
--- a/Tests/Functional/ListTests/main.swift
+++ b/Tests/Functional/ListTests/main.swift
@@ -3,7 +3,7 @@
 // RUN: %{xctest_checker} %t_list %s
 // RUN: %T/ListTests --dump-tests-json > %t_json || true
 // RUN: %T/ListTests --verify %t_json > %t_verify
-// RUN: %{xctest_checker} %t_verify verify_json.expected
+// RUN: %{xctest_checker} %t_verify %S/verify_json.expected
 
 #if os(macOS)
     import SwiftXCTest


### PR DESCRIPTION
Adjust the test to run in different PWD.  This will enable us to use
lit.site.cfg instead.