### PR TITLE
XCTest: replace String(reflecting:) with _typeName

### DIFF
--- a/Sources/XCTest/Private/TestFiltering.swift
+++ b/Sources/XCTest/Private/TestFiltering.swift
@@ -67,6 +67,6 @@ private extension SelectedTest {
     }
 
     init(testCaseClass: XCTestCase.Type, testCaseMethodName: String?) {
-        self.init(testCaseClassName: String(reflecting: testCaseClass), testCaseMethodName: testCaseMethodName)
+        self.init(testCaseClassName: _typeName(testCaseClass, qualified: true), testCaseMethodName: testCaseMethodName)
     }
 }

--- a/Sources/XCTest/Private/TestListing.swift
+++ b/Sources/XCTest/Private/TestListing.swift
@@ -46,7 +46,7 @@ protocol Listable {
 }
 
 private func moduleName(value: Any) -> String {
-    let moduleAndType = String(reflecting: type(of: value))
+    let moduleAndType = _typeName(type(of: value), qualified: true)
     return String(moduleAndType.split(separator: ".").first!)
 }
 


### PR DESCRIPTION
Optimized XCTest test listing and filtering by replacing `String(reflecting:)` with `_typeName`

### Motivation:

Calculating type-name using heavy `String(reflecting:)` is inefficient. There is far more performant alternative - `_typeName(_:qualified: true)`

### Modifications:

Replaced `String(reflecting:)` with `_typeName(_:qualified: true)`

### Result:

Performance of XCTest test filtering and listing will be slightly improved

### Testing:

Tested locally. In my opinion, testing is not needed, because these calls are basically equivalent when its argument is `Any.Type`. The same change was made here: https://github.com/swiftlang/swift/pull/77369
