### PR TITLE
Enable targeted interoperability by default

### DIFF
--- a/Sources/XCTest/Private/Interop/InteropHandler.swift
+++ b/Sources/XCTest/Private/Interop/InteropHandler.swift
@@ -23,21 +23,6 @@
 enum Interop {}
 
 extension Interop {
-    /// Interop is an experimental feature, so users must manually opt-in.
-    enum Config {}
-}
-
-extension Interop.Config {
-    static let optInEnvName = "XCT_EXPERIMENTAL_ENABLE_INTEROP"
-    static let isEnabledAtRuntime = {
-        ProcessInfo.processInfo.environment[optInEnvName] == "1"
-    }()
-    static let isDebugPrintEnabled = {
-        ProcessInfo.processInfo.environment["XCT_EXPERIMENTAL_ENABLE_INTEROP_DEBUG"] == "1"
-    }()
-}
-
-extension Interop {
     /// Utilities for installing and getting the fallback event handler. The
     /// handler is stored in the `_TestingInterop` library, and all test
     /// libraries that participate in interop dynamically link it at runtime so
@@ -46,13 +31,6 @@ extension Interop {
 }
 
 extension Interop.Handler {
-    /// Print the message if debug printing is enabled for interop.
-    fileprivate static func debugPrint(_ message: String) {
-        if Interop.Config.isDebugPrintEnabled {
-            print(message)
-        }
-    }
-
     /// Install XCTest's fallback event handler. This should only be called
     /// if the current process is running XCTest test cases.
     ///
@@ -66,17 +44,8 @@ extension Interop.Handler {
 
     private static let _installFallbackEventHandler: Bool = {
         #if XCT_BUILD_WITH_INTEROP
-        guard Interop.Config.isEnabledAtRuntime else {
-            debugPrint("Interop: disabled because \(Interop.Config.optInEnvName) not set")
-            return false
-        }
-
-        debugPrint("Interop: installing XCTest's interop handler")
-        let ok = installer(ourFallbackEventHandler)
-        debugPrint("Interop: install \(ok ? "succeeded" : "failed! Interop is disabled")")
-        return ok
+        return installer(ourFallbackEventHandler)
         #else
-        debugPrint("Interop: disabled because this was built without XCT_BUILD_WITH_INTEROP")
         return false
         #endif
     }()
@@ -127,7 +96,6 @@ extension Interop.Handler {
         recordJSONSchemaVersionNumber, recordJSONBaseAddress, recordJSONByteCount, _ in
         guard let schemaVersion = String(validatingCString: recordJSONSchemaVersionNumber),
                 schemaVersion == "6.3" else {
-            debugPrint("Not handling event because of unsupported schema version")
             return
         }
 
@@ -140,13 +108,11 @@ extension Interop.Handler {
 
         do {
             guard let currentTestCase = XCTCurrentTestCase else {
-                debugPrint("Called without current test case")
                 return
             }
             let outputRecord = try JSONDecoder().decode(Interop.OutputRecord.self, from: jsonData)
             currentTestCase.recordFailure(event: outputRecord.payload)
         } catch {
-            debugPrint("Unable to convert json event into an output record: \(error)")
         }
     }
 
@@ -174,7 +140,6 @@ extension XCTestCase {
     ///   typically populated by a foreign test library.
     fileprivate func recordFailure(event: Interop.Event) {
         guard event.kind == "issueRecorded", let eventIssue = event.issue else {
-            Interop.Handler.debugPrint("Skipping interop for event kind \(event.kind)")
             return
         }
 

--- a/Tests/Functional/DetachedTaskLostFailure/main.swift
+++ b/Tests/Functional/DetachedTaskLostFailure/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/DetachedTaskLostFailure
-// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/DetachedTaskLostFailure > %t || true
+// RUN: %T/DetachedTaskLostFailure > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)

--- a/Tests/Functional/InteropSWTInXCTest/main.swift
+++ b/Tests/Functional/InteropSWTInXCTest/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/InteropSWTInXCTest
-// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/InteropSWTInXCTest > %t || true
+// RUN: %T/InteropSWTInXCTest > %t || true
 // RUN: %{xctest_checker} %t %s
 
 #if os(macOS)

--- a/Tests/Functional/InteropXCTestInSWT/main.swift
+++ b/Tests/Functional/InteropXCTestInSWT/main.swift
@@ -1,5 +1,5 @@
 // RUN: %{swiftc} %s -o %T/InteropXCTestInSWT -enable-experimental-feature Extern
-// RUN: env XCT_EXPERIMENTAL_ENABLE_INTEROP=1 %T/InteropXCTestInSWT > %t 2>&1 || true
+// RUN: %T/InteropXCTestInSWT > %t 2>&1 || true
 // RUN: %{xctest_checker} %t %s
 
 // Test that XCTFail called without an active XCTestCase forwards the failure


### PR DESCRIPTION
### Motivation:

Interoperability is a feature that makes it safer and easier than ever to migrate from XCTest to Swift Testing.

It does this by addressing the problem of "lossy without interop", where issues created by XCTest are normally not handled in a Swift Testing test.

Interop supports a few modes:

    class FooTests: XCTestCase {
        func testInterop() {
        // None:     No-op
        // Limited:  ❌ "Interop failure"
        // Complete: ❌ "Interop failure"
        // Strict:   ❌ "Interop failure"
        Issue.record("Interop failure")
        }
    }

    @Test func `Test Interop`() {
        // None:     No-op
        // Limited:  ⚠️ "Interop failure", ⚠️ Adopt Swift Testing primitives
        // Complete: ❌ "Interop failure", ⚠️ Adopt Swift Testing primitives
        // Strict:   💥 fatalError: Adopt Swift Testing primitives
        XCTFail("Interop failure")
    }

The default is "complete" for `swift-tools-version: 6.4`[^1] and "limited" otherwise.

Use env var `SWIFT_TESTING_XCTEST_INTEROP_MODE=<mode in lowercase>` to override this mode at runtime.

[^1]: https://github.com/swiftlang/swift-package-manager/pull/9857

To learn more, refer to the full proposal:

https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0021-targeted-interoperability-swift-testing-and-xctest.md

### Modifications:

* Remove XCT_EXPERIMENTAL_ENABLE_INTEROP flag and related checks. This ensures that interoperability Just Works when you use a toolchain that supports it.

### 6.4.x PR details

- **Explanation**:
  Remove XCT_EXPERIMENTAL_ENABLE_INTEROP flag and related checks. This ensures
  that interoperability Just Works when you use a toolchain that supports it.

- **Scope**:
  Enables a feature currently guarded by a flag. This can result in new test
  failures in existing XCTests if a user is recording issues with Swift Testing
  API.

- **Issues**: n/a

- **Original PRs**:
  https://github.com/swiftlang/swift-corelibs-xctest/pull/545

- **Risk**:
  Interop can surface new test failures. Users can opt-out of interop with the
  environment variable `SWIFT_TESTING_XCTEST_INTEROP_MODE=none`

- **Testing**:
  Automated tests

- **Reviewers**:
  @stmontgomery
  @harlanhaskins
