### PR TITLE
tests: allow passing in SDKROOT for Windows as well

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -73,6 +73,9 @@ else:
     # We need to jump through extra hoops to link swift-corelibs-foundation.
     foundation_dir = _getenv('FOUNDATION_BUILT_PRODUCTS_DIR')
     if platform.system() == 'Windows':
+        sdkroot = os.getenv('SDKROOT', None)
+        if sdkroot:
+            swift_exec.extend(['-sdk', sdkroot])
         swift_exec.extend(['-Xlinker', '-nodefaultlib:libcmt'])
     else:
         swift_exec.extend([


### PR DESCRIPTION
Allow passing through `-sdk %SDKROOT%` on Windows for tests.