### PR TITLE
test: quote the path to the python interpreter

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -13,6 +13,7 @@ import platform
 import tempfile
 import sys
 import lit
+import pipes
 
 # Set up lit config.
 config.name = 'SwiftXCTestFunctionalTests'
@@ -137,4 +138,4 @@ xctest_checker = os.path.join(
 config.substitutions.append(('%{xctest_checker}', '%%{python} %s' % xctest_checker))
 
 # Add Python to run xctest_checker.py tests as part of XCTest tests
-config.substitutions.append( ('%{python}', sys.executable) )
+config.substitutions.append( ('%{python}', pipes.quote(sys.executable)) )


### PR DESCRIPTION
This is needed to ensure that paths with spaces don't break the test
suite.