### PR TITLE
Support XCTestExpectation creation APIs on XCTestCase from non-main threads

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -41,6 +41,7 @@ public extension XCTestCase {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
+    // FIXME: This should have `@MainActor` to match Xcode XCTest, but adding it causes errors in tests authored pre-Swift Concurrency which don't typically have `@MainActor`.
     func waitForExpectations(timeout: TimeInterval, file: StaticString = #file, line: Int = #line, handler: XCWaitCompletionHandler? = nil) {
         precondition(Thread.isMainThread, "\(#function) must be called on the main thread")
         if currentWaiter != nil {
@@ -58,7 +59,7 @@ public extension XCTestCase {
 
         currentWaiter = nil
 
-        cleanUpExpectations()
+        cleanUpExpectations(expectations)
 
         // The handler is invoked regardless of whether the test passed.
         if let handler = handler {


### PR DESCRIPTION
This matches a behavior change made in the Xcode copy of XCTest and allows tests which call `XCTestCase.expectation(description:)` — as well as other `XCTestCase` APIs that return an `XCTestExpectation` — to do so from any thread. This removes a previous requirement that tests call these APIs from the main thread, and it allows existing tests using them to adopt `async` without requiring `@MainActor`.

rdar://85344643
rdar://79163972
rdar://81024086