### PR TITLE
Add new include path into Foundation when building tests

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -99,7 +99,7 @@ else:
         '-L', os.path.join(foundation_dir, 'lib'),
         '-I', foundation_dir,
         '-I', os.path.join(foundation_dir, 'swift'),
-        '-I', os.path.join(foundation_dir, '_CModulesForClients',
+        '-I', os.path.join(foundation_dir, '_CModulesForClients'),
         '-Xcc', '-F', '-Xcc', foundation_dir,
     ])
 

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -99,6 +99,7 @@ else:
         '-L', os.path.join(foundation_dir, 'lib'),
         '-I', foundation_dir,
         '-I', os.path.join(foundation_dir, 'swift'),
+        '-I', os.path.join(foundation_dir, '_CModulesForClients',
         '-Xcc', '-F', '-Xcc', foundation_dir,
     ])
 


### PR DESCRIPTION
Now that Foundation is being re-cored ontop of swift-foundation, we're adding some new (internal) C modules. XCTest's tests add an explicit include path into the Foundation build directory to pickup these modules, but it does not account for the new location of these modules. Instead of adding more paths into Foundation's build directory, I'm adding one new path to a new folder named `_CModulesForClients`. We're updating the Foundation build to place all C modules that XCTest's tests need into this folder, so that the tests here need to only include this directory.

For now, I'm leaving the old paths as-is in case they are load-bearing with the current Foundation build. I've validated that all XCTest tests pass in my local build with Foundation re-cored and will use swift-ci to validate that this does not break the existing build either.