### PR TITLE
Clean up expectations when done before stopping the test run

### DIFF
--- a/Sources/XCTest/Public/XCTestCase.swift
+++ b/Sources/XCTest/Public/XCTestCase.swift
@@ -141,6 +141,8 @@ open class XCTestCase: XCTest {
         let allExpectations = XCTWaiter.subsystemQueue.sync { _allExpectations }
         failIfExpectationsNotWaitedFor(allExpectations)
 
+        cleanUpExpectations()
+
         testRun.stop()
         XCTCurrentTestCase = nil
     }

--- a/Tests/Functional/Asynchronous/Expectations/Cleanup/main.swift
+++ b/Tests/Functional/Asynchronous/Expectations/Cleanup/main.swift
@@ -1,0 +1,57 @@
+// RUN: %{swiftc} %s -o %T/ExpectationCleanup
+// RUN: %T/ExpectationCleanup > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+// CHECK: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'ExpectationCleanupTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class ExpectationCleanupTestCase: XCTestCase {
+    static var notificationHandlerCalled = false
+
+// CHECK: Test Case 'ExpectationCleanupTestCase.test_createExpectationAndSkipWait' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: .*[/\\]Tests[/\\]Functional[/\\]Asynchronous[/\\]Expectations[/\\]Cleanup[/\\]main.swift:[[@LINE+3]]: error: ExpectationCleanupTestCase.test_createExpectationAndSkipWait : Failed due to unwaited expectation 'Expect notification 'TestCleanup' from any object'
+// CHECK: Test Case 'ExpectationCleanupTestCase.test_createExpectationAndSkipWait' failed \(\d+\.\d+ seconds\)
+    func test_createExpectationAndSkipWait() {
+        self.expectation(
+            forNotification: Notification.Name("TestCleanup"), object: nil,
+            handler: { _ in
+                ExpectationCleanupTestCase.notificationHandlerCalled = true
+                return true
+            })
+    }
+
+// CHECK: Test Case 'ExpectationCleanupTestCase.test_verifyCleanup' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Case 'ExpectationCleanupTestCase.test_verifyCleanup' passed \(\d+\.\d+ seconds\)
+    func test_verifyCleanup() {
+        // Post notification.
+        NotificationCenter.default.post(name: Notification.Name("TestCleanup"), object: nil)
+
+        // If observer was removed, handler is NOT called.
+        XCTAssertFalse(
+            ExpectationCleanupTestCase.notificationHandlerCalled,
+            "Expectation handler called, meaning cleanup failed!")
+    }
+
+    static var allTests = {
+        return [
+            ("test_createExpectationAndSkipWait", test_createExpectationAndSkipWait),
+            ("test_verifyCleanup", test_verifyCleanup),
+        ]
+    }()
+}
+// CHECK: Test Suite 'ExpectationCleanupTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 2 tests, with 1 failure \(1 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+XCTMain([testCase(ExpectationCleanupTestCase.allTests)])
+
+// CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 2 tests, with 1 failure \(1 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 2 tests, with 1 failure \(1 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds


### PR DESCRIPTION
When a test creates expectations but never waits on them (e.g., expectation(forNotification:) without a corresponding wait(for:timeout:)), those expectations are never cleaned up. 

> Note from reviewer @stmontgomery:
>
> As one example of the consequence of this bug, the handler for an unwaited NSNotification expectation may be called for a notification during an unrelated test. I haven’t tried, but I expect there would be a similar problem for XCTNSPredicateExpectation.