### PR TITLE
build: add export targets for XCTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ if(ENABLE_TESTING)
 endif()
 
 
+set_property(GLOBAL APPEND PROPERTY XCTest_EXPORTS XCTest)
 get_swift_host_arch(swift_arch)
 install(TARGETS XCTest
   ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
@@ -106,3 +107,5 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/swift/XCTest.swiftdoc
   ${CMAKE_CURRENT_BINARY_DIR}/swift/XCTest.swiftmodule
   DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+
+add_subdirectory(cmake/modules)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+set(XCTest_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/XCTestExports.cmake)
+configure_file(XCTestConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/XCTestConfig.cmake)
+
+get_property(XCTest_EXPORTS GLOBAL PROPERTY XCTest_EXPORTS)
+export(TARGETS ${XCTest_EXPORTS} FILE ${XCTest_EXPORTS_FILE})

--- a/cmake/modules/XCTestConfig.cmake.in
+++ b/cmake/modules/XCTestConfig.cmake.in
@@ -1,0 +1,4 @@
+
+if(NOT TARGET XCTest)
+  include(@XCTest_EXPORTS_FILE@)
+endif()


### PR DESCRIPTION
This enables the export targets for XCTest to tie it together with the
other projects.