### PR TITLE
Fix a use-after-free bug in `fulfillment(of:)`

### DIFF
--- a/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
+++ b/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift
@@ -284,7 +284,7 @@ open class XCTWaiter {
             // This function operates by blocking a background thread instead of one owned by libdispatch or by the
             // Swift runtime (as used by Swift concurrency.) To ensure we use a thread owned by neither subsystem, use
             // Foundation's Thread.detachNewThread(_:).
-            Thread.detachNewThread { [self] in
+            Thread.detachNewThread { [self, expectations, timeout, enforceOrder, file, line] in
                 let result = wait(for: expectations, timeout: timeout, enforceOrder: enforceOrder, file: file, line: line)
                 continuation.resume(returning: result)
             }


### PR DESCRIPTION
Fix a use-after-free bug in `fulfillment(of:)`

### Motivation:

Ensure `fulfillment(of:)` captures the passed-in expectations so it cannot be accidentally freed before use in `XCTWaiter.wait()`.

### Modifications:

Add the passed-in expectations along with other variables to the capture list in the body of `fulfillment(of:)`.

This potentially regressed in #532 since it's the only recent relevant change, and I hadn't noticed this when running tests locally earlier in the year.

This test occasionally crashes (full backtrace below) when attempting to create a `Set(expectations)` in the body of `XCTWaiter.wait`. This indicates that `expectations` can get released prior to the wait finishing.

To validate the fix, I verified that tests all passed after running the entire suite multiple times.
```
# .---command stderr------------
# |
# | *** Signal 11: Backtracing from 0xffffa3b09c7c... done *** # |
# | *** Program crashed: Bad pointer dereference at 0x0000000000000010 *** # |
# | Platform: arm64 Linux (Ubuntu 22.04.5 LTS)
# |
# | Thread 0 "r-initiated-qos" crashed:
# |
# |   0      0x0000ffffa3b09c7c specialized Set.init<A>(_:) + 24 in libXCTest.so
# |   1 [ra] 0x0000ffffa3b0b1c8 XCTWaiter.wait(for:timeout:enforceOrder:file:line:) + 79 in libXCTest.so
# |   2 [ra] 0x0000ffffa3b09fd8 partial apply for closure #1 in closure #1 in XCTWaiter.fulfillment(of:timeout:enforceOrder:file:line:) + 95 in libXCTest.so
# |   3 [ra] 0x0000ffffa46f34b8 Thread.main() + 27 in libFoundation.so
# |   4 [ra] 0x0000ffffa46f22d0 NSThreadStart(_:) + 163 in libFoundation.so
# |   5 [ra] 0x0000ffffa3900398 <unknown> in libc.so.6
# | ...
# |
```