### PR TITLE
[5.3][CMake] fix runpath for ELF platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(XCTest PRIVATE
     dispatch
     Foundation)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+    target_link_options(XCTest PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+  endif()
 endif()
 set_target_properties(XCTest PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/swift


### PR DESCRIPTION
- Explanation

Remove the absolute path to the host toolchain's stdlib from libXCTest.so.

- Scope

I previously submitted a pull to do this for the main branch, #303, but after discussing it with some Swift devs, I'm now submitting it for the 5.3 branch without the `$ORIGIN` portion which we couldn't agree on. @compnerd seemed to agree that only the part removing the build toolchain's stdlib rpath should be done on the 5.3 branch to get this removed for the upcoming release.

- SR issue

Resolves point 2. in SR-1650

- Risk

None, this should be completely safe for the 5.3 branch, as it's just removing the build toolchain's stdlib rpath, which should be unused by this library.

- Testing

The other corelibs had similar pulls merged before the 5.3 release and have had no complaints.

- Reviewer

I discussed these rpath issues in detail across the entire toolchain with @gottesmm and @compnerd.