### PR TITLE
Escape CMAKE_Swift_FLAGS to preserve Windows path separators when running tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ if(ENABLE_TESTING)
 
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
+  string(REPLACE "\\" "\\\\" CMAKE_Swift_FLAGS_ESCAPED ${CMAKE_Swift_FLAGS})
   add_custom_target(check-xctest
                     COMMAND
                     ${CMAKE_COMMAND} -E env
@@ -104,7 +105,7 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
-                      SWIFT_FLAGS=${CMAKE_Swift_FLAGS}
+                      SWIFT_FLAGS=${CMAKE_Swift_FLAGS_ESCAPED}
                       $<TARGET_FILE:Python3::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT
                       "Running XCTest functional test suite"


### PR DESCRIPTION
Swift flags can include paths, which lost their `\` separators to CMake's escaping when running tests.