### PR TITLE
Disable Swift backtracer in a deliberately-crashing test.

### DIFF
--- a/Tests/Functional/TestCaseLifecycle/Misuse/main.swift
+++ b/Tests/Functional/TestCaseLifecycle/Misuse/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -g -o %T/TestCaseLifecycleMisuse
-// RUN: %T/TestCaseLifecycleMisuse > %t || true
+// RUN: env SWIFT_BACKTRACE=enable=no %T/TestCaseLifecycleMisuse > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)


### PR DESCRIPTION
With the new backtracer enabled, you get extra output, so this test fails.

rdar://110315737