### PR TITLE
Corrected branch name in link to Swift repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ ./FooTests --dump-tests-json
 
 To contribute, you'll need to be able to build this project and and run its test suite. The easiest way to do so is via the Swift build script.
 
-First, follow [the instructions in the Swift README](https://github.com/apple/swift/blob/master/README.md) to build Swift from source. Confirm you're able to build the Swift project using `utils/build-script -R`.
+First, follow [the instructions in the Swift README](https://github.com/apple/swift/blob/main/README.md) to build Swift from source. Confirm you're able to build the Swift project using `utils/build-script -R`.
 
 Once you are able to build the Swift project, build XCTest and run its tests:
 
@@ -103,7 +103,7 @@ $ cd swift-corelibs-xctest
 $ ../swift/utils/build-script --preset corelibs-xctest
 ```
 
-This project is only guaranteed to build with the very latest commit on the Swift and swift-corelibs-foundation `master` branches. You may update to the latest commits using the Swift `utils/update-checkout` script:
+This project is only guaranteed to build with the very latest commit on the Swift and swift-corelibs-foundation `main` branches. You may update to the latest commits using the Swift `utils/update-checkout` script:
 
 ```
 $ ../swift/utils/update-checkout
@@ -115,6 +115,6 @@ To browse files in this project using Xcode, use `XCTest.xcworkspace`. You may b
 
 However, in order to successfully build the project in Xcode, **you must use an Xcode toolchain with an extremely recent version of Swift**. The Swift website provides [Xcode toolchains to download](https://swift.org/download/#latest-development-snapshots), as well as [instructions on how to use Xcode with those toolchains](https://swift.org/download/#apple-platforms). Swift development moves fairly quickly, and so even a week-old toolchain may no longer work.
 
-> If none of the toolchains available to download are recent enough to build XCTest, you may build your own toolchain by using the [`utils/build-toolchain` script](https://github.com/apple/swift/blob/master/utils/build-toolchain) in the Swift repository.
+> If none of the toolchains available to download are recent enough to build XCTest, you may build your own toolchain by using the [`utils/build-toolchain` script](https://github.com/apple/swift/blob/main/utils/build-toolchain) in the Swift repository.
 >
 > Keep in mind that the build script invocation in "Contributing to XCTest" above will always work, regardless of which Swift toolchains you have installed. The Xcode workspace exists simply for the convenience of contributors. It is not necessary to successfully build this project in Xcode in order to contribute.


### PR DESCRIPTION
Corrected branch in link to Swift repository to main (renamed from master)