### PR TITLE
Fix SR-13047 (failure in XCTAssertEqual(Inf, Inf, accuracy: 1e-6))

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -174,7 +174,9 @@ public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -
 public func XCTAssertEqual<T: FloatingPoint>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, accuracy: T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     _XCTEvaluateAssertion(.equalWithAccuracy, message: message(), file: file, line: line) {
         let (value1, value2) = (try expression1(), try expression2())
-        if abs(value1.distance(to: value2)) <= abs(accuracy.distance(to: T(0))) {
+        // Test with equality first to handle comparing inf/-inf with itself.
+        if value1 == value2 ||
+             abs(value1.distance(to: value2)) <= abs(accuracy.distance(to: T(0))) {
             return .success
         } else {
             return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\") +/- (\"\(accuracy)\")")

--- a/Tests/Functional/InfinityAccuracyTestCase/main.swift
+++ b/Tests/Functional/InfinityAccuracyTestCase/main.swift
@@ -1,0 +1,70 @@
+// RUN: %{swiftc} %s -o %T/InfinityAccuracyTestCase
+// RUN: %T/InfinityAccuracyTestCase > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+// Regression test for https://bugs.swift.org/browse/SR-13047
+
+// CHECK: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'InfinityAccuracyTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class InfinityAccuracyTestCase: XCTestCase {
+    static var allTests = {
+        return [
+            ("test_equalWithAccuracy_double_passes", test_equalWithAccuracy_double_passes),
+            ("test_equalWithAccuracy_float_passes", test_equalWithAccuracy_float_passes),
+            ("test_equalWithAccuracy_fails", test_equalWithAccuracy_fails),
+            ("test_notEqualWithAccuracy_passes", test_notEqualWithAccuracy_passes),
+            ("test_notEqualWithAccuracy_fails", test_notEqualWithAccuracy_fails),
+        ]
+    }()
+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_equalWithAccuracy_double_passes' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_equalWithAccuracy_double_passes' passed \(\d+\.\d+ seconds\)
+    func test_equalWithAccuracy_double_passes() {
+        XCTAssertEqual(-Double.infinity, -Double.infinity, accuracy: 1e-6)
+        XCTAssertEqual(Double.infinity, Double.infinity, accuracy: 1e-6)
+    }
+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_equalWithAccuracy_float_passes' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_equalWithAccuracy_float_passes' passed \(\d+\.\d+ seconds\)
+    func test_equalWithAccuracy_float_passes() {
+        XCTAssertEqual(-Float.infinity, -Float.infinity, accuracy: 1e-6)
+        XCTAssertEqual(Float.infinity, Float.infinity, accuracy: 1e-6)
+    }
+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_equalWithAccuracy_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: .*[/\\]InfinityAccuracyTestCase[/\\]main.swift:[[@LINE+3]]: error: InfinityAccuracyTestCase.test_equalWithAccuracy_fails : XCTAssertEqual failed: \(\"-inf\"\) is not equal to \(\"inf\"\) \+\/- \(\"1e-06"\) - $
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_equalWithAccuracy_fails' failed \(\d+\.\d+ seconds\)
+    func test_equalWithAccuracy_fails() {
+        XCTAssertEqual(-Double.infinity, Double.infinity, accuracy: 1e-6)
+    }
+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_notEqualWithAccuracy_passes' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_notEqualWithAccuracy_passes' passed \(\d+\.\d+ seconds\)
+    func test_notEqualWithAccuracy_passes() {
+        XCTAssertNotEqual(-Double.infinity, Double.infinity, accuracy: 1e-6)
+    }
+
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_notEqualWithAccuracy_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: .*[/\\]InfinityAccuracyTestCase[/\\]main.swift:[[@LINE+3]]: error: InfinityAccuracyTestCase.test_notEqualWithAccuracy_fails : XCTAssertNotEqual failed: \("-inf"\) is equal to \("-inf"\) \+/- \("1e-06"\) - $
+// CHECK: Test Case 'InfinityAccuracyTestCase.test_notEqualWithAccuracy_fails' failed \(\d+\.\d+ seconds\)
+    func test_notEqualWithAccuracy_fails() {
+        XCTAssertNotEqual(-Double.infinity, -Double.infinity, accuracy: 1e-6)
+    }
+}
+// CHECK: Test Suite 'InfinityAccuracyTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed \d+ tests, with \d+ failures \(\d+ unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+XCTMain([testCase(InfinityAccuracyTestCase.allTests)])
+
+// CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed \d+ tests, with \d+ failures \(\d+ unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed \d+ tests, with \d+ failures \(\d+ unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds


### PR DESCRIPTION
`XCTAssertEqual(Inf, Int, accuracy: 1e-6)` currently fails.

To fix the issue, this PR changes `XCTAssertEqual()` to compare values for exact equality *before* checking distance. (Otherwise, distance calculation on infinity returns NaN, which fails all comparisons).

Fixes https://bugs.swift.org/browse/SR-13047 .