### PR TITLE
tests: migrate to Python3 for the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(ENABLE_TESTING)
     find_program(LIT_COMMAND NAMES llvm-lit lit.py lit)
   endif()
 
-  find_package(Python2 COMPONENTS Interpreter REQUIRED)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
   add_custom_target(check-xctest
                     COMMAND
@@ -96,7 +96,7 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
-                      $<TARGET_FILE:Python2::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
+                      $<TARGET_FILE:Python3::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT
                       "Running XCTest functional test suite"
                     DEPENDS

--- a/Tests/Functional/xctest_checker/tests/test_compare.py
+++ b/Tests/Functional/xctest_checker/tests/test_compare.py
@@ -36,7 +36,7 @@ class CompareTestCase(unittest.TestCase):
         with self.assertRaises(XCTestCheckerError) as cm:
             compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
-        self.assertIn('{}:{}'.format(expected, 1), cm.exception.message)
+        self.assertIn('{}:{}'.format(expected, 1), str(cm.exception))
 
     def test_too_many_expected_raises_and_excess_check_line_in_error(self):
         actual = _tmpfile('foo\nbar\n')
@@ -44,7 +44,7 @@ class CompareTestCase(unittest.TestCase):
         with self.assertRaises(XCTestCheckerError) as cm:
             compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
-        self.assertIn('{}:{}'.format(expected, 3), cm.exception.message)
+        self.assertIn('{}:{}'.format(expected, 3), str(cm.exception))
 
     def test_match_does_not_raise(self):
         actual = _tmpfile('foo\nbar\nbaz\n')
@@ -62,7 +62,7 @@ class CompareTestCase(unittest.TestCase):
         with self.assertRaises(XCTestCheckerError) as cm:
             compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
-        self.assertIn('{}:{}'.format(expected, 2), cm.exception.message)
+        self.assertIn('{}:{}'.format(expected, 2), str(cm.exception))
 
     def test_check_prefix_in_run_line_ignored(self):
         actual = _tmpfile('flim\n')
@@ -75,7 +75,7 @@ class CompareTestCase(unittest.TestCase):
         with self.assertRaises(XCTestCheckerError) as cm:
             compare.compare(open(actual, 'r'), expected, check_prefix='c: ')
 
-        self.assertIn("{}:{}:".format(expected, 2), cm.exception.message)
+        self.assertIn("{}:{}:".format(expected, 2), str(cm.exception))
 
     def test_matching_ignores_leading_and_trailing_whitespace(self):
         actual = _tmpfile('foo\nbar\nbaz\n')

--- a/Tests/Functional/xctest_checker/xctest_checker/compare.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/compare.py
@@ -9,6 +9,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import re
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 
 from .error import XCTestCheckerError
 from .line import replace_offsets
@@ -63,8 +67,7 @@ def compare(actual, expected, check_prefix):
     file, raises an AssertionError. Also raises an AssertionError if the number
     of lines in the two files differ.
     """
-    for actual_line, expected_line_and_number in map(
-            None,
+    for actual_line, expected_line_and_number in zip_longest(
             _actual_lines(actual),
             _expected_lines_and_line_numbers(expected, check_prefix)):
 


### PR DESCRIPTION
Adjust the test suite to be compatible with Python 3 and require python
3 for running the tests as python 2 has been EOL'ed.