### PR TITLE
[6.0] Add new include path into Foundation when building tests

### DIFF
--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -99,6 +99,7 @@ else:
         '-L', os.path.join(foundation_dir, 'lib'),
         '-I', foundation_dir,
         '-I', os.path.join(foundation_dir, 'swift'),
+        '-I', os.path.join(foundation_dir, '_CModulesForClients'),
         '-Xcc', '-F', '-Xcc', foundation_dir,
     ])
 


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift-corelibs-xctest/pull/493

Explanation: Updates the build script to add a new header include path when building tests
Scope: Affects building tests for XCTest itself, should not have any effect at this time
Original PR: https://github.com/apple/swift-corelibs-xctest/pull/493
Risk: Minimal - this simply adds a new include path to the XCTest tests build which does not yet exist
Testing: Testing done via local execution of tests and swift-ci testing
Reviewer: @stmontgomery @briancroom @parkera 