### PR TITLE
Only use the last CoreFoundation reference on Apple platforms

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -10,7 +10,7 @@
 //  XCTWaiter.swift
 //
 
-#if !os(Windows)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 import CoreFoundation
 #endif
 
@@ -369,10 +369,10 @@ private extension XCTWaiter {
 
     func cancelPrimitiveWait() {
         guard let runLoop = runLoop else { return }
-#if os(Windows)
-        runLoop._stop()
-#else
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         CFRunLoopStop(runLoop.getCFRunLoop())
+#else
+        runLoop._stop()
 #endif
     }
 }


### PR DESCRIPTION
Now that CoreFoundation is no longer exposed on new platforms, ie except for Darwin and linux, apple/swift-corelibs-foundation#2878, change this last reference that was added years ago, before `RunLoop._stop()` was available. Removing the CoreFoundation interface broke building XCTest for Android, just like on Windows, which this patch fixes.

@millenomi and @compnerd, if this won't work for some reason, just let me know and I could try another approach.