### PR TITLE
SR-1872 Using RunLoopSource in XCTestCase.waitForExpectations

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -349,14 +349,12 @@ open class XCTWaiter {
 
 private extension XCTWaiter {
     func primitiveWait(using runLoop: RunLoop, duration timeout: TimeInterval) {
-        
         self.runLoopSource = RunLoop._Source()
         self.runLoop?._add(self.runLoopSource!, forMode: .default)
         _ = self.runLoop?.run(until: .init(timeIntervalSinceNow: timeout))
     }
 
     func cancelPrimitiveWait() {
-        
         runLoopSource?.invalidate()
     }
 }

--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -357,12 +357,7 @@ private extension XCTWaiter {
 
     func cancelPrimitiveWait() {
         
-#if os(Windows)
-        guard let runLoop = runLoop else { return }
-        runLoop._stop()
-#else
         runLoopSource?.invalidate()
-#endif
     }
 }
 


### PR DESCRIPTION
[SR-1872](https://bugs.swift.org/browse/SR-1872) Replacing polling expectations to check whether an expectation is fulfilled with RunloopSource