### PR TITLE
tests: add some more library search paths

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -107,6 +107,8 @@ else:
                 '-I', os.path.join(libdispatch_overlay_dir, 'swift'),
                 '-L', libdispatch_build_dir,
                 '-L', os.path.join(libdispatch_build_dir, 'src'),
+                '-L', os.path.join(libdispatch_build_dir, 'src', 'BlocksRuntime'),
+                '-L', os.path.join(libdispatch_build_dir, 'src', 'swift'),
             ])
 
     config.environment['LD_LIBRARY_PATH'] = ":".join([


### PR DESCRIPTION
When building on Windows, there are a few additional library search
paths that need to be considered.  This will enable the tests to be
enabled for nightly CI.