### PR TITLE
Make XCTestExpectation Sendable

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift
@@ -11,7 +11,7 @@
 //
 
 /// Expectations represent specific conditions in asynchronous testing.
-open class XCTestExpectation {
+open class XCTestExpectation: @unchecked Sendable {
 
     private static var currentMonotonicallyIncreasingToken: UInt64 = 0
     private static func queue_nextMonotonicallyIncreasingToken() -> UInt64 {

--- a/Tests/Functional/Asynchronous/ExpectationsWithConcurrency/main.swift
+++ b/Tests/Functional/Asynchronous/ExpectationsWithConcurrency/main.swift
@@ -1,0 +1,12 @@
+// RUN: %{swiftc} %s -typecheck -warn-concurrency -warnings-as-errors
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+let expectation = XCTestExpectation()
+Task.detached {
+    expectation.fulfill()
+}


### PR DESCRIPTION
This makes the `XCTestExpectation` class hierarchy conform to `Sendable`. This class and its descendants are designed to be used concurrently and are already internally concurrency-safe, so this conformance formally permits them to be used in Swift Concurrency APIs which enforce sendability.

Includes a build-only test which has concurrency warnings enabled to validate the fix.

rdar://95746454