### PR TITLE
Stop importing CF as a framework

### DIFF
--- a/Tests/Functional/Asynchronous/Expectations/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/main.swift
@@ -1,4 +1,4 @@
-// RUN: %{swiftc} %s -o %T/Asynchronous
+// RUN: %{swiftc} -Xfrontend -disable-autolink-framework -Xfrontend CoreFoundation %s -o %T/Asynchronous
 // RUN: %T/Asynchronous > %t || true
 // RUN: %{xctest_checker} %t %s
 


### PR DESCRIPTION
Frameworks don't exist off of Darwin resulting in link failures in this test. The CF modulemap declares CF as a framework everywhere, which is wrong, but importing CF from swift-corelibs-foundation is also equally wrong, which this test does as well, so there's a lot of wrongness.

To get the rebranch working, we need to stop importing CoreFoundation as a framework in this test, or disable the test on non-darwin platforms. Given that corelibs-xctest is for non-Darwin platforms, that seems like the wrong course of action. Technically, things outside of swift-corelibs-Foundation should not be importing the CoreFoundation module at all.

This is affecting rebranch as clang changed modulemap import behavior in a way that affects the corelibs-Foundation CoreFoundation module.
