### PR TITLE
Update lit.py references to be relative to the new LLVM monorepo directory

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 			buildConfigurationList = DAA333B81C267AD6000CC115 /* Build configuration list for PBXLegacyTarget "SwiftXCTestFunctionalTests" */;
 			buildPhases = (
 			);
-			buildToolPath = "$(SRCROOT)/../llvm/utils/lit/lit.py";
+			buildToolPath = "$(SRCROOT)/../llvm-project/llvm/utils/lit/lit.py";
 			buildWorkingDirectory = "";
 			dependencies = (
 				DAA333BA1C267AF3000CC115 /* PBXTargetDependency */,

--- a/build_script.py
+++ b/build_script.py
@@ -480,9 +480,9 @@ def main(args=sys.argv[1:]):
     build_parser.add_argument(
         "--test",
         help="Whether to run tests after building. Note that you must have "
-             "cloned https://github.com/apple/swift-llvm at {} in order to "
+             "cloned https://github.com/apple/llvm-project at {} in order to "
              "run this command.".format(os.path.join(
-                 os.path.dirname(SOURCE_DIR), 'llvm')),
+                 os.path.dirname(SOURCE_DIR), 'llvm-project')),
         action="store_true")
 
     test_parser = subparsers.add_parser(
@@ -502,7 +502,7 @@ def main(args=sys.argv[1:]):
         help="Path to the 'lit' tester tool used to run the test suite. "
              "'%(default)s' by default.",
         default=os.path.join(os.path.dirname(SOURCE_DIR),
-                             "llvm", "utils", "lit", "lit.py"))
+                             "llvm-project", "llvm", "utils", "lit", "lit.py"))
     test_parser.add_argument(
         "--foundation-build-dir",
         help="Path to swift-corelibs-foundation build products, which the "


### PR DESCRIPTION
This should fix recent CI failures on Pull Requests, which have been failing to locate the `lit.py` script.

See this forum post describing the LLVM monorepo transition details:

https://forums.swift.org/t/llvm-monorepo-transition-happening-on-thursday-the-17th-of-october/29674