### PR TITLE
Send interop event if XCTest is not the active test library

### DIFF
--- a/Sources/XCTest/Private/Interop/InteropHandler.swift
+++ b/Sources/XCTest/Private/Interop/InteropHandler.swift
@@ -123,7 +123,7 @@ typealias FallbackEventHandler =
 extension Interop.Handler {
     /// XCTest's fallback event handler, which is used to handle issues reported by other test libraries.
     /// It can only report test issues if there is an active XCTest test case.
-    fileprivate static let ourFallbackEventHandler: FallbackEventHandler = {
+    static let ourFallbackEventHandler: FallbackEventHandler = {
         recordJSONSchemaVersionNumber, recordJSONBaseAddress, recordJSONByteCount, _ in
         guard let schemaVersion = String(validatingCString: recordJSONSchemaVersionNumber),
                 schemaVersion == "6.3" else {

--- a/Sources/XCTest/Public/XCTAssert.swift
+++ b/Sources/XCTest/Public/XCTAssert.swift
@@ -95,14 +95,117 @@ private func _XCTEvaluateAssertion(_ assertion: _XCTAssertion, message: @autoclo
     case .success:
         return
     default:
+        // XCTest assertions record failures in a few scenarios which require separate treatment.
+        //
+        // 1) Within the body of an XCTestCase test: the test case itself records the failure.
+        //
+        // 2) While Swift Testing* tests are running: the other test library records the failure.
+        // We encode the failure into an event and call the fallback event handler.
+        // (*or other test library that participates in interop)
+        //
+        // 3) Neither: recorded failure outside of test case.
+        // We drop this kind of failure since there is currently no affordance for recording it.
+        //
+        // This is timing-dependent on global XCTCurrentTestCase state.
+        // For example, the following test _may_ lose the error depending on when the task executes
+        // relative to the end of test case execution.
+        //
+        // func testDetached() {
+        //   Task.detached {
+        //     XCTFail("Might be lost")
+        //   }
+        // }
+        let description = "\(result.failureDescription(assertion)) - \(message())"
         if let currentTestCase = XCTCurrentTestCase {
             currentTestCase.recordFailure(
-                withDescription: "\(result.failureDescription(assertion)) - \(message())",
+                withDescription: description,
                 inFile: String(describing: file),
                 atLine: Int(line),
                 expected: result.isExpected)
+        } else {
+            // Handle case 2 and 3
+            _recordInteropFailure(
+                withDescription: description,
+                inFile: String(describing: file),
+                atLine: Int(line))
         }
     }
+}
+
+/// If appropriate, forward an assertion failure using the fallback event
+/// handler so it can be recorded by the active test library.
+///
+/// * Drop the failure if XCTest is the current test library.
+///
+///   This prevents us from getting into a recursive "error handling loop" or
+///   otherwise handling our own errors in an excessively roundabout manner.
+///
+///   In practise, it shouldn't be possible to get stuck here because the XCTest
+///   fallback event handler drops events if there isn't a current test case
+///   (which is the scenario in the body of _recordInteropFailure).
+///
+/// * Drop the failure if XCT_BUILD_WITH_INTEROP is not set.
+///
+/// - Parameter description: The description of the failure being reported.
+/// - Parameter filePath: The file path to the source file where the failure
+///   being reported was encountered.
+/// - Parameter lineNumber: The line number in the source file at filePath
+///   where the failure being reported was encountered.
+private func _recordInteropFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int) {
+#if XCT_BUILD_WITH_INTEROP
+    guard let fallbackHandler = Interop.Handler.activeFallbackEventHandler else { return }
+    let isOurInstalledHandler =
+        unsafeBitCast(fallbackHandler, to: UnsafeRawPointer.self)
+        == unsafeBitCast(Interop.Handler.ourFallbackEventHandler, to: UnsafeRawPointer.self)
+    guard !isOurInstalledHandler else {
+        // The fallback event handler belongs to XCTest, so we don't want
+        // to call it on our own behalf. The issue is dropped.
+        return
+    }
+
+    let instant = {
+        let d = SuspendingClock().systemEpoch.duration(to: .now)
+        return Interop.Event.Instant(
+            absolute: d / .seconds(1),
+            since1970: Date().timeIntervalSince1970
+        )
+    }()
+
+    let sourceLocation = {
+        let fileName = (filePath as NSString).lastPathComponent
+        // Module name is not available to us, so unconditionally fill with <unknown>
+        let fileID = "<unknown>/\(fileName)"
+        return Interop.Event.Issue.SourceLocation(
+            fileID: fileID, filePath: filePath, line: lineNumber, column: 0)
+    }()
+
+    let event = Interop.Event(
+        kind: "issueRecorded",
+        instant: instant,
+        // isKnown is NOT the same as XCTest's concept of isExpected.
+        // This must always be false since the equivalent API, XCTExpectFailure,
+        // is not supported in XCTest.
+        // https://github.com/swiftlang/swift-corelibs-xctest/issues/438/
+        issue: .init(isKnown: false, sourceLocation: sourceLocation),
+        attachment: nil,
+        messages: [
+            .init(
+                symbol: "fail",
+                text: description)
+        ],
+        testId: nil,
+    )
+
+    let outputRecord = Interop.OutputRecord(payload: event)
+    do {
+        let encodedEvent = try JSONEncoder().encode(outputRecord)
+        encodedEvent.withUnsafeBytes { ptr in
+            fallbackHandler("6.3", ptr.baseAddress!, ptr.count, nil)
+        }
+    } catch {
+        print("Failed to encode event: \(error)")
+    }
+#endif
 }
 
 /// This function emits a test failure if the general `Boolean` expression passed

--- a/Tests/Functional/DetachedTaskLostFailure/main.swift
+++ b/Tests/Functional/DetachedTaskLostFailure/main.swift
@@ -1,0 +1,52 @@
+// RUN: %{swiftc} %s -o %T/DetachedTaskLostFailure
+// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/DetachedTaskLostFailure > %t || true
+// RUN: %{xctest_checker} %t %s
+
+#if os(macOS)
+    import SwiftXCTest
+#else
+    import XCTest
+#endif
+import Foundation
+
+let testsFinished = DispatchSemaphore(value: 0)
+let issueReported = DispatchSemaphore(value: 0)
+
+// CHECK: Test Suite 'All tests' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: Test Suite '.*\.xctest' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+
+// CHECK: Test Suite 'DetachedTaskLostFailureTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+class DetachedTaskLostFailureTestCase: XCTestCase {
+    static var allTests = {
+        return [
+            ("test_XCTFailInDetachedTaskIsLost", test_XCTFailInDetachedTaskIsLost),
+        ]
+    }()
+
+    // Use semaphores to guarantee XCTFail() is called after the test case already ends.
+    // The test failure should be dropped as a result.
+    // CHECK: Test Case 'DetachedTaskLostFailureTestCase.test_XCTFailInDetachedTaskIsLost' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+    // CHECK: Test Case 'DetachedTaskLostFailureTestCase.test_XCTFailInDetachedTaskIsLost' passed \(\d+\.\d+ seconds\)
+    func test_XCTFailInDetachedTaskIsLost() {
+        // Don't write actual tests like this :)
+        Task.detached {
+            testsFinished.wait()
+            XCTFail("This is not reported")
+            issueReported.signal()
+        }
+    }
+}
+// CHECK: Test Suite 'DetachedTaskLostFailureTestCase' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+
+// This has to capture the return value explicitly as CInt, otherwise we call
+// the variant of XCTMain that terminates the program with exit()
+let _: CInt = XCTMain([testCase(DetachedTaskLostFailureTestCase.allTests)])
+// Unblock the code within Task.detached
+testsFinished.signal()
+issueReported.wait()
+
+// CHECK: Test Suite '.*\.xctest' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds
+// CHECK: Test Suite 'All tests' passed at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
+// CHECK: \t Executed 1 test, with 0 failures \(0 unexpected\) in \d+\.\d+ \(\d+\.\d+\) seconds

--- a/Tests/Functional/InteropSWTInXCTest/main.swift
+++ b/Tests/Functional/InteropSWTInXCTest/main.swift
@@ -1,5 +1,5 @@
-// RUN: %{swiftc} %s -o %T/InteropWithSWT
-// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/InteropWithSWT > %t || true
+// RUN: %{swiftc} %s -o %T/InteropSWTInXCTest
+// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/InteropSWTInXCTest > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)
@@ -15,14 +15,14 @@ import Testing
 // CHECK: Test Suite 'InteropWithSWTTestCase' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
 class InteropWithSWTTestCase: XCTestCase {
     // CHECK: Test Case 'InteropWithSWTTestCase.test_records_issue' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-    // CHECK: .*[/\\]InteropWithSWT[/\\]main.swift:[[@LINE+3]]: error: InteropWithSWTTestCase.test_records_issue : Issue recorded: Interop recorded issue failure
+    // CHECK: .*[/\\]InteropSWTInXCTest[/\\]main.swift:[[@LINE+3]]: error: InteropWithSWTTestCase.test_records_issue : Issue recorded: Interop recorded issue failure
     // CHECK: Test Case 'InteropWithSWTTestCase.test_records_issue' failed \(\d+\.\d+ seconds\)
     func test_records_issue() {
         Issue.record("Interop recorded issue failure")
     }
 
     // CHECK: Test Case 'InteropWithSWTTestCase.test_assertion_fails' started at \d+-\d+-\d+ \d+:\d+:\d+\.\d+
-    // CHECK: .*[/\\]InteropWithSWT[/\\]main.swift:[[@LINE+4]]: error: InteropWithSWTTestCase.test_assertion_fails : Expectation failed: Bool\(false\): Bool\(false\) → false
+    // CHECK: .*[/\\]InteropSWTInXCTest[/\\]main.swift:[[@LINE+4]]: error: InteropWithSWTTestCase.test_assertion_fails : Expectation failed: Bool\(false\): Bool\(false\) → false
     // CHECK: false → \(\)
     // CHECK: Test Case 'InteropWithSWTTestCase.test_assertion_fails' failed \(\d+\.\d+ seconds\)
     func test_assertion_fails() {

--- a/Tests/Functional/InteropXCTestInSWT/main.swift
+++ b/Tests/Functional/InteropXCTestInSWT/main.swift
@@ -1,0 +1,57 @@
+// RUN: %{swiftc} %s -o %T/InteropXCTestInSWT -enable-experimental-feature Extern
+// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/InteropXCTestInSWT > %t 2>&1 || true
+// RUN: %{xctest_checker} %t %s
+
+// Test that XCTFail called without an active XCTestCase forwards the failure
+// to the installed fallback event handler (the XCTest → Swift Testing direction).
+//
+// Ideally we'd just call XCTFail within an @Test function and call it a day,
+// but running Swift Testing tests directly through lit is tricky!
+//
+// Instead, we do the next best thing and install a fallback event handler
+// before invoking XCTest to masquerade as a foreign test library.
+
+import Foundation
+
+#if os(macOS)
+import SwiftXCTest
+#else
+import XCTest
+#endif
+
+typealias FallbackEventHandler =
+    @Sendable @convention(c) (
+        _ recordJSONSchemaVersionNumber: UnsafePointer<CChar>,
+        _ recordJSONBaseAddress: UnsafeRawPointer,
+        _ recordJSONByteCount: Int,
+        _ reserved: UnsafeRawPointer?
+    ) -> Void
+
+@_extern(c, "_swift_testing_installFallbackEventHandler")
+func installer(_ handler: FallbackEventHandler) -> CBool
+
+/// Our custom fallback handler captures the fallback events
+/// that Swift Testing would normally receive.
+///
+/// Prints the message text from the event if found.
+let customHandler: FallbackEventHandler = { _, jsonBase, count, _ in
+    let jsonData = Data(bytes: jsonBase, count: count)
+    if let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+        let payload = json["payload"] as? [String: Any],
+        let messages = payload["messages"] as? [[String: Any]],
+        let text = messages.first?["text"] as? String
+    {
+        print("<HANDLER RECEIVED>: \(text)")
+    } else {
+        print("<HANDLER FAILURE> <failed to decode>")
+    }
+}
+
+// Take over the installed fallback event handler by installing before running XCTestMain
+let installed = installer(customHandler)
+precondition(installed, "Failed to install fallback event handler")
+
+// This is triggered outside of a test case, so the failure is forwarded
+// to the installed fallback handler (masquerading as Swift Testing).
+// CHECK: <HANDLER RECEIVED>: failed - XCTest failure forwarded to Swift Testing
+XCTFail("XCTest failure forwarded to Swift Testing")

--- a/Tests/Functional/lit.cfg
+++ b/Tests/Functional/lit.cfg
@@ -79,6 +79,7 @@ else:
     swift_exec.extend([
         '-I', os.path.join(swift_testing_dir, 'swift'),
         '-L', os.path.join(swift_testing_dir, 'lib'),
+        '-l_TestingInterop',
         '-plugin-path', swift_testing_macros_dir,
     ])
     if not platform.system() == 'Windows':


### PR DESCRIPTION
### Motivation:

Enable reporting of XCTAssert failures in a Swift Testing test.

### Modifications:

* Update XCTAssert impl to encode issues and send to installed fallback event handler if no active XCTestCase
* Test both directions of interop as well as the more general case of issue handling without an active test case.
