### PR TITLE
build: use the modern spelling for the Swift compiler (NFC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_SRC_DIR=${XCTEST_PATH_TO_LIBDISPATCH_SOURCE}
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
-                      SWIFT_EXEC=${CMAKE_SWIFT_COMPILER}
+                      SWIFT_EXEC=${CMAKE_Swift_COMPILER}
                       ${PYTHON_EXECUTABLE} ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT
                       "Running XCTest functional test suite"


### PR DESCRIPTION
This uses `CMAKE_Swift_COMPILER` which is used by CMake rather than
`CMAKE_SWIFT_COMPILER` which was used by the local Swift build system.