### PR TITLE
XCTest: update shebang line to name python3 instead of python generically.

### DIFF
--- a/Tests/Functional/xctest_checker/xctest_checker.py
+++ b/Tests/Functional/xctest_checker/xctest_checker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # xctest_checker.py - Verify XCTest output -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/Tests/Functional/xctest_checker/xctest_checker/main.py
+++ b/Tests/Functional/xctest_checker/xctest_checker/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # xctest_checker/main.py - Entry point for xctest_checker -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/build_script.py
+++ b/build_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # build_script.py - Build, install, and test XCTest -*- python -*-
 #
 # This source file is part of the Swift.org open source project


### PR DESCRIPTION
Motivated by [failure](https://ci.swift.org/job/swift-corelibs-foundation-PR-macOS/221/execution/node/43/log/) from https://github.com/apple/swift-corelibs-foundation/pull/4740's test runs, which ended with:
```
+ /Users/ec2-user/jenkins/workspace/swift-corelibs-foundation-PR-macOS/branch-main/swift-corelibs-xctest/build_script.py --swiftc=/Users/ec2-user/jenkins/workspace/swift-corelibs-foundation-PR-macOS/branch-main/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc --build-dir=/Users/ec2-user/jenkins/workspace/swift-corelibs-foundation-PR-macOS/branch-main/build/Ninja-ReleaseAssert/xctest-macosx-x86_64 --foundation-build-dir=/Users/ec2-user/jenkins/workspace/swift-corelibs-foundation-PR-macOS/branch-main/build/Ninja-ReleaseAssert/foundation-macosx-x86_64 --swift-build-dir=/Users/ec2-user/jenkins/workspace/swift-corelibs-foundation-PR-macOS/branch-main/build/Ninja-ReleaseAssert/swift-macosx-x86_64 --release
env: python: No such file or directory
```