### PR TITLE
build_script.py: use `python3` by default

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # build_script.py - Build, install, and test XCTest -*- python -*-
 #
 # This source file is part of the Swift.org open source project


### PR DESCRIPTION
We're seeing sporadic CI failures, since apparently some nodes don't have `python` symlinking to a correct Python version. Changing this to `python3` will also make it consistent with the rest of the Python scripts in the Swift project.

Unblocks macOS CI check for https://github.com/apple/swift-corelibs-xctest/pull/421.