### PR TITLE
Bump the macOS deployment target to 10.13 in the Xcode project.

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -513,7 +513,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
 					SwiftFoundation,
@@ -538,7 +538,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
 					SwiftFoundation,


### PR DESCRIPTION
What it says on the tin. In February, the minimum deployment target for the Swift project at-large was increased to 10.13. This mismatch is now causing build warnings e.g. here: https://ci.swift.org/job/swift-corelibs-foundation-PR-macOS/268/

This PR changes the deployment target of the XCTest Xcode project to match Swift's.