### PR TITLE
[5.9] Apply recent concurrency quality-of-life fixes

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift
@@ -19,7 +19,7 @@ open class XCTNSNotificationExpectation: XCTestExpectation {
     /// - Returns: `true` if the expectation should be fulfilled, `false` if it should not.
     ///
     /// - SeeAlso: `XCTNSNotificationExpectation.handler`
-    public typealias Handler = (Notification) -> Bool
+    public typealias Handler = @Sendable (Notification) -> Bool
 
     private let queue = DispatchQueue(label: "org.swift.XCTest.XCTNSNotificationExpectation")
 

--- a/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift
@@ -18,7 +18,7 @@ open class XCTNSPredicateExpectation: XCTestExpectation {
     /// - Returns: `true` if the expectation should be fulfilled, `false` if it should not.
     ///
     /// - SeeAlso: `XCTNSPredicateExpectation.handler`
-    public typealias Handler = () -> Bool
+    public typealias Handler = @Sendable () -> Bool
 
     private let queue = DispatchQueue(label: "org.swift.XCTest.XCTNSPredicateExpectation")
 

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -85,9 +85,35 @@ public extension XCTestCase {
     ///   provide this parameter when calling this method.
     ///
     /// - SeeAlso: XCTWaiter
+    @available(*, noasync, message: "Use await fulfillment(of:timeout:enforceOrder:) instead.")
     func wait(for expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) {
         let waiter = XCTWaiter(delegate: self)
         waiter.wait(for: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
+
+        cleanUpExpectations(expectations)
+    }
+
+    /// Wait on an array of expectations for up to the specified timeout, and optionally specify whether they
+    /// must be fulfilled in the given order. May return early based on fulfillment of the waited on expectations.
+    ///
+    /// - Parameter expectations: The expectations to wait on.
+    /// - Parameter timeout: The maximum total time duration to wait on all expectations.
+    /// - Parameter enforceOrder: Specifies whether the expectations must be fulfilled in the order
+    ///   they are specified in the `expectations` Array. Default is false.
+    /// - Parameter file: The file name to use in the error message if
+    ///   expectations are not fulfilled before the given timeout. Default is the file
+    ///   containing the call to this method. It is rare to provide this
+    ///   parameter when calling this method.
+    /// - Parameter line: The line number to use in the error message if the
+    ///   expectations are not fulfilled before the given timeout. Default is the line
+    ///   number of the call to this method in the calling file. It is rare to
+    ///   provide this parameter when calling this method.
+    ///
+    /// - SeeAlso: XCTWaiter
+    @available(macOS 12.0, *)
+    func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async {
+        let waiter = XCTWaiter(delegate: self)
+        await waiter.fulfillment(of: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
 
         cleanUpExpectations(expectations)
     }

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -41,7 +41,7 @@ public extension XCTestCase {
     ///   these environments. To ensure compatibility of tests between
     ///   swift-corelibs-xctest and Apple XCTest, it is not recommended to pass
     ///   explicit values for `file` and `line`.
-    // FIXME: This should have `@MainActor` to match Xcode XCTest, but adding it causes errors in tests authored pre-Swift Concurrency which don't typically have `@MainActor`.
+    @preconcurrency @MainActor
     func waitForExpectations(timeout: TimeInterval, file: StaticString = #file, line: Int = #line, handler: XCWaitCompletionHandler? = nil) {
         precondition(Thread.isMainThread, "\(#function) must be called on the main thread")
         if currentWaiter != nil {

--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -48,7 +48,7 @@ open class XCTestCase: XCTest {
         return 1
     }
 
-    // FIXME: Once `waitForExpectations(timeout:...handler:)` gains `@MainActor`, this may be able to add it as well.
+    @MainActor
     internal var currentWaiter: XCTWaiter?
 
     /// The set of expectations made upon this test case.

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -96,6 +96,21 @@ class ExpectationsTestCase: XCTestCase {
         XCTWaiter(delegate: self).wait(for: [foo, bar], timeout: 1)
     }
 
+// CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectations_async' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectations_async' passed \(\d+\.\d+ seconds\)
+    func test_multipleExpectations_async() async {
+        let foo = expectation(description: "foo")
+        let bar = XCTestExpectation(description: "bar")
+        DispatchQueue.global(qos: .default).asyncAfter(wallDeadline: .now() + 0.01) {
+            bar.fulfill()
+        }
+        DispatchQueue.global(qos: .default).asyncAfter(wallDeadline: .now() + 0.01) {
+            foo.fulfill()
+        }
+
+        await XCTWaiter(delegate: self).fulfillment(of: [foo, bar], timeout: 1)
+    }
+
 // CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectationsEnforceOrderingCorrect' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 // CHECK: Test Case 'ExpectationsTestCase.test_multipleExpectationsEnforceOrderingCorrect' passed \(\d+\.\d+ seconds\)
     func test_multipleExpectationsEnforceOrderingCorrect() {
@@ -548,6 +563,7 @@ class ExpectationsTestCase: XCTestCase {
 
             // Multiple Expectations
             ("test_multipleExpectations", test_multipleExpectations),
+            ("test_multipleExpectations_async", asyncTest(test_multipleExpectations_async)),
             ("test_multipleExpectationsEnforceOrderingCorrect", test_multipleExpectationsEnforceOrderingCorrect),
             ("test_multipleExpectationsEnforceOrderingCorrectBeforeWait", test_multipleExpectationsEnforceOrderingCorrectBeforeWait),
             ("test_multipleExpectationsEnforceOrderingIncorrect", test_multipleExpectationsEnforceOrderingIncorrect),
@@ -591,11 +607,11 @@ class ExpectationsTestCase: XCTestCase {
     }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 34 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ExpectationsTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 34 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 34 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -551,6 +551,28 @@ class ExpectationsTestCase: XCTestCase {
         RunLoop.main.run(until: Date() + 1)
     }
 
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsAsync' passed \(\d+\.\d+ seconds\)
+    func test_waitForExpectationsAsync() async {
+        // Basic check that waitForExpectations() is functional when used with the
+        // await keyword in an async function.
+        let expectation = self.expectation(description: "foo")
+        expectation.fulfill()
+        await self.waitForExpectations(timeout: 0.0)
+    }
+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationsTestCase.test_waitForExpectationsFromMainActor' passed \(\d+\.\d+ seconds\)
+    func test_waitForExpectationsFromMainActor() async {
+        await MainActor.run {
+            // Basic check that waitForExpectations() is functional and does not need
+            // the await keyword when used from a main-actor-isolated test function.
+            let expectation = self.expectation(description: "foo")
+            expectation.fulfill()
+            self.waitForExpectations(timeout: 0.0)
+        }
+    }
+
     static var allTests = {
         return [
             ("test_waitingForAnUnfulfilledExpectation_fails", test_waitingForAnUnfulfilledExpectation_fails),
@@ -603,15 +625,19 @@ class ExpectationsTestCase: XCTestCase {
             ("test_expectationCreationOnSecondaryThread", test_expectationCreationOnSecondaryThread),
             ("test_expectationCreationWhileWaiting", test_expectationCreationWhileWaiting),
             ("test_runLoopInsideDispatch", test_runLoopInsideDispatch),
+
+            // waitForExpectations() + @MainActor
+            ("test_waitForExpectationsAsync", asyncTest(test_waitForExpectationsAsync)),
+            ("test_waitForExpectationsFromMainActor", asyncTest(test_waitForExpectationsFromMainActor)),
         ]
     }()
 }
 // CHECK: Test Suite 'ExpectationsTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 37 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 
 XCTMain([testCase(ExpectationsTestCase.allTests)])
 
 // CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 37 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
 // CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-// CHECK: \t Executed 35 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: \t Executed 37 tests, with 16 failures \(2 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds


### PR DESCRIPTION
**Explanation:** I've made some concurrency-oriented fixes to the package recently on mainline that match recent changes in the XCTest framework that ships with Xcode. This PR pulls them into 5.9.
**Scope:** The changes are important for the quality of concurrent test code that uses this package. The change may cause some source-breakage in concurrent unit tests that are unsafe.
**Issue:** #428, #436, #454
**Risk:** No effect on production code. Unit tests may start emitting new diagnostics (including errors) related to concurrency correctness.
**Testing:** New unit tests have been added and existing unit tests continue to pass.
**Reviewer:** @briancroom