### PR TITLE
Introduce XCTSkip and related APIs for skipping tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(XCTest
   Sources/XCTest/Public/XCTestObservationCenter.swift
   Sources/XCTest/Public/XCTestCase+Performance.swift
   Sources/XCTest/Public/XCTAssert.swift
+  Sources/XCTest/Public/XCTSkip.swift
   Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift
   Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
   Sources/XCTest/Public/Asynchronous/XCTWaiter+Validation.swift

--- a/Sources/XCTest/Private/IgnoredErrors.swift
+++ b/Sources/XCTest/Private/IgnoredErrors.swift
@@ -10,16 +10,58 @@
 //  IgnoredErrors.swift
 //
 
-/// The user info key used by errors so that they are ignored by the XCTest library.
-internal let XCTestErrorUserInfoKeyShouldIgnore = "XCTestErrorUserInfoKeyShouldIgnore"
+protocol XCTCustomErrorHandling: Error {
+
+    /// Whether this error should be recorded as a test failure when it is caught. Default: true.
+    var shouldRecordAsTestFailure: Bool { get }
+
+    /// Whether this error should cause the test invocation to be skipped when it is caught during a throwing setUp method. Default: true.
+    var shouldSkipTestInvocation: Bool { get }
+
+    /// Whether this error should be recorded as a test skip when it is caught during a test invocation. Default: false.
+    var shouldRecordAsTestSkip: Bool { get }
+
+}
+
+extension XCTCustomErrorHandling {
+
+    var shouldRecordAsTestFailure: Bool {
+        true
+    }
+
+    var shouldSkipTestInvocation: Bool {
+        true
+    }
+
+    var shouldRecordAsTestSkip: Bool {
+        false
+    }
+
+}
+
+extension Error {
+
+    var xct_shouldRecordAsTestFailure: Bool {
+        (self as? XCTCustomErrorHandling)?.shouldRecordAsTestFailure ?? true
+    }
+
+    var xct_shouldSkipTestInvocation: Bool {
+        (self as? XCTCustomErrorHandling)?.shouldSkipTestInvocation ?? true
+    }
+
+    var xct_shouldRecordAsTestSkip: Bool {
+        (self as? XCTCustomErrorHandling)?.shouldRecordAsTestSkip ?? false
+    }
+
+}
 
 /// The error type thrown by `XCTUnwrap` on assertion failure.
-internal struct XCTestErrorWhileUnwrappingOptional: Error, CustomNSError {
-    static var errorDomain: String = XCTestErrorDomain
+internal struct XCTestErrorWhileUnwrappingOptional: Error, XCTCustomErrorHandling {
 
-    var errorCode: Int = 105
-
-    var errorUserInfo: [String : Any] {
-        return [XCTestErrorUserInfoKeyShouldIgnore: true]
+    var shouldRecordAsTestFailure: Bool {
+        // Don't record this error as a test failure, because XCTUnwrap
+        // internally records the failure before throwing this error
+        false
     }
+
 }

--- a/Sources/XCTest/Private/XCTestInternalObservation.swift
+++ b/Sources/XCTest/Private/XCTestInternalObservation.swift
@@ -15,6 +15,8 @@
 /// Expanded version of `XCTestObservation` used internally to respond to
 /// additional events not publicly exposed.
 internal protocol XCTestInternalObservation: XCTestObservation {
+    func testCase(_ testCase: XCTestCase, wasSkippedWithDescription description: String, at sourceLocation: SourceLocation?)
+
     /// Called when a test case finishes measuring performance and has results
     /// to report
     /// - Parameter testCase: The test case that did the measurements.
@@ -28,5 +30,6 @@ internal protocol XCTestInternalObservation: XCTestObservation {
 
 // All `XCInternalTestObservation` methods are optional, so empty default implementations are provided
 internal extension XCTestInternalObservation {
+    func testCase(_ testCase: XCTestCase, wasSkippedWithDescription description: String, at sourceLocation: SourceLocation?) {}
     func testCase(_ testCase: XCTestCase, didMeasurePerformanceResults results: String, file: StaticString, line: Int) {}
 }

--- a/Sources/XCTest/Public/XCAbstractTest.swift
+++ b/Sources/XCTest/Public/XCAbstractTest.swift
@@ -52,6 +52,10 @@ open class XCTest {
         perform(testRun!)
     }
 
+    /// Setup method called before the invocation of `setUp` and the test method
+    /// for each test method in the class.
+    open func setUpWithError() throws {}
+
     /// Setup method called before the invocation of each test method in the
     /// class.
     open func setUp() {}
@@ -59,6 +63,10 @@ open class XCTest {
     /// Teardown method called after the invocation of each test method in the
     /// class.
     open func tearDown() {}
+
+    /// Teardown method called after the invocation of the test method and `tearDown`
+    /// for each test method in the class.
+    open func tearDownWithError() throws {}
 
     // FIXME: This initializer is required due to a Swift compiler bug on Linux.
     //        It should be removed once the bug is fixed.

--- a/Sources/XCTest/Public/XCTSkip.swift
+++ b/Sources/XCTest/Public/XCTSkip.swift
@@ -1,0 +1,116 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//
+//  XCTSkip.swift
+//  APIs for skipping tests
+//
+
+/// An error which causes the current test to cease executing
+/// and be marked as skipped when it is thrown.
+public struct XCTSkip: Error {
+
+    /// The user-supplied message related to this skip, if specified.
+    public let message: String?
+
+    /// A complete description of the skip. Includes the string-ified expression and user-supplied message when possible.
+    let summary: String
+
+    /// An explanation of why the skip has occurred.
+    ///
+    /// - Note: May be nil if the skip was unconditional.
+    private let explanation: String?
+
+    /// The source code location where the skip occurred.
+    let sourceLocation: SourceLocation?
+
+    private init(explanation: String?, message: String?, sourceLocation: SourceLocation?) {
+        self.explanation = explanation
+        self.message = message
+        self.sourceLocation = sourceLocation
+
+        var summary = "Test skipped"
+        if let explanation = explanation {
+            summary += ": \(explanation)"
+        }
+        if let message = message, !message.isEmpty {
+            summary += " - \(message)"
+        }
+        self.summary = summary
+    }
+
+    public init(_ message: @autoclosure () -> String? = nil, file: StaticString = #file, line: UInt = #line) {
+        self.init(explanation: nil, message: message(), sourceLocation: SourceLocation(file: file, line: line))
+    }
+
+    fileprivate init(expectedValue: Bool, message: String?, file: StaticString, line: UInt) {
+        let explanation = expectedValue
+            ? "required true value but got false"
+            : "required false value but got true"
+        self.init(explanation: explanation, message: message, sourceLocation: SourceLocation(file: file, line: line))
+    }
+
+    internal init(error: Error, message: String?, sourceLocation: SourceLocation?) {
+        let explanation = #"threw error "\#(error)""#
+        self.init(explanation: explanation, message: message, sourceLocation: sourceLocation)
+    }
+
+}
+
+extension XCTSkip: XCTCustomErrorHandling {
+
+    var shouldRecordAsTestFailure: Bool {
+        // Don't record this error as a test failure since it's a test skip
+        false
+    }
+
+    var shouldRecordAsTestSkip: Bool {
+        true
+    }
+
+}
+
+/// Evaluates a boolean expression and, if it is true, throws an error which
+/// causes the current test to cease executing and be marked as skipped.
+public func XCTSkipIf(
+    _ expression: @autoclosure () throws -> Bool,
+    _ message: @autoclosure () -> String? = nil,
+    file: StaticString = #file, line: UInt = #line
+) throws {
+    try skipIfEqual(expression(), true, message(), file: file, line: line)
+}
+
+/// Evaluates a boolean expression and, if it is false, throws an error which
+/// causes the current test to cease executing and be marked as skipped.
+public func XCTSkipUnless(
+    _ expression: @autoclosure () throws -> Bool,
+    _ message: @autoclosure () -> String? = nil,
+    file: StaticString = #file, line: UInt = #line
+) throws {
+    try skipIfEqual(expression(), false, message(), file: file, line: line)
+}
+
+private func skipIfEqual(
+    _ expression: @autoclosure () throws -> Bool,
+    _ expectedValue: Bool,
+    _ message: @autoclosure () -> String?,
+    file: StaticString, line: UInt
+) throws {
+    let expressionValue: Bool
+
+    do {
+        // evaluate the expression exactly once
+        expressionValue = try expression()
+    } catch {
+        throw XCTSkip(error: error, message: message(), sourceLocation: SourceLocation(file: file, line: line))
+    }
+
+    if expressionValue == expectedValue {
+        throw XCTSkip(expectedValue: expectedValue, message: message(), file: file, line: line)
+    }
+}

--- a/Sources/XCTest/Public/XCTestCaseRun.swift
+++ b/Sources/XCTest/Public/XCTestCaseRun.swift
@@ -36,6 +36,15 @@ open class XCTestCaseRun: XCTestRun {
             atLine: lineNumber)
     }
 
+    override func recordSkip(description: String, sourceLocation: SourceLocation?) {
+        super.recordSkip(description: description, sourceLocation: sourceLocation)
+
+        XCTestObservationCenter.shared.testCase(
+            testCase,
+            wasSkippedWithDescription: description,
+            at: sourceLocation)
+    }
+
     private var testCase: XCTestCase {
         return test as! XCTestCase
     }

--- a/Sources/XCTest/Public/XCTestObservationCenter.swift
+++ b/Sources/XCTest/Public/XCTestObservationCenter.swift
@@ -54,6 +54,10 @@ public class XCTestObservationCenter {
         forEachObserver { $0.testCase(testCase, didFailWithDescription: description, inFile: filePath, atLine: lineNumber) }
     }
 
+    internal func testCase(_ testCase: XCTestCase, wasSkippedWithDescription description: String, at sourceLocation: SourceLocation?) {
+        forEachInternalObserver { $0.testCase(testCase, wasSkippedWithDescription: description, at: sourceLocation) }
+    }
+
     internal func testCaseDidFinish(_ testCase: XCTestCase) {
         forEachObserver { $0.testCaseDidFinish(testCase) }
     }

--- a/Sources/XCTest/Public/XCTestRun.swift
+++ b/Sources/XCTest/Public/XCTestRun.swift
@@ -49,6 +49,11 @@ open class XCTestRun {
     /// The number of test executions recorded during the run.
     open private(set) var executionCount: Int = 0
 
+    /// The number of test skips recorded during the run.
+    open var skipCount: Int {
+        hasBeenSkipped ? 1 : 0
+    }
+
     /// The number of test failures recorded during the run.
     open private(set) var failureCount: Int = 0
 
@@ -69,6 +74,9 @@ open class XCTestRun {
         }
         return totalFailureCount == 0
     }
+
+    /// `true` if the test was skipped, otherwise `false`.
+    open private(set) var hasBeenSkipped = false
 
     /// Designated initializer for the XCTestRun class.
     /// - Parameter test: An XCTest instance.
@@ -141,6 +149,31 @@ open class XCTestRun {
         } else {
             unexpectedExceptionCount += 1
         }
+    }
+
+    func recordSkip(description: String, sourceLocation: SourceLocation?) {
+        func failureLocation() -> String {
+            if let sourceLocation = sourceLocation {
+                return "\(test.name) (\(sourceLocation.file):\(sourceLocation.line))"
+            } else {
+                return "\(test.name)"
+            }
+        }
+
+        guard isStarted else {
+            fatalError("Invalid attempt to record a skip for a test run " +
+                       "that has not yet been started: \(failureLocation())")
+        }
+        guard !hasBeenSkipped else {
+            fatalError("Invalid attempt to record a skip for a test run " +
+                       "that has already been skipped: \(failureLocation())")
+        }
+        guard !isStopped else {
+            fatalError("Invalid attempt to record a skip for a test run " +
+                       "has already been stopped: \(failureLocation())")
+        }
+
+        hasBeenSkipped = true
     }
 
     private var isStarted: Bool {

--- a/Sources/XCTest/Public/XCTestSuiteRun.swift
+++ b/Sources/XCTest/Public/XCTestSuiteRun.swift
@@ -23,6 +23,11 @@ open class XCTestSuiteRun: XCTestRun {
         return testRuns.reduce(0) { $0 + $1.executionCount }
     }
 
+    /// The combined skip count of each test case run in the suite.
+    open override var skipCount: Int {
+        testRuns.reduce(0) { $0 + $1.skipCount }
+    }
+
     /// The combined failure count of each test case run in the suite.
     open override var failureCount: Int {
         return testRuns.reduce(0) { $0 + $1.failureCount }

--- a/Tests/Functional/SkippingTestCase/main.swift
+++ b/Tests/Functional/SkippingTestCase/main.swift
@@ -1,0 +1,131 @@
+// RUN: %{swiftc} %s -o %T/SkippingTestCase
+// RUN: %T/SkippingTestCase > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+// CHECK: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'SkippingTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class SkippingTestCase: XCTestCase {
+    static var allTests = {
+        return [
+            ("testSkip", testSkip),
+            ("testSkip_withMessage", testSkip_withMessage),
+            ("testSkip_viaSetUpWithError", testSkip_viaSetUpWithError),
+            ("testSkipIf_pass", testSkipIf_pass),
+            ("testSkipUnless_pass", testSkipUnless_pass),
+            ("testSkipIf_fail", testSkipIf_fail),
+            ("testSkipUnless_fail", testSkipUnless_fail),
+            ("testSkipIf_fail_withMessage", testSkipIf_fail_withMessage),
+            ("testSkipUnless_fail_withMessage", testSkipUnless_fail_withMessage),
+            ("testSkipIf_fail_errorThrown", testSkipIf_fail_errorThrown),
+        ]
+    }()
+
+    override func setUpWithError() throws {
+        if name == "SkippingTestCase.testSkip_viaSetUpWithError" {
+            throw XCTSkip("via setUpWithError")
+        }
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkip' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE+3]]: SkippingTestCase.testSkip : Test skipped
+    // CHECK: Test Case 'SkippingTestCase.testSkip' skipped \(\d+\.\d+ seconds\)
+    func testSkip() throws {
+        throw XCTSkip()
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkip_withMessage' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE+3]]: SkippingTestCase.testSkip_withMessage : Test skipped - some reason
+    // CHECK: Test Case 'SkippingTestCase.testSkip_withMessage' skipped \(\d+\.\d+ seconds\)
+    func testSkip_withMessage() throws {
+        throw XCTSkip("some reason")
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkip_viaSetUpWithError' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE-19]]: SkippingTestCase.testSkip_viaSetUpWithError : Test skipped - via setUpWithError
+    // CHECK: Test Case 'SkippingTestCase.testSkip_viaSetUpWithError' skipped \(\d+\.\d+ seconds\)
+    func testSkip_viaSetUpWithError() {
+        XCTFail("should not happen due to XCTSkip in setUpWithError()")
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_pass' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_pass' passed \(\d+\.\d+ seconds\)
+    func testSkipIf_pass() throws {
+        let expectation = self.expectation(description: "foo")
+
+        try XCTSkipIf(false)
+
+        expectation.fulfill()
+        wait(for: [expectation], timeout: 0)
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkipUnless_pass' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: Test Case 'SkippingTestCase.testSkipUnless_pass' passed \(\d+\.\d+ seconds\)
+    func testSkipUnless_pass() throws {
+        let expectation = self.expectation(description: "foo")
+
+        try XCTSkipUnless(true)
+
+        expectation.fulfill()
+        wait(for: [expectation], timeout: 0)
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_fail' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE+3]]: SkippingTestCase.testSkipIf_fail : Test skipped: required true value but got false
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_fail' skipped \(\d+\.\d+ seconds\)
+    func testSkipIf_fail() throws {
+        try XCTSkipIf(true)
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkipUnless_fail' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE+3]]: SkippingTestCase.testSkipUnless_fail : Test skipped: required false value but got true
+    // CHECK: Test Case 'SkippingTestCase.testSkipUnless_fail' skipped \(\d+\.\d+ seconds\)
+    func testSkipUnless_fail() throws {
+        try XCTSkipUnless(false)
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_fail_withMessage' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE+3]]: SkippingTestCase.testSkipIf_fail_withMessage : Test skipped: required true value but got false - some reason
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_fail_withMessage' skipped \(\d+\.\d+ seconds\)
+    func testSkipIf_fail_withMessage() throws {
+        try XCTSkipIf(true, "some reason")
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkipUnless_fail_withMessage' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE+3]]: SkippingTestCase.testSkipUnless_fail_withMessage : Test skipped: required false value but got true - some reason
+    // CHECK: Test Case 'SkippingTestCase.testSkipUnless_fail_withMessage' skipped \(\d+\.\d+ seconds\)
+    func testSkipUnless_fail_withMessage() throws {
+        try XCTSkipUnless(false, "some reason")
+    }
+
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_fail_errorThrown' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]SkippingTestCase[/\\]main.swift:[[@LINE+7]]: SkippingTestCase.testSkipIf_fail_errorThrown : Test skipped: threw error "ContrivedError\(message: "foo"\)" - some reason
+    // CHECK: Test Case 'SkippingTestCase.testSkipIf_fail_errorThrown' skipped \(\d+\.\d+ seconds\)
+    func testSkipIf_fail_errorThrown() throws {
+        func someCondition() throws -> Bool {
+            throw ContrivedError(message: "foo")
+        }
+
+        try XCTSkipIf(someCondition(), "some reason")
+    }
+}
+// CHECK: Test Suite 'SkippingTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 10 tests, with 8 tests skipped and 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+XCTMain([testCase(SkippingTestCase.allTests)])
+
+// CHECK: Test Suite '.*\.xctest' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 10 tests, with 8 tests skipped and 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Test Suite 'All tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 10 tests, with 8 tests skipped and 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+private struct ContrivedError: Error {
+    let message: String
+}

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		172FF8A72117B74D0059CBC5 /* XCTNSNotificationExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172FF8A62117B74D0059CBC5 /* XCTNSNotificationExpectation.swift */; };
+		1748FE3723AFD2D80014DB87 /* XCTSkip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1748FE3623AFD2D80014DB87 /* XCTSkip.swift */; };
 		17B6C3EB210D5A3900A11ECC /* XCTWaiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6C3EA210D5A3900A11ECC /* XCTWaiter.swift */; };
 		17B6C3ED210F53BE00A11ECC /* WaiterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6C3EC210F53BE00A11ECC /* WaiterManager.swift */; };
 		17B6C3EF210F990100A11ECC /* XCTWaiter+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6C3EE210F990100A11ECC /* XCTWaiter+Validation.swift */; };
@@ -51,6 +52,7 @@
 
 /* Begin PBXFileReference section */
 		172FF8A62117B74D0059CBC5 /* XCTNSNotificationExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTNSNotificationExpectation.swift; sourceTree = "<group>"; };
+		1748FE3623AFD2D80014DB87 /* XCTSkip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTSkip.swift; sourceTree = "<group>"; };
 		17B6C3EA210D5A3900A11ECC /* XCTWaiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTWaiter.swift; sourceTree = "<group>"; };
 		17B6C3EC210F53BE00A11ECC /* WaiterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaiterManager.swift; sourceTree = "<group>"; };
 		17B6C3EE210F990100A11ECC /* XCTWaiter+Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTWaiter+Validation.swift"; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				DA9D44131D920A3500108768 /* Asynchronous */,
 				AE2FE0EA1CFE86DB003EF0D7 /* XCAbstractTest.swift */,
 				AE2FE0ED1CFE86DB003EF0D7 /* XCTAssert.swift */,
+				1748FE3623AFD2D80014DB87 /* XCTSkip.swift */,
 				AE2FE0EE1CFE86DB003EF0D7 /* XCTestCase.swift */,
 				AE2FE0F01CFE86DB003EF0D7 /* XCTestCase+Performance.swift */,
 				AE2FE0F11CFE86DB003EF0D7 /* XCTestCaseRun.swift */,
@@ -343,6 +346,7 @@
 				AE2FE11B1CFE86E6003EF0D7 /* XCTNSPredicateExpectation.swift in Sources */,
 				17D5B680211216EF00D93239 /* SourceLocation.swift in Sources */,
 				AE63767E1D01ED17002C0EA8 /* TestListing.swift in Sources */,
+				1748FE3723AFD2D80014DB87 /* XCTSkip.swift in Sources */,
 				AE2FE1151CFE86E6003EF0D7 /* ArgumentParser.swift in Sources */,
 				AE2FE0FF1CFE86DB003EF0D7 /* XCTestCase.swift in Sources */,
 				AE2FE11D1CFE86E6003EF0D7 /* XCTestInternalObservation.swift in Sources */,


### PR DESCRIPTION
- Add the following APIs which facilitate dynamically skipping tests based on runtime conditions, with signatures matching new APIs introduced in Xcode 11.4:
  - XCTSkip struct, conforming to Error protocol.
  - `XCTSkipIf` and `XCTSkipUnless` functions.
  - `skipCount` and `hasBeenSkipped` properties on XCTestRun class.
- Add throwing instance methods `setUpWithError()` and `tearDownWithError()`. These methods complement the existing `setUp()` and `tearDown()` APIs but allow throwing errors. Their names include 'WithError' suffixes to preserve source compatibility, since adding `throws` to the existing methods would be a source-breaking API change.
- Modify internal test case execution logic to handle skipping and new setUp/tearDown error handling.
- Add new unit tests.

Fixes rdar://problem/56671272