### PR TITLE
Update README with CMake build instructions and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+##
+
+FROM swiftlang/swift:nightly-main-jammy
+
+RUN apt-get -y update && apt-get -y install \
+    cmake                 \
+    ninja-build           \
+    python3               \
+    python3-pkg-resources
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+USER build-user
+
+WORKDIR /home/build-user

--- a/README.md
+++ b/README.md
@@ -58,19 +58,43 @@ $ ./FooTests --dump-tests-json
 
 To contribute, you'll need to be able to build this project and run its test suite. The easiest way to do so is via the Swift build script.
 
-First, follow [the instructions in the Swift README](https://github.com/apple/swift/blob/main/README.md) to build Swift from source. Confirm you're able to build the Swift project using `utils/build-script -R`.
+First, follow [the instructions in the Swift
+README](https://github.com/apple/swift/blob/main/README.md) to build Swift from
+source. This project is only guaranteed to build with the very latest commit on
+the Swift and swift-corelibs-foundation `main` branches. You may update to the
+latest commits using the Swift `utils/update-checkout` script:
+
+```
+$ ../swift/utils/update-checkout
+```
+
+Then, choose one of the methods below to build and test.
+
+### Using CMake and Docker (recommended)
+
+You can use CMake to build the project and run tests with the local
+`build_script.py`:
+
+```
+$ docker build -t swift-corelibs-xctest-docker:latest .
+# This assumes you've cloned the entire Swift project earlier into a folder named "swift-project"
+$ docker run -it -v ../../swift-project:/swift-project -w /swift-project/swift-corelibs-xctest swift-corelibs-xctest-docker \
+      sh -c "cmake -G Ninja -B .build && cmake --build .build && \
+      ./build_script.py test \
+      --swiftc=/usr/bin/swiftc \
+      --foundation-build-dir .build/ \
+      .build/"
+```
+
+### Using the Swift Build Script
+
+Confirm you're able to build the Swift project using `utils/build-script -R`.
 
 Once you are able to build the Swift project, build XCTest and run its tests:
 
 ```
 $ cd swift-corelibs-xctest
 $ ../swift/utils/build-script --preset corelibs-xctest
-```
-
-This project is only guaranteed to build with the very latest commit on the Swift and swift-corelibs-foundation `main` branches. You may update to the latest commits using the Swift `utils/update-checkout` script:
-
-```
-$ ../swift/utils/update-checkout
 ```
 
 ### Using Xcode
@@ -81,4 +105,4 @@ However, in order to successfully build the project in Xcode, **you must use an 
 
 > If none of the toolchains available to download are recent enough to build XCTest, you may build your own toolchain by using the [`utils/build-toolchain` script](https://github.com/apple/swift/blob/main/utils/build-toolchain) in the Swift repository.
 >
-> Keep in mind that the build script invocation in "Contributing to XCTest" above will always work, regardless of which Swift toolchains you have installed. The Xcode workspace exists simply for the convenience of contributors. It is not necessary to successfully build this project in Xcode in order to contribute.
+> Keep in mind that the build script invocation in "Using the Swift Build Script" above will always work, regardless of which Swift toolchains you have installed. The Xcode workspace exists simply for the convenience of contributors. It is not necessary to successfully build this project in Xcode in order to contribute.


### PR DESCRIPTION
Update recommended project build instructions to match what we do in CI:
* Build swift-corelibs-xctest with CMake.
* Then, build and run its tests with lit using the local build-script.

Create instructions for doing all this in a container for ease of development. The instructions still require a full checkout of the entire Swift project to build and test, although in the future it might be possible to just clone the llvm project for lit.