### PR TITLE
Fix `fulfillment(of:)` not playing well with sendability.

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -279,7 +279,7 @@ open class XCTWaiter {
     ///   explicit values for `file` and `line`.
     @available(macOS 12.0, *)
     @discardableResult
-    open func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async -> Result {
+    open nonisolated(nonsending) func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async -> Result {
         return await withCheckedContinuation { continuation in
             // This function operates by blocking a background thread instead of one owned by libdispatch or by the
             // Swift runtime (as used by Swift concurrency.) To ensure we use a thread owned by neither subsystem, use
@@ -329,7 +329,7 @@ open class XCTWaiter {
     ///   number of the call to this method in the calling file. It is rare to
     ///   provide this parameter when calling this method.
     @available(macOS 12.0, *)
-    open class func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async -> Result {
+    open class nonisolated(nonsending) func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async -> Result {
         return await XCTWaiter().fulfillment(of: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
     }
 

--- a/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift
@@ -113,7 +113,7 @@ public extension XCTestCase {
     ///
     /// - SeeAlso: XCTWaiter
     @available(macOS 12.0, *)
-    func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async {
+    nonisolated(nonsending) func fulfillment(of expectations: [XCTestExpectation], timeout: TimeInterval, enforceOrder: Bool = false, file: StaticString = #file, line: Int = #line) async {
         let waiter = XCTWaiter(delegate: self)
         await waiter.fulfillment(of: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
 

--- a/Tests/Functional/Asynchronous/NonsendingFulfillment/main.swift
+++ b/Tests/Functional/Asynchronous/NonsendingFulfillment/main.swift
@@ -1,0 +1,18 @@
+// RUN: %{swiftc} %s -warn-concurrency -warnings-as-errors
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+
+final class NonisolatedExpectationTests: XCTestCase {
+    @MainActor func testIt() async {
+        let something = expectation(description: "bla")
+        Task {
+            try? await Task.sleep(for: .seconds(1.0))
+            something.fulfill()
+        }
+        await fulfillment(of: [something], timeout: 2.0)
+    }
+}


### PR DESCRIPTION
We never annotated these methods with `#isolation`. Adding `nonisolated(nonsending)` is a cleaner fix anyway.

Resolves #507.
