### PR TITLE
`XCTWaiter` should spin the run loop in common modes, not default.

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -425,7 +425,7 @@ private extension XCTWaiter {
         let timeIntervalToRun = min(0.1, timeout)
 
         // RunLoop.run(mode:before:) should have @discardableResult <rdar://problem/45371901>
-        _ = runLoop.run(mode: .default, before: Date(timeIntervalSinceNow: timeIntervalToRun))
+        _ = runLoop.run(mode: .common, before: Date(timeIntervalSinceNow: timeIntervalToRun))
     }
 
     func cancelPrimitiveWait() {


### PR DESCRIPTION
`XCTWaiter` spins the run loop in the default mode, which is insufficient to avoid a deadlock if another subsystem schedules work in another common mode.

I don't have a unit test for this because it's non-deterministic and may take many test runs to trigger. @stmontgomery and I verified at-desk that the hang goes away with this change in place.

Resolves rdar://139710145.