### PR TITLE
tests: add the ability to pass along CMAKE_Swift_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
+                      SWIFT_FLAGS=${CMAKE_Swift_FLAGS}
                       $<TARGET_FILE:Python3::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT
                       "Running XCTest functional test suite"

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -11,6 +11,7 @@ from pkg_resources import parse_version
 import os
 import platform
 import tempfile
+import shlex
 import sys
 import lit
 import pipes
@@ -42,6 +43,7 @@ def _getenv(name):
 built_products_dir = _getenv('BUILT_PRODUCTS_DIR')
 # Force tests to build with -swift-version 5 for now.
 swift_exec = [ _getenv('SWIFT_EXEC'), '-swift-version', '5', ]
+swift_exec.extend(shlex.split(os.getenv('SWIFT_FLAGS', '')))
 if not platform.system() == 'Windows':
     swift_exec.extend(['-Xlinker', '-rpath', '-Xlinker', built_products_dir,])
 swift_exec.extend([


### PR DESCRIPTION
Pass along any compiler flags to the tests.  This is required on Windows for testing where we add a VFS overlay through the flags now to avoid modifying the Visual Studio installation.