### PR TITLE
Change XCTAssertThrowsError function signature to rethrow when the error handler throws

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -377,6 +377,12 @@ public func XCTFail(_ message: String = "", file: StaticString = #file, line: UI
 }
 
 public func XCTAssertThrowsError<T>(_ expression: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ errorHandler: (_ error: Swift.Error) -> Void = { _ in }) {
+    let rethrowsOverload: (() throws -> T, () -> String, StaticString, UInt, (Swift.Error) throws -> Void) throws -> Void = XCTAssertThrowsError
+
+    try? rethrowsOverload(expression, message, file, line, errorHandler)
+}
+
+public func XCTAssertThrowsError<T>(_ expression: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line, _ errorHandler: (_ error: Swift.Error) throws -> Void = { _ in }) rethrows {
     _XCTEvaluateAssertion(.throwsError, message: message(), file: file, line: line) {
         var caughtErrorOptional: Swift.Error?
         do {
@@ -386,7 +392,7 @@ public func XCTAssertThrowsError<T>(_ expression: @autoclosure () throws -> T, _
         }
 
         if let caughtError = caughtErrorOptional {
-            errorHandler(caughtError)
+            try errorHandler(caughtError)
             return .success
         } else {
             return .expectedFailure("did not throw error")

--- a/Tests/Functional/ErrorHandling/main.swift
+++ b/Tests/Functional/ErrorHandling/main.swift
@@ -16,6 +16,8 @@ class ErrorHandling: XCTestCase {
     static var allTests = {
         return [
             // Tests for XCTAssertThrowsError
+            ("test_shouldRethrowErrorFromHandler", test_shouldRethrowErrorFromHandler),
+            ("test_shouldNotRethrowWhenHandlerDoesNotThrow", test_shouldNotRethrowWhenHandlerDoesNotThrow),
             ("test_shouldButDoesNotThrowErrorInAssertion", test_shouldButDoesNotThrowErrorInAssertion),
             ("test_shouldThrowErrorInAssertion", test_shouldThrowErrorInAssertion),
             ("test_throwsErrorInAssertionButFailsWhenCheckingError", test_throwsErrorInAssertionButFailsWhenCheckingError),
@@ -57,6 +59,19 @@ class ErrorHandling: XCTestCase {
     
     func functionThatDoesThrowError() throws {
         throw SomeError.anError("an error message")
+    }
+
+// CHECK: Test Case 'ErrorHandling.test_shouldRethrowErrorFromHandler' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: .*[/\\]ErrorHandling[/\\]main.swift:[[@LINE+3]]: error: ErrorHandling.test_shouldRethrowErrorFromHandler : XCTAssertThrowsError threw error "anError\("an error message"\)" -
+// CHECK: Test Case 'ErrorHandling.test_shouldRethrowErrorFromHandler' failed \(\d+\.\d+ seconds\)
+    func test_shouldRethrowErrorFromHandler() throws {
+        try XCTAssertThrowsError(try functionThatDoesThrowError()) {_ in try functionThatDoesThrowError() }
+    }
+
+// CHECK: Test Case 'ErrorHandling.test_shouldNotRethrowWhenHandlerDoesNotThrow' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ErrorHandling.test_shouldNotRethrowWhenHandlerDoesNotThrow' passed \(\d+\.\d+ seconds\)
+    func test_shouldNotRethrowWhenHandlerDoesNotThrow() throws {
+        try XCTAssertThrowsError(try functionThatDoesThrowError()) {_ in try functionThatDoesNotThrowError() }
     }
 
 // CHECK: Test Case 'ErrorHandling.test_shouldButDoesNotThrowErrorInAssertion' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
@@ -278,11 +293,11 @@ class ErrorHandling: XCTestCase {
 }
 
 // CHECK: Test Suite 'ErrorHandling' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed \d+ tests, with \d+ failures \(5 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(6 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ErrorHandling.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed \d+ tests, with \d+ failures \(5 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(6 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed \d+ tests, with \d+ failures \(5 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed \d+ tests, with \d+ failures \(6 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds


### PR DESCRIPTION
The error handler for the XCTAssertThrowsError is not allowed to throw errors. This limits the code that we can write in the handler or forces us to use workarounds(i.e. explicit call XCTFail if the code inside the handler throws errors).
This PR creates an overload of the XCTAssertThrowsError to allow to the handler to throw errors.

See more details in https://forums.swift.org/t/change-xctassertthrowserror-function-signature-to-rethrow-when-the-error-handler-throws/45713.

I created an overload of the method because if I declare the original as rethrows then it will throw if the expression argument throws.

I build the framework and run the tests. Everything seems OK. If you would like I could add some unit tests for this.