### PR TITLE
[CMake] fix runpath for ELF platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(XCTest PRIVATE
     dispatch
     Foundation)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+    target_link_options(XCTest PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+  endif()
 endif()
 set_target_properties(XCTest PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift


### PR DESCRIPTION
Remove the absolute path to the host toolchain's stdlib from libXCTest.so ~and add `$ORIGIN`~.

Otherwise, you see the following in the current official release for linux:
```
readelf -d swift-5.2.3-RELEASE-ubuntu18.04/usr/lib/swift/linux/libXCTest.so | ag runpath
0x000000000000001d (RUNPATH)            Library runpath: [/home/buildnode/jenkins/workspace/oss-swift-5.2-package-linux-ubuntu-18_04/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux]
```