### PR TITLE
test: adjust library search paths for Foundation

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -80,6 +80,7 @@ else:
           '-Xlinker', '-rpath', '-Xlinker', os.path.join(foundation_dir, 'Sources', 'Foundation'),
           '-Xlinker', '-rpath', '-Xlinker', os.path.join(foundation_dir, 'Sources', 'FoundationNetworking'),
           '-Xlinker', '-rpath', '-Xlinker', os.path.join(foundation_dir, 'Sources', 'FoundationXML'),
+          '-Xlinker', '-rpath', '-Xlinker', os.path.join(foundation_dir, 'lib'),
         ])
     swift_exec.extend([
         '-L', foundation_dir,
@@ -87,6 +88,7 @@ else:
         '-L', os.path.join(foundation_dir, 'Sources', 'Foundation'),
         '-L', os.path.join(foundation_dir, 'Sources', 'FoundationNetworking'),
         '-L', os.path.join(foundation_dir, 'Sources', 'FoundationXML'),
+        '-L', os.path.join(foundation_dir, 'lib'),
         '-I', foundation_dir,
         '-I', os.path.join(foundation_dir, 'swift'),
         '-Xcc', '-F', '-Xcc', foundation_dir,
@@ -119,6 +121,7 @@ else:
       os.path.join(foundation_dir, 'Sources', 'Foundation'),
       os.path.join(foundation_dir, 'Sources', 'FoundationNetworking'),
       os.path.join(foundation_dir, 'Sources', 'FoundationXML'),
+      os.path.join(foundation_dir, 'lib'),
     ])
 
 # Having prepared the swiftc command, we set the substitution.


### PR DESCRIPTION
In order to support a uniform build tree layout, we need to add a new
library search path to XCTest.  This structures the tree similar to all
the other products (including XCTest itself).