### PR TITLE
An XCTUnwrap failure in `setUpWithError` causes the test method to not be invoked

### DIFF
--- a/Sources/XCTest/Private/IgnoredErrors.swift
+++ b/Sources/XCTest/Private/IgnoredErrors.swift
@@ -64,4 +64,11 @@ internal struct XCTestErrorWhileUnwrappingOptional: Error, XCTCustomErrorHandlin
         false
     }
 
+    var shouldSkipTestInvocation: Bool {
+        // This error is only used for control flow, but otherwise XCTUnwrap behaves more like
+        // an assertion rather than a typical thrown error, so it should not cause the test
+        // invocation to be skipped.
+        false
+    }
+
 }

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -35,6 +35,7 @@ class ErrorHandling: XCTestCase {
             ("test_shouldNotThrowErrorOnUnwrapSuccess", test_shouldNotThrowErrorOnUnwrapSuccess),
             ("test_shouldThrowErrorOnUnwrapFailure", test_shouldThrowErrorOnUnwrapFailure),
             ("test_shouldThrowErrorOnEvaluationFailure", test_shouldThrowErrorOnEvaluationFailure),
+            ("test_shouldInvokeTestDespiteUnwrapFailureInSetUp", test_shouldInvokeTestDespiteUnwrapFailureInSetUp),
             ("test_implicitlyUnwrappedOptional_notNil", test_implicitlyUnwrappedOptional_notNil),
             ("test_implicitlyUnwrappedOptional_nil", test_implicitlyUnwrappedOptional_nil),
             ("test_unwrapAnyOptional_notNil", test_unwrapAnyOptional_notNil),
@@ -57,6 +58,15 @@ class ErrorHandling: XCTestCase {
     
     func functionThatDoesThrowError() throws {
         throw SomeError.anError("an error message")
+    }
+
+    override func setUpWithError() throws {
+        if name == "ErrorHandling.test_shouldInvokeTestDespiteUnwrapFailureInSetUp" {
+            let value: String? = nil
+            #sourceLocation(file: "ErrorHandling/main.swift", line: 10001)
+            _ = try XCTUnwrap(value)
+            #sourceLocation()
+        }
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
@@ -174,6 +184,14 @@ class ErrorHandling: XCTestCase {
 
         // Should not be reached:
         throw SomeError.shouldNotBeReached
+    }
+
+// CHECK: Test Case 'ErrorHandling.test_shouldInvokeTestDespiteUnwrapFailureInSetUp' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: ErrorHandling[/\\]main.swift:10001: error: ErrorHandling.test_shouldInvokeTestDespiteUnwrapFailureInSetUp : XCTUnwrap failed: expected non-nil value of type "String" -
+// CHECK: Here is proof the test was invoked
+// CHECK: Test Case 'ErrorHandling.test_shouldInvokeTestDespiteUnwrapFailureInSetUp' failed \(\d+\.\d+ seconds\)
+    func test_shouldInvokeTestDespiteUnwrapFailureInSetUp() {
+        print("Here is proof the test was invoked")
     }
 
 // CHECK: Test Case 'ErrorHandling.test_implicitlyUnwrappedOptional_notNil' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+


### PR DESCRIPTION
This fixes an issue where an `XCTUnwrap` failure in `setUpWithError()` incorrectly causes the test method to not be invoked. If there is an unwrap failure during setUpWithError, the failure should be recorded and the overall test should be marked as a Failure (which is working correctly), but the test method should still be invoked. This is similar to all other XCT assert APIs, where a failure does not cause the remainder of the test to stop executing, regardless of whether that failure occurs in a setUp* method or in the test method itself.