### PR TITLE
Disambiguate the lib install path for different architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,8 @@ endif()
 set_property(GLOBAL APPEND PROPERTY XCTest_EXPORTS XCTest)
 get_swift_host_arch(swift_arch)
 install(TARGETS XCTest
-  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch}
+  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch}
   RUNTIME DESTINATION bin)
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/swift/XCTest.swiftdoc


### PR DESCRIPTION
The CMake install path for XCTests libs overlaps for different architectures on Windows, complicating building for multiple architectures on the same machine. This change adds an architecture subfolder, consistent with what we have for `XCTest.swiftdoc` and `XCTest.swiftmodule`.

The same problem applies to `bin`, but is better resolved by https://github.com/apple/swift-corelibs-xctest/pull/433

Co-dependent on https://github.com/apple/swift-installer-scripts/pull/181