### PR TITLE
DNM: Intentionally introduce breaking changes to see if CI works as expected

### DIFF
--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -76,6 +76,7 @@ public func XCTMain(
     arguments: [String] = CommandLine.arguments,
     observers: [XCTestObservation]? = nil
 ) async -> CInt {
+    print("DEBUG: ASYNC XCTMAIN START")
     // Async-version of XCTMain()
     switch XCTMainMisc(testCases, arguments: arguments, observers: observers) {
     case .exitCode(let code):
@@ -101,6 +102,7 @@ public func XCTMain(
     arguments: [String] = CommandLine.arguments,
     observers: [XCTestObservation]? = nil
 ) -> CInt {
+    print("DEBUG: SYNC XCTMAIN START")
     // Sync-version of XCTMain()
     switch XCTMainMisc(testCases, arguments: arguments, observers: observers) {
     case .exitCode(let code):


### PR DESCRIPTION
I tested this in a container locally using the build_script, and it would find the copy of libXCTest.so in /usr/lib/swift/ because it's prepended to the runpath of the test executables built by lit.

If CI is correctly using the built copy of libXCTest.so, then it should see test failures with this breaking change.

Do not merge this please!!!