### PR TITLE
build: support building against Foundation.framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 project(XCTest LANGUAGES Swift)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(USE_FOUNDATION_FRAMEWORK "Use Foundation.framework on Darwin" NO)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_package(dispatch CONFIG REQUIRED)
@@ -46,6 +47,10 @@ add_library(XCTest
   Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
   Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
   Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift)
+if(USE_FOUNDATION_FRAMEWORK)
+  target_compile_definitions(XCTest PRIVATE
+    USE_FOUNDATION_FRAMEWORK)
+endif()
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(XCTest PRIVATE
     dispatch

--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -15,7 +15,11 @@
 // Note that we are re-exporting Foundation so tests importing XCTest don't need
 // to import it themselves. This is consistent with the behavior of Apple XCTest
 #if os(macOS)
+    #if USE_FOUNDATION_FRAMEWORK
+    @_exported import Foundation
+    #else
     @_exported import SwiftFoundation
+    #endif
 #else
     @_exported import Foundation
 #endif
@@ -92,7 +96,7 @@ public func XCTMain(_ testCases: [XCTestCaseEntry]) -> Never {
             let errMsg = "Error: Invalid option \"\(invalid)\"\n"
             FileHandle.standardError.write(errMsg.data(using: .utf8) ?? Data())
         }
-        let exeName = CommandLine.arguments[0].lastPathComponent
+        let exeName = URL(fileURLWithPath: CommandLine.arguments[0]).lastPathComponent
         let sampleTest = rootTestSuite.list().first ?? "Tests.FooTestCase/testFoo"
         let sampleTests = sampleTest.prefix(while: { $0 != "/" })
         print("""


### PR DESCRIPTION
This enables building XCTest against the System Foundation.framework on
macOS.  This requires that the executable path is computed using `URL`
(`NSURL`) as the `lastPathComponent` has been explicitly made
unavailable.

```
/Users/compnerd/SourceCache/swift-corelibs-xctest/Sources/XCTest/Public/XCTestMain.swift:99:48: error: 'lastPathComponent' is unavailable: Use lastPathComponent on URL instead.
        let exeName = CommandLine.arguments[0].lastPathComponent
                                               ^~~~~~~~~~~~~~~~~
Foundation.StringProtocol:7:16: note: 'lastPathComponent' has been explicitly marked unavailable here
    public var lastPathComponent: String { get }
               ^
```