### PR TITLE
Backport async support to 5.5, PR #2

### DIFF
--- a/Tests/Functional/Asynchronous/Use/main.swift
+++ b/Tests/Functional/Asynchronous/Use/main.swift
@@ -3,6 +3,8 @@
 // RUN: %{xctest_checker} %t %s
 // REQUIRES: concurrency_runtime
 
+// UNSUPPORTED: OS=windows
+
 #if os(macOS)
     import SwiftXCTest
 #else
@@ -57,7 +59,7 @@ class AsyncAwaitTests: XCTestCase {
     override func setUp() async throws {}
     
     override func tearDown() async throws {}
-    
+
     // CHECK: Test Case 'AsyncAwaitTests.test_explicitFailures_withinAsyncTests_areReported' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
     // CHECK: .*[/\\]Asynchronous[/\\]Use[/\\]main.swift:[[@LINE+3]]: error: AsyncAwaitTests.test_explicitFailures_withinAsyncTests_areReported : XCTAssertTrue failed -
     // CHECK: Test Case 'AsyncAwaitTests.test_explicitFailures_withinAsyncTests_areReported' failed \(\d+\.\d+ seconds\)

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -148,3 +148,5 @@ os_is_not_macOS = run_os != 'Darwin'
 macOS_version_is_recent_enough = parse_version(run_vers) >= parse_version('12.0')
 if os_is_not_macOS or macOS_version_is_recent_enough:
     config.available_features.add('concurrency_runtime')
+if run_os == 'Windows':
+    config.available_features.add('OS=windows')

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -75,6 +75,9 @@ else:
     # We need to jump through extra hoops to link swift-corelibs-foundation.
     foundation_dir = _getenv('FOUNDATION_BUILT_PRODUCTS_DIR')
     if platform.system() == 'Windows':
+        sdkroot = os.getenv('SDKROOT', None)
+        if sdkroot:
+            swift_exec.extend(['-sdk', sdkroot])
         swift_exec.extend(['-Xlinker', '-nodefaultlib:libcmt'])
     else:
         swift_exec.extend([


### PR DESCRIPTION
This includes a set of changes that @compnerd landed. We're back porting these to 5.5 so more users can take advantage of `async/await` in XCTest. 