### PR TITLE
Test: simplify the test configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,6 @@ if(ENABLE_TESTING)
 
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
-  string(REPLACE "\\" "\\\\" CMAKE_Swift_FLAGS_ESCAPED ${CMAKE_Swift_FLAGS})
   add_custom_target(check-xctest
                     COMMAND
                     ${CMAKE_COMMAND} -E env
@@ -133,7 +132,6 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
-                      SWIFT_FLAGS=${CMAKE_Swift_FLAGS_ESCAPED}
                       $<TARGET_FILE:Python3::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT
                       "Running XCTest functional test suite"

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -78,7 +78,7 @@ else:
     if platform.system() == 'Windows':
         sdkroot = os.getenv('SDKROOT', None)
         if sdkroot:
-            swift_exec.extend(['-sdk', sdkroot])
+            swift_exec.extend(['-sdk', '"' + sdkroot + '"'])
         swift_exec.extend(['-Xlinker', '-nodefaultlib:libcmt'])
     else:
         swift_exec.extend([
@@ -88,42 +88,36 @@ else:
           '-Xlinker', '-rpath', '-Xlinker', os.path.join(foundation_dir, 'Sources', 'FoundationNetworking'),
           '-Xlinker', '-rpath', '-Xlinker', os.path.join(foundation_dir, 'Sources', 'FoundationXML'),
           '-Xlinker', '-rpath', '-Xlinker', os.path.join(foundation_dir, 'lib'),
+          '-L', foundation_dir,
+          '-L', os.path.join(foundation_dir, 'Foundation'),
+          '-L', os.path.join(foundation_dir, 'Sources', 'Foundation'),
+          '-L', os.path.join(foundation_dir, 'Sources', 'FoundationNetworking'),
+          '-L', os.path.join(foundation_dir, 'Sources', 'FoundationXML'),
+          '-L', os.path.join(foundation_dir, 'lib'),
+          '-I', foundation_dir,
+          '-I', os.path.join(foundation_dir, 'swift'),
+          '-I', os.path.join(foundation_dir, '_CModulesForClients'),
+          '-Xcc', '-F', '-Xcc', foundation_dir,
         ])
-    swift_exec.extend([
-        '-L', foundation_dir,
-        '-L', os.path.join(foundation_dir, 'Foundation'),
-        '-L', os.path.join(foundation_dir, 'Sources', 'Foundation'),
-        '-L', os.path.join(foundation_dir, 'Sources', 'FoundationNetworking'),
-        '-L', os.path.join(foundation_dir, 'Sources', 'FoundationXML'),
-        '-L', os.path.join(foundation_dir, 'lib'),
-        '-I', foundation_dir,
-        '-I', os.path.join(foundation_dir, 'swift'),
-        '-I', os.path.join(foundation_dir, '_CModulesForClients'),
-        '-Xcc', '-F', '-Xcc', foundation_dir,
-    ])
 
-    # We also need to link swift-corelibs-libdispatch, if
-    # swift-corelibs-foundation is using it.
-    libdispatch_src_dir = os.getenv('LIBDISPATCH_SRC_DIR')
-    libdispatch_build_dir = os.getenv('LIBDISPATCH_BUILD_DIR')
-    libdispatch_overlay_dir = os.getenv('LIBDISPATCH_OVERLAY_DIR')
-    if ((libdispatch_src_dir is not None) 
-        and (libdispatch_build_dir is not None)
-        and (libdispatch_overlay_dir is not None)):
-            swift_exec.extend([
-                '-Xcc', '-fblocks',
-                '-I', libdispatch_src_dir,
-                '-I', libdispatch_overlay_dir,
-                '-I', os.path.join(libdispatch_overlay_dir, 'swift'),
-                '-L', libdispatch_build_dir,
-                '-L', os.path.join(libdispatch_build_dir, 'src'),
-                '-L', os.path.join(libdispatch_build_dir, 'src', 'BlocksRuntime'),
-                '-L', os.path.join(libdispatch_build_dir, 'src', 'swift'),
-                '-vfsoverlay', os.path.join(libdispatch_build_dir, 'dispatch-vfs-overlay.yaml'),
-            ])
-
-            if platform.system() != 'Windows':
+        # We also need to link swift-corelibs-libdispatch, if
+        # swift-corelibs-foundation is using it.
+        libdispatch_src_dir = os.getenv('LIBDISPATCH_SRC_DIR')
+        libdispatch_build_dir = os.getenv('LIBDISPATCH_BUILD_DIR')
+        libdispatch_overlay_dir = os.getenv('LIBDISPATCH_OVERLAY_DIR')
+        if ((libdispatch_src_dir is not None)
+            and (libdispatch_build_dir is not None)
+            and (libdispatch_overlay_dir is not None)):
                 swift_exec.extend([
+                    '-Xcc', '-fblocks',
+                    '-I', libdispatch_src_dir,
+                    '-I', libdispatch_overlay_dir,
+                    '-I', os.path.join(libdispatch_overlay_dir, 'swift'),
+                    '-L', libdispatch_build_dir,
+                    '-L', os.path.join(libdispatch_build_dir, 'src'),
+                    '-L', os.path.join(libdispatch_build_dir, 'src', 'BlocksRuntime'),
+                    '-L', os.path.join(libdispatch_build_dir, 'src', 'swift'),
+                    '-vfsoverlay', os.path.join(libdispatch_build_dir, 'dispatch-vfs-overlay.yaml'),
                     '-Xlinker', '-rpath', '-Xlinker', libdispatch_build_dir,
                 ])
 


### PR DESCRIPTION
Remove the compatibility paths in the test infrastructure. Foundation and dispatch have had evolved over the years. Remove the compatibility assuming that something within the past few years is used to build. This is now more reasonable given that the Foundation and dispatch dependencies have been made optional - this allows building XCTest against a SDK.

This also reduces the setup for Windows to a very trivial skeleton of just passing along SDKROOT. This enables the windows build to run the test suite against the SDKROOT that has been built up which allows us to swap to the new runtime implementation.