### PR TITLE
Remove unnecessary `import CoreFoundation` on Windows

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -10,7 +10,9 @@
 //  XCTWaiter.swift
 //
 
+#if !os(Windows)
 import CoreFoundation
+#endif
 
 /// Events are reported to the waiter's delegate via these methods. XCTestCase conforms to this
 /// protocol and will automatically report timeouts and other unexpected events as test failures.


### PR DESCRIPTION
This removes the unnecessary import of CoreFoundation in the XCTest
module.  It is unused and the removal enables the removal of the
CoreFoundation headers from the distribution which are internal
implementation details on non-Darwin platforms.