### PR TITLE
Expectation handlers need to be @Sendable. #454

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift
@@ -19,7 +19,7 @@ open class XCTNSNotificationExpectation: XCTestExpectation {
     /// - Returns: `true` if the expectation should be fulfilled, `false` if it should not.
     ///
     /// - SeeAlso: `XCTNSNotificationExpectation.handler`
-    public typealias Handler = (Notification) -> Bool
+    public typealias Handler = @Sendable (Notification) -> Bool
 
     private let queue = DispatchQueue(label: "org.swift.XCTest.XCTNSNotificationExpectation")
 

--- a/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
@@ -18,7 +18,7 @@ open class XCTNSPredicateExpectation: XCTestExpectation {
     /// - Returns: `true` if the expectation should be fulfilled, `false` if it should not.
     ///
     /// - SeeAlso: `XCTNSPredicateExpectation.handler`
-    public typealias Handler = () -> Bool
+    public typealias Handler = @Sendable () -> Bool
 
     private let queue = DispatchQueue(label: "org.swift.XCTest.XCTNSPredicateExpectation")
 


### PR DESCRIPTION
See for example https://developer.apple.com/documentation/xctest/xctnsnotificationexpectation/handler

The handlers for `XCTestExpectation` subclasses need to be `@Sendable` because they can be invoked asynchronously or concurrently.

Resolves #454.