### PR TITLE
build: use `find_package` to find the python interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(ENABLE_TESTING)
     find_program(LIT_COMMAND NAMES llvm-lit lit.py lit)
   endif()
 
-  find_package(PythonInterp)
+  find_package(Python2 COMPONENTS Interpreter REQUIRED)
 
   add_custom_target(check-xctest
                     COMMAND
@@ -96,7 +96,7 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
-                      ${PYTHON_EXECUTABLE} ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
+                      $<TARGET_FILE:Python2::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT
                       "Running XCTest functional test suite"
                     DEPENDS


### PR DESCRIPTION
This removes the dependency on the user specifying `PYTHON_EXECUTABLE`.