### PR TITLE
[SR-1625] Remove LD_LIBRARY_PATH from tests

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -119,16 +119,10 @@ else:
                 '-L', os.path.join(libdispatch_build_dir, 'src', 'swift'),
             ])
 
-    config.environment['LD_LIBRARY_PATH'] = ":".join([
-      libdispatch_build_dir,
-      os.path.join(libdispatch_build_dir, 'src'),
-      foundation_dir,
-      os.path.join(foundation_dir, 'Foundation'),
-      os.path.join(foundation_dir, 'Sources', 'Foundation'),
-      os.path.join(foundation_dir, 'Sources', 'FoundationNetworking'),
-      os.path.join(foundation_dir, 'Sources', 'FoundationXML'),
-      os.path.join(foundation_dir, 'lib'),
-    ])
+            if platform.system() != 'Windows':
+                swift_exec.extend([
+                    '-Xlinker', '-rpath', '-Xlinker', libdispatch_build_dir,
+                ])
 
 # Having prepared the swiftc command, we set the substitution.
 config.substitutions.append(('%{swiftc}', ' '.join(swift_exec)))


### PR DESCRIPTION
This was put in as a hack five and a half years ago, SR-1625, but it now breaks using the early swift-driver on ELF platforms like Android, because this `LD_LIBRARY_PATH` overrides the Foundation rpath that the early swift-driver gets from a host toolchain.

I was able to get the same tests to pass natively on Android with this patch, let's see if it works on the CI for other non-Darwin platforms.