### PR TITLE
[5.9] build_script.py: use `python3` by default

### DIFF
--- a/build_script.py
+++ b/build_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # build_script.py - Build, install, and test XCTest -*- python -*-
 #
 # This source file is part of the Swift.org open source project


### PR DESCRIPTION
We're seeing sporadic CI failures, since apparently some CI nodes don't have `python` symlinking to a correct Python version. Changing this to `python3` will also make it consistent with the rest of the Python scripts in the Swift project.

Risk: low, all other Python scripts in the `swift` and `swift-package-manager` repositories already include this change and use `python3` in both `main` and `release/5.9` branches.
Original PRs: https://github.com/apple/swift-corelibs-xctest/pull/449
Reviewed by: @grynspan
Resolves: unblocks PRs on the `swift-corelibs-foundation` repository that build XCTest as a part of their CI jobs.
Tests: N/A