### PR TITLE
Enable C language in CMakeList to avoid error finding LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set_target_properties(XCTest PROPERTIES
 if(ENABLE_TESTING)
   enable_testing()
 
+  enable_language(C)
   find_package(LLVM CONFIG)
   if(LLVM_FOUND)
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")


### PR DESCRIPTION
With the absortion of
https://github.com/apple/llvm-project/commit/b66339575a9b541e67ce5ad2ba7e88da07cf9305 in stable/20220421, the LLVMConfig might try to execute C code if Terminfo library is found in the system. However the project line of XCTest does not enable the C language, and finding the package might fail in that case.

This is not a problem in Swift CI because the CI machines does not seem to have the Terminfo library (as reported in their logs during the configuration of XCTest). This might only affect developers in their local machines.