### PR TITLE
[5.2 branch] addTeardownBlock API

### DIFF
--- a/Tests/Functional/TestCaseLifecycle/Misuse/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/Misuse/main.swift
@@ -1,0 +1,40 @@
+// RUN: %{swiftc} %s -g -o %T/TestCaseLifecycleMisuse
+// RUN: %T/TestCaseLifecycleMisuse > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+// CHECK: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'TeardownBlocksMisuseTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class TeardownBlocksMisuseTestCase: XCTestCase {
+
+    // CHECK: Test Case 'TeardownBlocksMisuseTestCase.test_addingATeardownBlockLate_crashes' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    func test_addingATeardownBlockLate_crashes() {
+        addTeardownBlock { [weak self] in
+            guard let self = self else {
+                XCTFail("self should still exist at this point")
+                return
+            }
+            // The following line should crash and nothing more will be printed
+            self.addTeardownBlock {
+                print("This should not be printed")
+            }
+        }
+    }
+
+    static var allTests = {
+      return [
+          ("test_addingATeardownBlockLate_crashes", test_addingATeardownBlockLate_crashes),
+      ]
+    }()
+}
+
+XCTMain([
+    testCase(TeardownBlocksMisuseTestCase.allTests),
+])

--- a/Tests/Functional/TestCaseLifecycle/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/main.swift
@@ -86,12 +86,62 @@ class NewInstanceForEachTestTestCase: XCTestCase {
 // CHECK: \t Executed 2 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 
+// CHECK: Test Suite 'TeardownBlocksTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class TeardownBlocksTestCase: XCTestCase {
+    static var allTests = {
+        return [
+            ("test_withoutTeardownBlocks", test_withoutTeardownBlocks),
+            ("test_withATeardownBlock", test_withATeardownBlock),
+            ("test_withSeveralTeardownBlocks", test_withSeveralTeardownBlocks),
+        ]
+    }()
+
+    override func tearDown() {
+        print("In tearDown function")
+    }
+
+    // CHECK: Test Case 'TeardownBlocksTestCase.test_withoutTeardownBlocks' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: In tearDown function
+    // CHECK: Test Case 'TeardownBlocksTestCase.test_withoutTeardownBlocks' passed \(\d+\.\d+ seconds\)
+    func test_withoutTeardownBlocks() {
+        // Intentionally blank
+    }
+
+    // CHECK: Test Case 'TeardownBlocksTestCase.test_withATeardownBlock' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: In teardown block A
+    // CHECK: In tearDown function
+    // CHECK: Test Case 'TeardownBlocksTestCase.test_withATeardownBlock' passed \(\d+\.\d+ seconds\)
+    func test_withATeardownBlock() {
+        addTeardownBlock {
+            print("In teardown block A")
+        }
+    }
+
+    // CHECK: Test Case 'TeardownBlocksTestCase.test_withSeveralTeardownBlocks' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: In teardown block C
+    // CHECK: In teardown block B
+    // CHECK: In tearDown function
+    // CHECK: Test Case 'TeardownBlocksTestCase.test_withSeveralTeardownBlocks' passed \(\d+\.\d+ seconds\)
+    func test_withSeveralTeardownBlocks() {
+        addTeardownBlock {
+            print("In teardown block B")
+        }
+        addTeardownBlock {
+            print("In teardown block C")
+        }
+    }
+}
+// CHECK: Test Suite 'TeardownBlocksTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+
 XCTMain([
     testCase(SetUpTearDownTestCase.allTests),
-    testCase(NewInstanceForEachTestTestCase.allTests)
+    testCase(NewInstanceForEachTestTestCase.allTests),
+    testCase(TeardownBlocksTestCase.allTests),
 ])
 
 // CHECK: Test Suite '.*\.xctest' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 6 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 3 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 6 tests, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds


### PR DESCRIPTION
Implement XCTestCase.addTeardownBlock

### 5.2 release branch merge request

- Explanation: This includes the `addTeardownBlock` API in the 5.2 release, for greater API parity with Xcode's XCTest, and partly because this is a dependency of the XCTSkip APIs which will be landed in a subsequent PR.
- Scope: Additive change to API, no impact to existing source.
- Radar: rdar://problem/48687341
- Risk: Low, requires clients to adopt the new API to get new behaviors
- Testing: New unit tests added
- Reviewer: @stmontgomery 