### PR TITLE
Removing additional quotes around values in a XCTAssertEqual

### DIFF
--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -170,7 +170,7 @@ public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -
         if value1 == value2 {
             return .success
         } else {
-            return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+            return .expectedFailure("(\(value1)) is not equal to (\(value2))")
         }
     }
 }


### PR DESCRIPTION
https://github.com/apple/swift-corelibs-xctest/issues/473