### PR TITLE
Call recordIssue on issues from other test libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,12 @@ if(ENABLE_TESTING)
 
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
+  if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(SWIFT_TESTING_MACRO_PATH "${XCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD}/libTestingMacros.so")
+  elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    set(SWIFT_TESTING_MACRO_PATH "${XCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD}/TestingMacros.dll")
+  endif()
+
   add_custom_target(check-xctest
                     COMMAND
                     ${CMAKE_COMMAND} -E env
@@ -146,6 +152,8 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_SRC_DIR=${XCTEST_PATH_TO_LIBDISPATCH_SOURCE}
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
+                      SWIFT_TESTING_BUILD_DIR=${XCTEST_PATH_TO_SWIFT_TESTING_BUILD}
+                      SWIFT_TESTING_MACRO_PATH=${SWIFT_TESTING_MACRO_PATH}
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
                       $<TARGET_FILE:Python3::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,12 +138,6 @@ if(ENABLE_TESTING)
 
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
-  if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD")
-    set(SWIFT_TESTING_MACRO_PATH "${XCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD}/libTestingMacros.so")
-  elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-    set(SWIFT_TESTING_MACRO_PATH "${XCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD}/TestingMacros.dll")
-  endif()
-
   add_custom_target(check-xctest
                     COMMAND
                     ${CMAKE_COMMAND} -E env
@@ -153,7 +147,7 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
                       SWIFT_TESTING_BUILD_DIR=${XCTEST_PATH_TO_SWIFT_TESTING_BUILD}
-                      SWIFT_TESTING_MACRO_PATH=${SWIFT_TESTING_MACRO_PATH}
+                      SWIFT_TESTING_MACRO_BUILD_DIR=${XCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD}
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
                       $<TARGET_FILE:Python3::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,9 @@ if(DISABLE_XCTWAITER)
     DISABLE_XCTWAITER)
 endif()
 
+# This exports SwiftTesting_MACRO_DIR and SwiftTesting_BUILD_DIR
 find_package(SwiftTesting CONFIG)
+find_package(SwiftTestingMacros CONFIG)
 if(SwiftTesting_FOUND)
   target_link_libraries(XCTest PRIVATE
     _TestingInterop)
@@ -146,8 +148,8 @@ if(ENABLE_TESTING)
                       LIBDISPATCH_SRC_DIR=${XCTEST_PATH_TO_LIBDISPATCH_SOURCE}
                       LIBDISPATCH_BUILD_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}
                       LIBDISPATCH_OVERLAY_DIR=${XCTEST_PATH_TO_LIBDISPATCH_BUILD}/src/swift
-                      SWIFT_TESTING_BUILD_DIR=${XCTEST_PATH_TO_SWIFT_TESTING_BUILD}
-                      SWIFT_TESTING_MACRO_BUILD_DIR=${XCTEST_PATH_TO_SWIFT_TESTING_MACROS_BUILD}
+                      SWIFT_TESTING_BUILD_DIR=${SwiftTesting_BUILD_DIR}
+                      SWIFT_TESTING_MACRO_BUILD_DIR=${SwiftTesting_MACRO_DIR}
                       SWIFT_EXEC=${CMAKE_Swift_COMPILER}
                       $<TARGET_FILE:Python3::Interpreter> ${LIT_COMMAND} -sv ${CMAKE_SOURCE_DIR}/Tests/Functional
                     COMMENT

--- a/Sources/XCTest/Private/Interop/InteropHandler.swift
+++ b/Sources/XCTest/Private/Interop/InteropHandler.swift
@@ -10,6 +10,16 @@
 //  InteropHandler.swift
 //
 
