### PR TITLE
Tests: enable the previously disabled test on Windows

### DIFF
--- a/Tests/Functional/Asynchronous/Use/main.swift
+++ b/Tests/Functional/Asynchronous/Use/main.swift
@@ -3,8 +3,6 @@
 // RUN: %{xctest_checker} %t %s
 // REQUIRES: concurrency_runtime
 
-// UNSUPPORTED: OS=windows
-
 #if os(macOS)
     import SwiftXCTest
 #else


### PR DESCRIPTION
Now that the underlying issue for the concurrency instability is
resolved, re-enable the test on Windows.