### PR TITLE
[5.10] Guard `parse_version`

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -143,10 +143,14 @@ config.substitutions.append(('%{xctest_checker}', '%%{python} %s' % xctest_check
 config.substitutions.append( ('%{python}', pipes.quote(sys.executable)) )
 
 # Conditionally report the Swift 5.5 Concurrency runtime as available depending on the OS and version.
+# Darwin is the only platform where this is a limitation.
 (run_os, run_vers) = config.os_info
-os_is_not_macOS = run_os != 'Darwin'
-macOS_version_is_recent_enough = parse_version(run_vers) >= parse_version('12.0')
-if os_is_not_macOS or macOS_version_is_recent_enough:
+if run_os == 'Darwin':
+    assert run_vers != "", "No runtime version set."
+    if parse_version(run_vers) >= parse_version('12.0'):
+        config.available_features.add('concurrency_runtime')
+else:
+    # Non-Darwin platforms have a concurrency runtime
     config.available_features.add('concurrency_runtime')
 if run_os == 'Windows':
     config.available_features.add('OS=windows')


### PR DESCRIPTION
The most recent versions of `parse_version` throw an exception if the version is empty. The version passed in is only set on Darwin (call to `mac_ver()`, so it's causing test failures on newer versions of Linux since the test suite can't even start.

Now, the only reason for the version parse is because the tests are looking at whether or not concurrency is available on the OS. This is only a limitation if we're working with Darwin. Swift 5.10 on Windows and Linux always have a Swift 5.10 concurrency runtime, so we don't even need to check for a version.

rdar://128502662

https://ci.swift.org/view/Swift%205.10/job/oss-swift-5.10-package-debian-12/9/console
```
 llvm-lit: /home/build-user/llvm-project/llvm/utils/lit/lit/TestingConfig.py:138: fatal: unable to parse config file '/home/build-user/swift-corelibs-xctest/Tests/Functional/lit.cfg', traceback: Traceback (most recent call last):
  File "/home/build-user/llvm-project/llvm/utils/lit/lit/TestingConfig.py", line 127, in load_from_path
    exec(compile(data, path, 'exec'), cfg_globals, None)
  File "/home/build-user/swift-corelibs-xctest/Tests/Functional/lit.cfg", line 148, in <module>
    macOS_version_is_recent_enough = parse_version(run_vers) >= parse_version('12.0')
                                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pkg_resources/_vendor/packaging/version.py", line 266, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: ''
```