+#if os(macOS)
+    #if USE_FOUNDATION_FRAMEWORK
+    import Foundation
+    #else
+    import SwiftFoundation
+    #endif
+#else
+    import Foundation
+#endif
+
 enum Interop {}
 
 extension Interop {
@@ -37,7 +47,7 @@ extension Interop {
 
 extension Interop.Handler {
     /// Print the message if debug printing is enabled for interop.
-    private static func debugPrint(_ message: String) {
+    fileprivate static func debugPrint(_ message: String) {
         if Interop.Config.isDebugPrintEnabled {
             print(message)
         }
@@ -48,46 +58,52 @@ extension Interop.Handler {
     ///
     /// Install can only be performed once per process, and subsequent attempts
     /// will fail.
-    static func install() {
+    ///
+    /// - Returns: Whether the handler was successfully installed.
+    static func installFallbackEventHandler() -> Bool {
+        _installFallbackEventHandler
+    }
+
+    private static let _installFallbackEventHandler: Bool = {
         #if XCT_BUILD_WITH_INTEROP
         guard Interop.Config.isEnabledAtRuntime else {
             debugPrint("Interop: disabled because \(Interop.Config.optInEnvName) not set")
-            return
+            return false
         }
 
         debugPrint("Interop: installing XCTest's interop handler")
-        let ok = installer(handler)
+        let ok = installer(ourFallbackEventHandler)
         debugPrint("Interop: install \(ok ? "succeeded" : "failed! Interop is disabled")")
+        return ok
         #else
         debugPrint("Interop: disabled because this was built without XCT_BUILD_WITH_INTEROP")
+        return false
         #endif
-    }
-}
-
-#if XCT_BUILD_WITH_INTEROP
-
-extension Interop.Handler {
-    /// XCTest's fallback event handler, which is used to handle issues reported by other test libraries.
-    static let handler: FallbackEventHandler = {
-        recordJSONSchemaVersionNumber, recordJSONBaseAddress, recordJSONByteCount, reserved in
-        // Not implemented yet
-        debugPrint("Interop: handler called")
-    }
+    }()
 
     /// The currently installed fallback event handler, which is provided by the
     /// testing library that is hosting tests.
     ///
     /// For example, when XCTAssert is called in a Swift Testing test, Swift
     /// Testing installs a handler, and XCTest will store its address in
-    /// `_installedHandler`.
-    private static var _installedHandler: FallbackEventHandler? = getter()
+    /// `activeFallbackEventHandler`.
+    static var activeFallbackEventHandler: FallbackEventHandler? = {
+        #if XCT_BUILD_WITH_INTEROP
+        getter()
+        #else
+        nil
+        #endif
+    }()
 }
 
 /// A fallback event handler is called by a testing library when it wants to
 /// record an event, but the current test is being run by a different testing
 /// library.
 ///
-/// Refer to Swift Testing's source code for more info.
+/// For example, when `XCTAssertEqual` fails in a Swift Testing test, it cannot
+/// directly record the `XCTIssue`. Instead, the `XCTest` library gets the
+/// current fallback handler, serializes the `XCTIssue`, and passes the result
+/// to the fallback handler.
 ///
 /// - Parameters:
 ///     - recordJSONSchemaVersionNumber: the schema version for the JSON event.
@@ -102,7 +118,38 @@ typealias FallbackEventHandler =
         _ reserved: UnsafeRawPointer?
     ) -> Void
 
+#if XCT_BUILD_WITH_INTEROP
+
 extension Interop.Handler {
+    /// XCTest's fallback event handler, which is used to handle issues reported by other test libraries.
+    /// It can only report test issues if there is an active XCTest test case.
+    static let ourFallbackEventHandler: FallbackEventHandler = {
+        recordJSONSchemaVersionNumber, recordJSONBaseAddress, recordJSONByteCount, _ in
+        guard let schemaVersion = String(validatingCString: recordJSONSchemaVersionNumber),
+                schemaVersion == "6.3" else {
+            debugPrint("Not handling event because of unsupported schema version")
+            return
+        }
+
+        // Memory is managed by the caller of the fallback event handler, so do
+        // not attempt to deallocate when done.
+        let jsonData = Data(
+            bytesNoCopy: .init(mutating: recordJSONBaseAddress),
+            count: recordJSONByteCount,
+            deallocator: .none)
+
+        do {
+            guard let currentTestCase = XCTCurrentTestCase else {
+                debugPrint("Called without current test case")
+                return
+            }
+            let outputRecord = try JSONDecoder().decode(Interop.OutputRecord.self, from: jsonData)
+            currentTestCase.recordFailure(event: outputRecord.payload)
+        } catch {
+            debugPrint("Unable to convert json event into an output record: \(error)")
+        }
+    }
+
     @_extern(c, "_swift_testing_installFallbackEventHandler")
     static func installer(_ handler: FallbackEventHandler) -> CBool
 
@@ -111,3 +158,50 @@ extension Interop.Handler {
 }
 
 #endif
+
+extension XCTestCase {
+    /// Records a failure created by another test library in the execution of
+    /// the test for this test run.
+    ///
+    /// Note that some detail will be lost in the conversion. For example, this
+    /// records all issues as "expected" failures even if they were the result
+    /// of thrown errors.
+    ///
+    /// Must be called *after* the test run has started and *before* it has
+    /// stopped.
+    ///
+    /// - Parameter event: The event record representing a failure. This is
+    ///   typically populated by a foreign test library.
+    func recordFailure(event: Interop.Event) {
+        guard event.kind == "issueRecorded", let eventIssue = event.issue else {
+            Interop.Handler.debugPrint("Skipping interop for event kind \(event.kind)")
+            return
+        }
+
+        let description = {
+            let messages = event.messages.map { $0.text.trimmingCharacters(in: .whitespacesAndNewlines) }
+            guard let firstMessage = messages.first, !firstMessage.isEmpty else {
+                return "Unknown issue"
+            }
+
+            if messages.count > 1 {
+                let remainingMessages = String(messages[1...].joined(separator: "\n"))
+                return "\(firstMessage): \(remainingMessages)"
+            } else {
+                return firstMessage
+            }
+        }()
+
+        let sourceLocation = eventIssue.sourceLocation
+        let filePath = sourceLocation?.filePath ?? "<unknown file>"
+        let line = sourceLocation?.line ?? -1
+
+        self.recordFailure(
+            withDescription: description,
+            inFile: filePath,
+            atLine: line,
+            // This is not the case for thrown errors, but this information
+            // isn't available in the encoded event at this time.
+            expected: true)
+    }
+}

--- a/Sources/XCTest/Private/Interop/InteropHandler.swift
+++ b/Sources/XCTest/Private/Interop/InteropHandler.swift
@@ -123,7 +123,7 @@ typealias FallbackEventHandler =
 extension Interop.Handler {
     /// XCTest's fallback event handler, which is used to handle issues reported by other test libraries.
     /// It can only report test issues if there is an active XCTest test case.
-    static let ourFallbackEventHandler: FallbackEventHandler = {
+    fileprivate static let ourFallbackEventHandler: FallbackEventHandler = {
         recordJSONSchemaVersionNumber, recordJSONBaseAddress, recordJSONByteCount, _ in
         guard let schemaVersion = String(validatingCString: recordJSONSchemaVersionNumber),
                 schemaVersion == "6.3" else {
@@ -172,7 +172,7 @@ extension XCTestCase {
     ///
     /// - Parameter event: The event record representing a failure. This is
     ///   typically populated by a foreign test library.
-    func recordFailure(event: Interop.Event) {
+    fileprivate func recordFailure(event: Interop.Event) {
         guard event.kind == "issueRecorded", let eventIssue = event.issue else {
             Interop.Handler.debugPrint("Skipping interop for event kind \(event.kind)")
             return
@@ -194,7 +194,7 @@ extension XCTestCase {
 
         let sourceLocation = eventIssue.sourceLocation
         let filePath = sourceLocation?.filePath ?? "<unknown file>"
-        let line = sourceLocation?.line ?? -1
+        let line = sourceLocation?.line ?? 0
 
         self.recordFailure(
             withDescription: description,

--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -133,7 +133,7 @@ internal func XCTMainMisc(
     arguments: [String] = CommandLine.arguments,
     observers: [XCTestObservation]?
 ) -> TestSuiteOrExitCode {
-    Interop.Handler.install()
+    _ = Interop.Handler.installFallbackEventHandler()
     let observers = observers ?? [PrintObserver()]
     let testBundle = Bundle.main
 

--- a/Tests/Functional/InteropWithSWT/main.swift
+++ b/Tests/Functional/InteropWithSWT/main.swift
@@ -1,0 +1,47 @@
+// RUN: %{swiftc} %s -o %T/InteropWithSWT
+// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/InteropWithSWT > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+import Testing
+
+// CHECK: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'InteropWithSWTTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class InteropWithSWTTestCase: XCTestCase {
+    // CHECK: Test Case 'InteropWithSWTTestCase.test_records_issue' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]InteropWithSWT[/\\]main.swift:[[@LINE+3]]: error: InteropWithSWTTestCase.test_records_issue : Issue recorded: Interop recorded issue failure
+    // CHECK: Test Case 'InteropWithSWTTestCase.test_records_issue' failed \(\d+\.\d+ seconds\)
+    func test_records_issue() {
+        // #expect(Bool(false))
+        Issue.record("Interop recorded issue failure")
+    }
+
+    // CHECK: Test Case 'InteropWithSWTTestCase.test_assertion_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: .*[/\\]InteropWithSWT[/\\]main.swift:[[@LINE+3]]: error: InteropWithSWTTestCase.test_assertion_fails : Expectation failed: Bool\(false\)
+    // CHECK: Test Case 'InteropWithSWTTestCase.test_assertion_fails' failed \(\d+\.\d+ seconds\)
+    func test_assertion_fails() {
+        #expect(Bool(false))
+    }
+
+    static var allTests = {
+        return [
+            ("test_records_issue", test_records_issue),
+            ("test_assertion_fails", test_assertion_fails)
+        ]
+    }()
+}
+// CHECK: Test Suite 'InteropWithSWTTestCase' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 2 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+XCTMain([testCase(InteropWithSWTTestCase.allTests)])
+
+// CHECK: Test Suite '.*\.xctest' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 2 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Test Suite 'All tests' failed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 2 tests, with 2 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/InteropWithSWT/main.swift
+++ b/Tests/Functional/InteropWithSWT/main.swift
@@ -18,12 +18,12 @@ class InteropWithSWTTestCase: XCTestCase {
     // CHECK: .*[/\\]InteropWithSWT[/\\]main.swift:[[@LINE+3]]: error: InteropWithSWTTestCase.test_records_issue : Issue recorded: Interop recorded issue failure
     // CHECK: Test Case 'InteropWithSWTTestCase.test_records_issue' failed \(\d+\.\d+ seconds\)
     func test_records_issue() {
-        // #expect(Bool(false))
         Issue.record("Interop recorded issue failure")
     }
 
     // CHECK: Test Case 'InteropWithSWTTestCase.test_assertion_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-    // CHECK: .*[/\\]InteropWithSWT[/\\]main.swift:[[@LINE+3]]: error: InteropWithSWTTestCase.test_assertion_fails : Expectation failed: Bool\(false\)
+    // CHECK: .*[/\\]InteropWithSWT[/\\]main.swift:[[@LINE+4]]: error: InteropWithSWTTestCase.test_assertion_fails : Expectation failed: Bool\(false\): Bool\(false\) → false
+    // CHECK: false → \(\)
     // CHECK: Test Case 'InteropWithSWTTestCase.test_assertion_fails' failed \(\d+\.\d+ seconds\)
     func test_assertion_fails() {
         #expect(Bool(false))

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -100,6 +100,15 @@ else:
           '-Xcc', '-F', '-Xcc', foundation_dir,
         ])
 
+        # Required to build interop tests
+        swift_testing_dir = _getenv('SWIFT_TESTING_BUILD_DIR')
+        swift_testing_macros_dir = _getenv('SWIFT_TESTING_MACRO_PATH')
+        swift_exec.extend([
+            '-I', os.path.join(swift_testing_dir, 'swift'),
+            '-L', os.path.join(swift_testing_dir, 'lib'),
+            '-load-plugin-library', swift_testing_macros_dir,
+        ])
+
         # We also need to link swift-corelibs-libdispatch, if
         # swift-corelibs-foundation is using it.
         libdispatch_src_dir = os.getenv('LIBDISPATCH_SRC_DIR')

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -73,6 +73,19 @@ if platform.system() == 'Darwin':
         '-I', os.path.join(built_products_dir, 'usr', 'local', 'include'),
     ])
 else:
+    # Required to build interop tests
+    swift_testing_dir = _getenv('SWIFT_TESTING_BUILD_DIR')
+    swift_testing_macros_dir = _getenv('SWIFT_TESTING_MACRO_BUILD_DIR')
+    swift_exec.extend([
+        '-I', os.path.join(swift_testing_dir, 'swift'),
+        '-L', os.path.join(swift_testing_dir, 'lib'),
+        '-plugin-path', swift_testing_macros_dir,
+    ])
+    if not platform.system() == 'Windows':
+        swift_exec.extend([
+            '-Xlinker', '-rpath', '-Xlinker', os.path.join(swift_testing_dir, 'lib'),
+        ])
+
     # We need to jump through extra hoops to link swift-corelibs-foundation.
     foundation_dir = _getenv('FOUNDATION_BUILT_PRODUCTS_DIR')
     if platform.system() == 'Windows':
@@ -98,15 +111,6 @@ else:
           '-I', os.path.join(foundation_dir, 'swift'),
           '-I', os.path.join(foundation_dir, '_CModulesForClients'),
           '-Xcc', '-F', '-Xcc', foundation_dir,
-        ])
-
-        # Required to build interop tests
-        swift_testing_dir = _getenv('SWIFT_TESTING_BUILD_DIR')
-        swift_testing_macros_dir = _getenv('SWIFT_TESTING_MACRO_PATH')
-        swift_exec.extend([
-            '-I', os.path.join(swift_testing_dir, 'swift'),
-            '-L', os.path.join(swift_testing_dir, 'lib'),
-            '-load-plugin-library', swift_testing_macros_dir,
         ])
 
         # We also need to link swift-corelibs-libdispatch, if


### PR DESCRIPTION
### Motivation:

Enables usage of #expect in XCTest tests.

Note that the other direction of interop (XCTAssert in Swift Testing) is not supported yet and will be addressed in a follow-up change.

### Modifications:

* Implement an XCTest fallback event handler that reports encoded issues from Swift Testing as issues for the current XCTest test case

* Install this handler before running XCTest tests

* Miscellany naming improvements

* Add lit tests for this direction of interop
