### PR TITLE
Add @MainActor to waitForExpectations(timeout:handler:) #428

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -41,7 +41,7 @@ public extension XCTestCase {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    // FIXME: This should have `@MainActor` to match Xcode XCTest, but adding it causes errors in tests authored pre-Swift Concurrency which don't typically have `@MainActor`.
+    @preconcurrency @MainActor
     func waitForExpectations(timeout: TimeInterval, file: StaticString = #file, line: Int = #line, handler: XCWaitCompletionHandler? = nil) {
         precondition(Thread.isMainThread, "\(#function) must be called on the main thread")
         if currentWaiter != nil {

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -48,7 +48,7 @@ open class XCTestCase: XCTest {
         return 1
     }
 
-    // FIXME: Once `waitForExpectations(timeout:...handler:)` gains `@MainActor`, this may be able to add it as well.
+    @MainActor
     internal var currentWaiter: XCTWaiter?
 
     /// The set of expectations made upon this test case.

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -551,7 +551,37 @@ class ExpectationsTestCase: XCTestCase {
         RunLoop.main.run(until: Date() + 1)
     }
 
-    static var allTests = {
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' failed \(\d+\.\d+ seconds\)
+    func test_waitForExpectationsAsync() async {
+      // Basic check that waitForExpectations() is functional when used with the
+      // await keyword in an async function.
+      let expectation = self.expectation(description: "foo")
+      expectation.fulfill()
+      await self.waitForExpectations(timeout: 0.0)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' failed \(\d+\.\d+ seconds\)
+    @MainActor func test_waitForExpectationsFromMainActor() {
+      // Basic check that waitForExpectations() is functional and does not need
+      // the await keyword when used from a main-actor-isolated test function.
+      let expectation = self.expectation(description: "foo")
+      expectation.fulfill()
+      self.waitForExpectations(timeout: 0.0)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' failed \(\d+\.\d+ seconds\)
+    @MainActor func test_waitForExpectationsFromMainActor_async() async {
+      // Basic check that waitForExpectations() is functional and does not need
+      // the await keyword when used from a main-actor-isolated test function.
+      let expectation = self.expectation(description: "foo")
+      expectation.fulfill()
+      self.waitForExpectations(timeout: 0.0)
+    }
+
+    static var allTests: [(String, (ExpectationsTestCase) -> () throws -> Void)] = {
         return [
             ("test_waitingForAnUnfulfilledExpectation_fails", test_waitingForAnUnfulfilledExpectation_fails),
             ("test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails", test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails),
@@ -603,15 +633,20 @@ class ExpectationsTestCase: XCTestCase {
             ("test_expectationCreationOnSecondaryThread", test_expectationCreationOnSecondaryThread),
             ("test_expectationCreationWhileWaiting", test_expectationCreationWhileWaiting),
             ("test_runLoopInsideDispatch", test_runLoopInsideDispatch),
+
+            // waitForExpectations() + @MainActor
+            ("test_waitForExpectationsAsync", asyncTest(test_waitForExpectationsAsync)),
+            ("test_waitForExpectationsFromMainActor", asyncTest { test_waitForExpectationsFromMainActor($0) }),
+            ("test_waitForExpectationsFromMainActor_async", asyncTest { test_waitForExpectationsFromMainActor_async($0) }),
         ]
     }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 38 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ExpectationsTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 38 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 38 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -551,8 +551,8 @@ class ExpectationsTestCase: XCTestCase {
         RunLoop.main.run(until: Date() + 1)
     }
 
-// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' failed \(\d+\.\d+ seconds\)
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' failed \(\d+\.\d+ seconds\)
     func test_waitForExpectationsAsync() async {
       // Basic check that waitForExpectations() is functional when used with the
       // await keyword in an async function.

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -563,22 +563,14 @@ class ExpectationsTestCase: XCTestCase {
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' passed \(\d+\.\d+ seconds\)
-    @MainActor func test_waitForExpectationsFromMainActor() {
-        // Basic check that waitForExpectations() is functional and does not need
-        // the await keyword when used from a main-actor-isolated test function.
-        let expectation = self.expectation(description: "foo")
-        expectation.fulfill()
-        self.waitForExpectations(timeout: 0.0)
-    }
-
-// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' passed \(\d+\.\d+ seconds\)
-    @MainActor func test_waitForExpectationsFromMainActor_async() async {
-        // Basic check that waitForExpectations() is functional and does not need
-        // the await keyword when used from a main-actor-isolated test function.
-        let expectation = self.expectation(description: "foo")
-        expectation.fulfill()
-        self.waitForExpectations(timeout: 0.0)
+    func test_waitForExpectationsFromMainActor() async {
+        await MainActor.run {
+            // Basic check that waitForExpectations() is functional and does not need
+            // the await keyword when used from a main-actor-isolated test function.
+            let expectation = self.expectation(description: "foo")
+            expectation.fulfill()
+            self.waitForExpectations(timeout: 0.0)
+        }
     }
 
     static var allTests = {
@@ -636,9 +628,7 @@ class ExpectationsTestCase: XCTestCase {
 
             // waitForExpectations() + @MainActor
             ("test_waitForExpectationsAsync", asyncTest(test_waitForExpectationsAsync)),
-            // Disabled due to a SILGen crash: <rdar://111340003>
-            // ("test_waitForExpectationsFromMainActor", asyncTest(test_waitForExpectationsFromMainActor)),
-            // ("test_waitForExpectationsFromMainActor_async", asyncTest(test_waitForExpectationsFromMainActor_async)),
+            ("test_waitForExpectationsFromMainActor", asyncTest(test_waitForExpectationsFromMainActor)),
         ]
     }()
 }

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -554,34 +554,34 @@ class ExpectationsTestCase: XCTestCase {
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' failed \(\d+\.\d+ seconds\)
     func test_waitForExpectationsAsync() async {
-      // Basic check that waitForExpectations() is functional when used with the
-      // await keyword in an async function.
-      let expectation = self.expectation(description: "foo")
-      expectation.fulfill()
-      await self.waitForExpectations(timeout: 0.0)
+        // Basic check that waitForExpectations() is functional when used with the
+        // await keyword in an async function.
+        let expectation = self.expectation(description: "foo")
+        expectation.fulfill()
+        await self.waitForExpectations(timeout: 0.0)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' failed \(\d+\.\d+ seconds\)
     @MainActor func test_waitForExpectationsFromMainActor() {
-      // Basic check that waitForExpectations() is functional and does not need
-      // the await keyword when used from a main-actor-isolated test function.
-      let expectation = self.expectation(description: "foo")
-      expectation.fulfill()
-      self.waitForExpectations(timeout: 0.0)
+        // Basic check that waitForExpectations() is functional and does not need
+        // the await keyword when used from a main-actor-isolated test function.
+        let expectation = self.expectation(description: "foo")
+        expectation.fulfill()
+        self.waitForExpectations(timeout: 0.0)
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' failed \(\d+\.\d+ seconds\)
     @MainActor func test_waitForExpectationsFromMainActor_async() async {
-      // Basic check that waitForExpectations() is functional and does not need
-      // the await keyword when used from a main-actor-isolated test function.
-      let expectation = self.expectation(description: "foo")
-      expectation.fulfill()
-      self.waitForExpectations(timeout: 0.0)
+        // Basic check that waitForExpectations() is functional and does not need
+        // the await keyword when used from a main-actor-isolated test function.
+        let expectation = self.expectation(description: "foo")
+        expectation.fulfill()
+        self.waitForExpectations(timeout: 0.0)
     }
 
-    static var allTests: [(String, (ExpectationsTestCase) -> () throws -> Void)] = {
+    static var allTests = {
         return [
             ("test_waitingForAnUnfulfilledExpectation_fails", test_waitingForAnUnfulfilledExpectation_fails),
             ("test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails", test_waitingForUnfulfilledExpectations_outputsAllExpectations_andFails),
@@ -636,8 +636,8 @@ class ExpectationsTestCase: XCTestCase {
 
             // waitForExpectations() + @MainActor
             ("test_waitForExpectationsAsync", asyncTest(test_waitForExpectationsAsync)),
-            ("test_waitForExpectationsFromMainActor", asyncTest { test_waitForExpectationsFromMainActor($0) }),
-            ("test_waitForExpectationsFromMainActor_async", asyncTest { test_waitForExpectationsFromMainActor_async($0) }),
+            ("test_waitForExpectationsFromMainActor", asyncTest(test_waitForExpectationsFromMainActor)),
+            ("test_waitForExpectationsFromMainActor_async", asyncTest(test_waitForExpectationsFromMainActor_async)),
         ]
     }()
 }

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -633,11 +633,11 @@ class ExpectationsTestCase: XCTestCase {
     }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 36 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 37 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ExpectationsTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 36 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 37 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 36 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 37 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -636,17 +636,18 @@ class ExpectationsTestCase: XCTestCase {
 
             // waitForExpectations() + @MainActor
             ("test_waitForExpectationsAsync", asyncTest(test_waitForExpectationsAsync)),
-            ("test_waitForExpectationsFromMainActor", asyncTest(test_waitForExpectationsFromMainActor)),
-            ("test_waitForExpectationsFromMainActor_async", asyncTest(test_waitForExpectationsFromMainActor_async)),
+            // Disabled due to a SILGen crash: <rdar://111340003>
+            // ("test_waitForExpectationsFromMainActor", asyncTest(test_waitForExpectationsFromMainActor)),
+            // ("test_waitForExpectationsFromMainActor_async", asyncTest(test_waitForExpectationsFromMainActor_async)),
         ]
     }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 38 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 36 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ExpectationsTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 38 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 36 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 38 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 36 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -552,7 +552,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' failed \(\d+\.\d+ seconds\)
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' passed \(\d+\.\d+ seconds\)
     func test_waitForExpectationsAsync() async {
         // Basic check that waitForExpectations() is functional when used with the
         // await keyword in an async function.
@@ -562,7 +562,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' failed \(\d+\.\d+ seconds\)
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' passed \(\d+\.\d+ seconds\)
     @MainActor func test_waitForExpectationsFromMainActor() {
         // Basic check that waitForExpectations() is functional and does not need
         // the await keyword when used from a main-actor-isolated test function.
@@ -572,7 +572,7 @@ class ExpectationsTestCase: XCTestCase {
     }
 
 // CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' failed \(\d+\.\d+ seconds\)
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor_async' passed \(\d+\.\d+ seconds\)
     @MainActor func test_waitForExpectationsFromMainActor_async() async {
         // Basic check that waitForExpectations() is functional and does not need
         // the await keyword when used from a main-actor-isolated test function.


### PR DESCRIPTION
This change makes `waitForExpectations()` as main-actor-isolated, as it is in Xcode's version of XCTest. It is marked `@preconcurrency @MainActor` so that existing synchronous functions can continue to use it without `await` or `@MainActor`.

Resolves #428.