### PR TITLE
Tests: add vfs overlay for dipsatch

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -119,6 +119,7 @@ else:
                 '-L', os.path.join(libdispatch_build_dir, 'src'),
                 '-L', os.path.join(libdispatch_build_dir, 'src', 'BlocksRuntime'),
                 '-L', os.path.join(libdispatch_build_dir, 'src', 'swift'),
+                '-vfsoverlay', os.path.join(libdispatch_build_dir, 'dispatch-vfs-overlay.yaml'),
             ])
 
             if platform.system() != 'Windows':


### PR DESCRIPTION
Introduce an additional compile time parameter for swift builds in the tests to pass along the VFS overlay for dispatch if the build directory is present.  This ensures that we prefer the just built dispatch over the installed dispatch which is a prerequisite for permitting building Foundation et al with a build tree of dispatch when we have an installed toolchain.