### PR TITLE
Tests: add a workaround for Windows

### DIFF
--- a/Tests/Functional/Asynchronous/Use/main.swift
+++ b/Tests/Functional/Asynchronous/Use/main.swift
@@ -3,6 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 // REQUIRES: concurrency_runtime
 
+// UNSUPPORTED: OS=windows
+
 #if os(macOS)
     import SwiftXCTest
 #else
@@ -57,7 +59,7 @@ class AsyncAwaitTests: XCTestCase {
     override func setUp() async throws {}
     
     override func tearDown() async throws {}
-    
+
     // CHECK: Test Case 'AsyncAwaitTests.test_explicitFailures_withinAsyncTests_areReported' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     // CHECK: .*[/\\]Asynchronous[/\\]Use[/\\]main.swift:[[@LINE+3]]: error: AsyncAwaitTests.test_explicitFailures_withinAsyncTests_areReported : XCTAssertTrue failed -
     // CHECK: Test Case 'AsyncAwaitTests.test_explicitFailures_withinAsyncTests_areReported' failed \(\d+\.\d+ seconds\)

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -151,3 +151,5 @@ os_is_not_macOS = run_os != 'Darwin'
 macOS_version_is_recent_enough = parse_version(run_vers) >= parse_version('12.0')
 if os_is_not_macOS or macOS_version_is_recent_enough:
     config.available_features.add('concurrency_runtime')
+if run_os == 'Windows':
+    config.available_features.add('OS=windows')


### PR DESCRIPTION
The Windows test regularly fails if the stdout is not flushed on
completion.  This increases the stability of the tests on Windows
(though there is another async related issue lurking that causes a
sporadic failure).