### PR TITLE
build: optionalise Foundation and dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ endif()
 option(DISABLE_XCTWAITER "Disable XCTWaiter" "${DISABLE_XCTWAITER_default}")
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin AND NOT DISABLE_XCTWAITER)
-  find_package(dispatch CONFIG REQUIRED)
-  find_package(Foundation CONFIG REQUIRED)
+  find_package(dispatch CONFIG)
+  find_package(Foundation CONFIG)
 endif()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Rather than requiring the build tree for the dependencies, optionalise them. This allows us to build against an existing SDK or against the build tree. This flexibility allows us to change the build order when building the Windows toolchain against a SDK that is being built up. Without this change, we must provide a dispatch build tree which will inject the modulemap for the dispatch runtime which conflicts with the verison in the SDK that is being built against.