### PR TITLE
Lower macOS availability of async APIs from 12.0 to 10.15

### DIFF
--- a/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift
+++ b/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift
@@ -19,7 +19,7 @@ extension XCTestCase {
         // which can unexpectedly change their semantics in difficult to track down ways.
         //
         // Because of this, we chose the unusual decision to forgo overloading (which is a super sweet language feature <3) to prevent this issue from surprising any contributors to corelibs-xctest
-        @available(macOS 12.0, *)
+        @available(macOS 10.15, *)
         func appendAsync(_ block: @Sendable @escaping () async throws -> Void) {
             self.append {
                 try awaitUsingExpectation { try await block() }

--- a/Sources/XCTest/Public/XCAbstractTest.swift
+++ b/Sources/XCTest/Public/XCAbstractTest.swift
@@ -53,7 +53,7 @@ open class XCTest {
     }
 
     /// Async setup method called before the invocation of `setUpWithError` for each test method in the class.
-    @available(macOS 12.0, *)
+    @available(macOS 10.15, *)
     open func setUp() async throws {}
     /// Setup method called before the invocation of `setUp` and the test method
     /// for each test method in the class.
@@ -73,7 +73,7 @@ open class XCTest {
 
     /// Async teardown method which is called after the invocation of `tearDownWithError`
     /// for each test method in the class.
-    @available(macOS 12.0, *)
+    @available(macOS 10.15, *)
     open func tearDown() async throws {}
     // FIXME: This initializer is required due to a Swift compiler bug on Linux.
     //        It should be removed once the bug is fixed.

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -206,7 +206,7 @@ open class XCTestCase: XCTest {
 
     /// Registers a block of teardown code to be run after the current test
     /// method ends.
-    @available(macOS 12.0, *)
+    @available(macOS 10.15, *)
     public func addTeardownBlock(_ block: @Sendable @escaping () async throws -> Void) {
         teardownBlocksState.appendAsync(block)
     }
@@ -227,7 +227,7 @@ open class XCTestCase: XCTest {
         }
 
         do {
-            if #available(macOS 12.0, *) {
+            if #available(macOS 10.15, *) {
                 try awaitUsingExpectation {
                     try await self.setUp()
                 }
@@ -273,7 +273,7 @@ open class XCTestCase: XCTest {
         }
 
         do {
-            if #available(macOS 12.0, *) {
+            if #available(macOS 10.15, *) {
                 try awaitUsingExpectation {
                     try await self.tearDown()
                 }
@@ -321,7 +321,7 @@ private func test<T: XCTestCase>(_ testFunc: @escaping (T) -> () throws -> Void)
     }
 }
 
-@available(macOS 12.0, *)
+@available(macOS 10.15, *)
 public func asyncTest<T: XCTestCase>(
     _ testClosureGenerator: @escaping (T) -> () async throws -> Void
 ) -> (T) -> () throws -> Void {
@@ -333,7 +333,7 @@ public func asyncTest<T: XCTestCase>(
     }
 }
 
-@available(macOS 12.0, *)
+@available(macOS 10.15, *)
 func awaitUsingExpectation(
     _ closure: @escaping () async throws -> Void
 ) throws -> Void {


### PR DESCRIPTION
After async test support was added to this version of XCTest in #331, the Swift async/await feature became available in older Apple OSes, and on macOS specifically it changed from requiring 12.0 to 10.15. So this lowers the availability of all macOS 12.0 requirements of async APIs to 10.15.