### PR TITLE
Ignore the `--testing-library` argument we are going to start passing from SwiftPM.

### DIFF
--- a/Sources/XCTest/Private/ArgumentParser.swift
+++ b/Sources/XCTest/Private/ArgumentParser.swift
@@ -50,8 +50,38 @@ internal struct ArgumentParser {
 
     private let arguments: [String]
 
+    /// Filter out arguments from an arguments array that XCTest doesn't care about.
+    ///
+    /// - Parameters:
+    ///     - arguments: The arguments array to filter.
+    ///
+    /// - Returns: A copy of `arguments` with ignored arguments removed.
+    private static func removeIgnoredArguments(from arguments: [String]) -> [String] {
+        var result = [String]()
+        result.reserveCapacity(arguments.count)
+
+        for i in arguments.indices {
+            let argument = arguments[i]
+
+            // Filter out any arguments of the form "--testing-library=xctest".
+            if argument.starts(with: "--testing-library=") {
+                continue
+            }
+
+            // Next, filter out any split arguments ("--testing-library xctest")
+            if argument == "--testing-library" {
+                i = arguments.index(after: i)
+                continue
+            }
+
+            result.append(argument)
+        }
+
+        return result
+    }
+
     init(arguments: [String]) {
-        self.arguments = arguments
+        self.arguments = Self.removeIgnoredArguments(from: arguments)
     }
 
     var executionMode: ExecutionMode {

--- a/Tests/Functional/ArgumentParserWithIgnoredArgs/main.swift
+++ b/Tests/Functional/ArgumentParserWithIgnoredArgs/main.swift
@@ -1,0 +1,22 @@
+// RUN: %{swiftc} %s -o %T/ArgumentParserWithIgnoredArgs
+// RUN: %T/ArgumentParserWithIgnoredArgs
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+class ArgumentParsingWithIgnoredArgsTestCase: XCTestCase {
+    static var allTests = {
+        return [
+          ("testFail", testFail),
+          ("testSuccess", testSuccess),
+        ]
+    }()
+    func testFail() { XCTFail("failure") }
+    func testSuccess() { }
+}
+
+let arguments = ["main", "--testing-library=xctest", "--testing-library", "xctest", "\(String(reflecting: ArgumentParsingTestCase.self))/testSuccess", "--testing-library",]
+XCTMain([testCase(ArgumentParsingTestCase.allTests)], arguments: arguments)


### PR DESCRIPTION
This PR adds functionality to XCTest's argument parser that allows it to skip arguments that the caller may specify but which are uninteresting to XCTest. Specifically, we are planning to start passing `--testing-library xctest` to the test runner process in order to disambiguate runs of XCTest from runs of Swift Testing, and we need to make sure this does not cause XCTest to run incorrectly.

Resolves rdar://129695171.