### PR TITLE
XCTestCase.fulfillment(…) missing on Linux #436

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -276,7 +276,8 @@ open class XCTWaiter {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    @available(macOS 12.0, *) @discardableResult
+    @available(macOS 12.0, *)
+    @discardableResult
     open func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async -> Result {
         return await withCheckedContinuation { continuation in
             // This function operates by blocking a background thread instead of one owned by libdispatch or by the

--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -187,6 +187,7 @@ open class XCTWaiter {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
+    @available(*, noasync, message: "Use await fulfillment(of:timeout:enforceOrder:) instead.")
     @discardableResult
     open func wait(for expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) -> Result {
         precondition(Set(expectations).count == expectations.count, "API violation - each expectation can appear only once in the 'expectations' parameter.")
@@ -252,6 +253,42 @@ open class XCTWaiter {
         return result
     }
 
+    /// Wait on an array of expectations for up to the specified timeout, and optionally specify whether they
+    /// must be fulfilled in the given order. May return early based on fulfillment of the waited on expectations.
+    ///
+    /// - Parameter expectations: The expectations to wait on.
+    /// - Parameter timeout: The maximum total time duration to wait on all expectations.
+    /// - Parameter enforceOrder: Specifies whether the expectations must be fulfilled in the order
+    ///   they are specified in the `expectations` Array. Default is false.
+    /// - Parameter file: The file name to use in the error message if
+    ///   expectations are not fulfilled before the given timeout. Default is the file
+    ///   containing the call to this method. It is rare to provide this
+    ///   parameter when calling this method.
+    /// - Parameter line: The line number to use in the error message if the
+    ///   expectations are not fulfilled before the given timeout. Default is the line
+    ///   number of the call to this method in the calling file. It is rare to
+    ///   provide this parameter when calling this method.
+    ///
+    /// - Note: Whereas Objective-C XCTest determines the file and line
+    ///   number of the "wait" call using symbolication, this implementation
+    ///   opts to take `file` and `line` as parameters instead. As a result,
+    ///   the interface to these methods are not exactly identical between
+    ///   these environments. To ensure compatibility of tests between
+    ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
+    ///   explicit values for `file` and `line`.
+    @available(macOS 12.0, *) @discardableResult
+    open func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async -> Result {
+        return await withCheckedContinuation { continuation in
+            // This function operates by blocking a background thread instead of one owned by libdispatch or by the
+            // Swift runtime (as used by Swift concurrency.) To ensure we use a thread owned by neither subsystem, use
+            // Foundation's Thread.detachNewThread(_:).
+            Thread.detachNewThread { [self] in
+                let result = wait(for: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
     /// Convenience API to create an XCTWaiter which then waits on an array of expectations for up to the specified timeout, and optionally specify whether they
     /// must be fulfilled in the given order. May return early based on fulfillment of the waited on expectations. The waiter
     /// is discarded when the wait completes.
@@ -268,8 +305,30 @@ open class XCTWaiter {
     ///   expectations are not fulfilled before the given timeout. Default is the line
     ///   number of the call to this method in the calling file. It is rare to
     ///   provide this parameter when calling this method.
+    @available(*, noasync, message: "Use await fulfillment(of:timeout:enforceOrder:) instead.")
     open class func wait(for expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) -> Result {
         return XCTWaiter().wait(for: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
+    }
+
+    /// Convenience API to create an XCTWaiter which then waits on an array of expectations for up to the specified timeout, and optionally specify whether they
+    /// must be fulfilled in the given order. May return early based on fulfillment of the waited on expectations. The waiter
+    /// is discarded when the wait completes.
+    ///
+    /// - Parameter expectations: The expectations to wait on.
+    /// - Parameter timeout: The maximum total time duration to wait on all expectations.
+    /// - Parameter enforceOrder: Specifies whether the expectations must be fulfilled in the order
+    ///   they are specified in the `expectations` Array. Default is false.
+    /// - Parameter file: The file name to use in the error message if
+    ///   expectations are not fulfilled before the given timeout. Default is the file
+    ///   containing the call to this method. It is rare to provide this
+    ///   parameter when calling this method.
+    /// - Parameter line: The line number to use in the error message if the
+    ///   expectations are not fulfilled before the given timeout. Default is the line
+    ///   number of the call to this method in the calling file. It is rare to
+    ///   provide this parameter when calling this method.
+    @available(macOS 12.0, *)
+    open class func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async -> Result {
+        return await XCTWaiter().fulfillment(of: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
     }
 
     deinit {

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -85,9 +85,35 @@ public extension XCTestCase {
     ///   provide this parameter when calling this method.
     ///
     /// - SeeAlso: XCTWaiter
+    @available(*, noasync, message: "Use await fulfillment(of:timeout:enforceOrder:) instead.")
     func wait(for expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) {
         let waiter = XCTWaiter(delegate: self)
         waiter.wait(for: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
+
+        cleanUpExpectations(expectations)
+    }
+
+    /// Wait on an array of expectations for up to the specified timeout, and optionally specify whether they
+    /// must be fulfilled in the given order. May return early based on fulfillment of the waited on expectations.
+    ///
+    /// - Parameter expectations: The expectations to wait on.
+    /// - Parameter timeout: The maximum total time duration to wait on all expectations.
+    /// - Parameter enforceOrder: Specifies whether the expectations must be fulfilled in the order
+    ///   they are specified in the `expectations` Array. Default is false.
+    /// - Parameter file: The file name to use in the error message if
+    ///   expectations are not fulfilled before the given timeout. Default is the file
+    ///   containing the call to this method. It is rare to provide this
+    ///   parameter when calling this method.
+    /// - Parameter line: The line number to use in the error message if the
+    ///   expectations are not fulfilled before the given timeout. Default is the line
+    ///   number of the call to this method in the calling file. It is rare to
+    ///   provide this parameter when calling this method.
+    ///
+    /// - SeeAlso: XCTWaiter
+    @available(macOS 12.0, *)
+    func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async {
+        let waiter = XCTWaiter(delegate: self)
+        await waiter.fulfillment(of: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
 
         cleanUpExpectations(expectations)
     }

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -607,11 +607,11 @@ class ExpectationsTestCase: XCTestCase {
     }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 34 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ExpectationsTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 34 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 34 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -563,6 +563,7 @@ class ExpectationsTestCase: XCTestCase {
 
             // Multiple Expectations
             ("test_multipleExpectations", test_multipleExpectations),
+            ("test_multipleExpectations_async", asyncTest(test_multipleExpectations_async)),
             ("test_multipleExpectationsEnforceOrderingCorrect", test_multipleExpectationsEnforceOrderingCorrect),
             ("test_multipleExpectationsEnforceOrderingCorrectBeforeWait", test_multipleExpectationsEnforceOrderingCorrectBeforeWait),
             ("test_multipleExpectationsEnforceOrderingIncorrect", test_multipleExpectationsEnforceOrderingIncorrect),

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -96,6 +96,21 @@ class ExpectationsTestCase: XCTestCase {
         XCTWaiter(delegate: self).wait(for: [foo, bar], timeout: 1)
     }
 
+// CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectations_async' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectations_async' passed \(\d+\.\d+ seconds\)
+    func test_multipleExpectations_async() async {
+        let foo = expectation(description: "foo")
+        let bar = XCTestExpectation(description: "bar")
+        DispatchQueue.global(qos: .default).asyncAfter(wallDeadline: .now() + 0.01) {
+            bar.fulfill()
+        }
+        DispatchQueue.global(qos: .default).asyncAfter(wallDeadline: .now() + 0.01) {
+            foo.fulfill()
+        }
+
+        await XCTWaiter(delegate: self).fulfillment(of: [foo, bar], timeout: 1)
+    }
+
 // CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectationsEnforceOrderingCorrect' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectationsEnforceOrderingCorrect' passed \(\d+\.\d+ seconds\)
     func test_multipleExpectationsEnforceOrderingCorrect() {


### PR DESCRIPTION
This change implements [`fulfillment(of:)`](https://developer.apple.com/documentation/xctest/xctwaiter/4109475-fulfillment) as found in Xcode's version of XCTest. The implementation, while (and I'm using a technical term here) ridiculous, is equivalent to the Xcode 14.3 implementation.

Resolves #436.