### PR TITLE
Set the minimum macOS deployment target to 10.13 for the test target

### DIFF
--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_CFLAGS = "";
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
@@ -575,6 +576,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_CFLAGS = "";
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",


### PR DESCRIPTION
The lit test suite respects `MACOSX_DEPLOYMENT_TARGET` to determine the `-target` option passed to compilers. However, the `SwiftXCTestFunctionalTests` target and the `XCTest` project do not set `MACOSX_DEPLOYMENT_TARGET` in their build settings, so the default value (14.2 in the current Xcode installed on the CI) is used and the macOS version of the CI machine is older than it. This patch fixes the issue by setting `MACOSX_DEPLOYMENT_TARGET` to 10.13, which is currently used as the minimum macOS version requirement in ci.swift.org.