### PR TITLE
[cmake] Make dispatch/Foundation non required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(USE_FOUNDATION_FRAMEWORK "Use Foundation.framework on Darwin" NO)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  find_package(dispatch CONFIG REQUIRED)
-  find_package(Foundation CONFIG REQUIRED)
+  find_package(dispatch CONFIG)
+  find_package(Foundation CONFIG)
 endif()
 
 include(SwiftSupport)


### PR DESCRIPTION
When building using an install tree which already contains
dispatch/Foundation, a dispatch/foundation packages do not need to be
specified since they are already automatically linked against.